### PR TITLE
Fix access violation on unparseable JSON-RPC requests

### DIFF
--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -62,6 +62,16 @@ class function TMCPJsonRpcProcessor.ExtractRequestID(JSONRequest: TJSONObject): 
 var
   IdValue: TJSONValue;
 begin
+  // JSONRequest is nil when the request body failed to parse; there is no id
+  // to extract. Without this guard the nil dereference surfaces as
+  // "Access violation ... Read of address 0000000000000010" for any
+  // syntactically invalid request.
+  if not Assigned(JSONRequest) then
+  begin
+    Result := TValue.Empty;
+    Exit;
+  end;
+
   IdValue := JSONRequest.GetValue('id');
   if not Assigned(IdValue) then
   begin
@@ -196,8 +206,12 @@ begin
       begin
         TLogger.Error('Error processing request: ' + E.Message);
 
+        // If parsing failed, JSONRequest is still nil: report a JSON-RPC parse
+        // error (-32700). ExtractRequestID is nil-safe and yields a null id.
         ErrorCode := JSONRPC_INTERNAL_ERROR;
-        if Pos('not found', E.Message) > 0 then
+        if not Assigned(JSONRequest) then
+          ErrorCode := JSONRPC_PARSE_ERROR
+        else if Pos('not found', E.Message) > 0 then
           ErrorCode := JSONRPC_METHOD_NOT_FOUND;
 
         Result := CreateErrorResponse(ExtractRequestID(JSONRequest), ErrorCode, E.Message);

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -5,6 +5,7 @@ interface
 uses
   System.SysUtils,
   System.Classes,
+  System.JSON,
   MCPServer.Types,
   MCPServer.JsonRpcProcessor,
   MCPServer.Logger;
@@ -41,7 +42,8 @@ end;
 
 procedure TMCPStdioTransport.Run;
 var
-  ErrorResponse: string;
+  ErrorJson: TJSONObject;
+  ErrorObj: TJSONObject;
   InputLine: string;
   Response: string;
 begin
@@ -73,9 +75,21 @@ begin
       begin
         TLogger.Error('Error processing STDIO request: ' + E.Message);
 
-        ErrorResponse := '{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"' +
-                             E.Message.Replace('"', '\"') + '"}}';
-        Writeln(Output, ErrorResponse);
+        // Build the error response with the JSON writer: hand-concatenated
+        // JSON with only '"' replaced emits invalid JSON whenever the message
+        // contains a backslash (e.g. a Windows path) or a control character.
+        ErrorJson := TJSONObject.Create;
+        try
+          ErrorJson.AddPair('jsonrpc', '2.0');
+          ErrorJson.AddPair('id', TJSONNull.Create);
+          ErrorObj := TJSONObject.Create;
+          ErrorJson.AddPair('error', ErrorObj);
+          ErrorObj.AddPair('code', TJSONNumber.Create(JSONRPC_INTERNAL_ERROR));
+          ErrorObj.AddPair('message', E.Message);
+          Writeln(Output, ErrorJson.ToJSON);
+        finally
+          ErrorJson.Free;
+        end;
         Flush(Output);
       end;
     end;


### PR DESCRIPTION
## Problem

Any request whose body fails JSON parsing crashes the server with an access violation instead of returning a JSON-RPC error:

```
Access violation at address ... in module 'MCPServer.exe'. Read of address 0000000000000010
```

Easy ways to trigger it:

- plain garbage on stdin: `this is not json {{{`
- hand-built JSON containing a raw Windows path — in `"C:\ProgramData\Oops"` the `\P` is an invalid JSON escape
- a UTF-8 BOM in front of the first message (some Windows pipelines add one)
- a request line truncated by a dying pipe/proxy

Correctly escaped arguments (e.g. `"C:\\ProgramData\\Data"`) were never affected — this only concerns bodies that `TJSONObject.ParseJSONValue` rejects.

## Root cause

In `TMCPJsonRpcProcessor.ProcessRequest`, `ParseJSONRequest` raises before `JSONRequest` is assigned, and the `except` handler then calls `ExtractRequestID(JSONRequest)` with `JSONRequest = nil`. `TJSONObject.GetValue` on a nil instance reads offset `$10` — confirmed by symbolicating the AV address against a detailed map file.

The transport loop catches the escaped AV so the demo server survives, but hosts that embed more machinery can fare much worse: we found this in a NexusDB-based MCP server where the embedded database engine's process-wide exception hook treats any access violation as fatal and suspends all database operations until the process is restarted. A malformed request should never cost more than an error response.

## Fix

- `ExtractRequestID`: return `TValue.Empty` when the request object is nil.
- `ProcessRequest`: report `JSONRPC_PARSE_ERROR` (-32700, per JSON-RPC 2.0) instead of -32603 when the body never parsed.
- `TMCPStdioTransport.Run`: build the transport-level error response with `TJSONObject` instead of string concatenation that only escaped quotes — the old code emitted invalid JSON whenever the exception message contained a backslash (e.g. a Windows path) or a control character.

## Verification

Win64, stdio transport, both builds from this same base revision (419b512):

| Input | Before | After |
|---|---|---|
| `{"...,"message":"C:\ProgramData\Oops"}` (invalid escape) | `Access violation ... Read of address 0000000000000010` | `{"code":-32700,"message":"Invalid JSON"}` |
| `this is not json {{{` | same access violation | `{"code":-32700,"message":"Invalid JSON"}` |
| `{"...,"message":"C:\\ProgramData\\OZZIE\\Data"}` (valid) | echoed correctly | echoed correctly (unchanged) |
| next request after a malformed one | served | served |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
