### PR TITLE
ToolsManager: pass TJSONArray tool results through as the content array

### DIFF
--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -141,8 +141,9 @@ begin
   if ResultValue.IsType<TJSONArray> then
   begin
     // The tool already produced a content array (e.g. text plus an image item);
-    // pass it through verbatim so callers can return non-text content.
-    Result.AddPair('content', TJSONArray(ResultValue.AsType<TJSONArray>.Clone));
+    // take ownership so it is passed through verbatim and freed with the
+    // response (no clone, no leak of the original array).
+    Result.AddPair('content', ResultValue.AsType<TJSONArray>);
   end
   else if ResultValue.IsType<string> then
   begin

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -138,7 +138,13 @@ var
 begin
   Result := TJSONObject.Create;
 
-  if ResultValue.IsType<string> then
+  if ResultValue.IsType<TJSONArray> then
+  begin
+    // The tool already produced a content array (e.g. text plus an image item);
+    // pass it through verbatim so callers can return non-text content.
+    Result.AddPair('content', TJSONArray(ResultValue.AsType<TJSONArray>.Clone));
+  end
+  else if ResultValue.IsType<string> then
   begin
     TextValue := ResultValue.AsString;
     HasError := TextValue.StartsWith('Error:') or TextValue.StartsWith('Error executing tool:');


### PR DESCRIPTION
Allows tools to return image (or mixed) MCP content instead of text only:

- A `TJSONArray` tool result is passed through as the `content` array verbatim.
- The manager takes ownership of the array instead of cloning it, so the original no longer leaks.