### PR TITLE
fix(serializer): match snake_case JSON keys to PascalCase properties

### DIFF
--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -71,10 +71,14 @@ begin
   if Assigned(Result) then
     Exit;
 
-  var LowerPropName := LowerCase(PropName);
+  const LowerPropName = LowerCase(PropName);
+  const LowerPropNameNoUnderscore = LowerPropName.Replace('_', '', [rfReplaceAll]);
   for var Pair in Json do
   begin
-    if SameText(Pair.JsonString.Value, PropName) or (LowerCase(Pair.JsonString.Value) = LowerPropName) then
+    const KeyName = Pair.JsonString.Value;
+    const LowerKey = LowerCase(KeyName);
+    const LowerKeyNoUnderscore = LowerKey.Replace('_', '', [rfReplaceAll]);
+    if SameText(KeyName, PropName) or (LowerKey = LowerPropName) or (LowerKeyNoUnderscore = LowerPropNameNoUnderscore) then
     begin
       Result := Pair.JsonValue;
       Exit;


### PR DESCRIPTION
Extend GetJsonValueCaseInsensitive with a third matching strategy that strips underscores before lowercase comparison. This lets the deserializer accept JSON keys like "board_id" or "issue_key" for Pascal properties named BoardId or IssueKey, in addition to the existing exact and case-insensitive matches.

LLMs producing tool arguments tend to snake_case JSON keys regardless of what the input schema specifies, which previously caused multi-word parameters to silently arrive empty.

The change is purely additive: the two existing matching strategies (exact, case-insensitive lowercase) are unchanged. Underscore-stripped matching is only attempted when neither earlier strategy succeeds.