### PR TITLE
Fix CORS preflight so the MCP Inspector can connect (#11)

### DIFF
--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -256,8 +256,9 @@ begin
 
   ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := AllowedOrigin;
   ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Methods'] := 'POST, GET, OPTIONS';
-  ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Headers'] := 
-    'Content-Type, Mcp-Session-Id';
+  ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Headers'] :=
+    'Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id';
+  ResponseInfo.CustomHeaders.Values['Access-Control-Expose-Headers'] := 'Mcp-Session-Id';
   ResponseInfo.CustomHeaders.Values['Access-Control-Max-Age'] := CORS_MAX_AGE.ToString;
 end;
 


### PR DESCRIPTION
Fixes #11. Thanks to @raelb for diagnosing this.

## Problem
The MCP Inspector (browser client) couldn't connect. Per the 2025-11-25 Streamable HTTP spec it sends `Mcp-Protocol-Version` and `Mcp-Session-Id` request headers after the handshake. These are non-simple headers, so the browser first issues an `OPTIONS` preflight. The server did **not** list `Mcp-Protocol-Version` in `Access-Control-Allow-Headers`, so the preflight failed and the real request never executed. It also never sent `Access-Control-Expose-Headers`, so client JavaScript couldn't read the `Mcp-Session-Id` response header to reuse it.

## Fix
In `VerifyAndSetCORSHeaders`:
- `Access-Control-Allow-Headers` → `Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id`
- add `Access-Control-Expose-Headers: Mcp-Session-Id`

Compiles cleanly (Delphi 13). Note: CORS must be enabled in `settings.ini` for browser clients:
```
[CORS]
Enabled=True
AllowedOrigins=*
```