### PR TITLE
Expose enum values in the schema and reject invalid ones

### DIFF
--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -14,6 +14,7 @@ type
     class function GetJsonTypeFromRttiType(RttiType: TRttiType): string;
     class function GetPropertyJsonName(Prop: TRttiProperty; RType: TRttiType): string;
     class function IsRequiredProperty(Prop: TRttiProperty): Boolean;
+    class function CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
   public
     class function GenerateSchema(Cls: TClass): TJSONObject;
     class function GenerateSchemaFromInstance(Instance: TObject): TJSONObject;
@@ -67,6 +68,8 @@ begin
         if JsonType = 'array' then
           PropSchema.AddPair('items', TJSONObject.Create);
 
+        EnumArray := nil;
+
         for Attr in RttiProp.GetAttributes do
         begin
           if Attr is SchemaDescriptionAttribute then
@@ -78,9 +81,14 @@ begin
             EnumArray := TJSONArray.Create;
             for Value in SchemaEnumAttribute(Attr).Values do
               EnumArray.Add(Value);
-            PropSchema.AddPair('enum', EnumArray);
           end;
         end;
+
+        if not Assigned(EnumArray) then
+          EnumArray := CreateEnumValuesArray(RttiProp.PropertyType);
+
+        if Assigned(EnumArray) then
+          PropSchema.AddPair('enum', EnumArray);
 
         if IsRequiredProperty(RttiProp) then
           RequiredArray.Add(JsonName);
@@ -139,6 +147,26 @@ begin
       Exit(False);
   end;
   Result := True;
+end;
+
+class function TMCPSchemaGenerator.CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
+var
+  EnumType: TRttiEnumerationType;
+  Ordinal: Integer;
+begin
+  Result := nil;
+
+  if not (RttiType is TRttiEnumerationType) then
+    Exit;
+
+  if RttiType.Handle = TypeInfo(Boolean) then
+    Exit;
+
+  EnumType := TRttiEnumerationType(RttiType);
+
+  Result := TJSONArray.Create;
+  for Ordinal := EnumType.MinValue to EnumType.MaxValue do
+    Result.Add(GetEnumName(RttiType.Handle, Ordinal));
 end;
 
 end.

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -20,6 +20,8 @@ type
 
     // Extracted type conversion methods
     class function ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
     class function ConvertValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
     class function CreateInstanceFromType(const RttiType: TRttiType): TObject;
 
@@ -128,7 +130,12 @@ begin
     if not Assigned(JsonValue) then
       Continue;
 
-    PropValue := ConvertJsonToValue(JsonValue, RttiProp.PropertyType);
+    try
+      PropValue := ConvertJsonToValue(JsonValue, RttiProp.PropertyType);
+    except
+      on E: EArgumentException do
+        raise EArgumentException.CreateFmt('Parameter "%s": %s', [LowerCase(RttiProp.Name), E.Message]);
+    end;
 
     if not PropValue.IsEmpty then
     begin
@@ -181,7 +188,6 @@ end;
 
 class function TMCPSerializer.ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
 var
-  EnumValue: Integer;
   NestedInstance: TObject;
 begin
   Result := TValue.Empty;
@@ -230,18 +236,9 @@ begin
       end
       else
       begin
-        if JsonValue is TJSONNumber then
-          Result := TValue.FromOrdinal(RttiType.Handle, (JsonValue as TJSONNumber).AsInt)
-        else
-        begin
-          EnumValue := GetEnumValue(RttiType.Handle, JsonValue.Value);
-          if EnumValue >= 0 then
-            Result := TValue.FromOrdinal(RttiType.Handle, EnumValue)
-          else
-            Result := TValue.FromOrdinal(RttiType.Handle, StrToIntDef(JsonValue.Value, 0));
-        end;
+        Result := ConvertJsonToEnum(JsonValue, RttiType);
       end;
-      
+
     tkClass:
       if JsonValue is TJSONObject then
       begin
@@ -259,6 +256,51 @@ begin
       if JsonValue is TJSONArray then
         Result := DeserializeArray(RttiType, JsonValue as TJSONArray);
   end;
+end;
+
+class function TMCPSerializer.ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+var
+  EnumType: TRttiEnumerationType;
+  Ordinal: Integer;
+begin
+  Result := TValue.Empty;
+
+  if not (RttiType is TRttiEnumerationType) then
+    Exit;
+
+  EnumType := TRttiEnumerationType(RttiType);
+
+  if JsonValue is TJSONNumber then
+    Ordinal := (JsonValue as TJSONNumber).AsInt
+  else
+  begin
+    if JsonValue.Value = '' then
+      Exit;
+
+    Ordinal := GetEnumValue(RttiType.Handle, JsonValue.Value);
+    if Ordinal < 0 then
+      Ordinal := StrToIntDef(JsonValue.Value, -1);
+  end;
+
+  if (Ordinal < EnumType.MinValue) or (Ordinal > EnumType.MaxValue) then
+    raise EArgumentException.CreateFmt(
+      'Invalid value "%s". Valid values: %s.',
+      [JsonValue.Value, GetEnumValueNames(EnumType)]);
+
+  Result := TValue.FromOrdinal(RttiType.Handle, Ordinal);
+end;
+
+class function TMCPSerializer.GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
+var
+  Names: TArray<string>;
+  Ordinal: Integer;
+begin
+  SetLength(Names, EnumType.MaxValue - EnumType.MinValue + 1);
+
+  for Ordinal := EnumType.MinValue to EnumType.MaxValue do
+    Names[Ordinal - EnumType.MinValue] := GetEnumName(EnumType.Handle, Ordinal);
+
+  Result := String.Join(', ', Names);
 end;
 
 class function TMCPSerializer.CreateInstanceFromType(const RttiType: TRttiType): TObject;


### PR DESCRIPTION
## Problem

Enumeration properties were published to clients as a bare `"type": "string"`, with no indication of which values are accepted:

```json
"action": { "type": "string" }
```

An LLM client cannot know that only `None` and `Confirm` exist, so it sends a plausible-looking value such as `"search"`. The serializer then fell through to `StrToIntDef(Value, 0)`, which maps **any** unknown string onto the first enum member. The tool ran a different code path than the caller intended, and no error was reported.

In practice that meant a client trying to search silently triggered a create preview.

## Changes

**`MCPServer.Schema.Generator.pas`** derives the allowed values from RTTI and emits them as a JSON Schema `enum` array:

```json
"action": { "type": "string", "enum": ["None", "Confirm"] }
```

An explicit `SchemaEnum` attribute still takes precedence, and `Boolean` keeps its dedicated `"boolean"` type.

**`MCPServer.Serializer.pas`** validates the ordinal against the enumeration range and raises `EArgumentException` listing the valid values, matching the existing `Unknown parameter` error:

```
Parameter "action": Invalid value "search". Valid values: None, Confirm.
```

That surfaces to the client as a normal tool error with `isError: true`, so the model can correct itself.

## Compatibility

Out-of-range numeric values are rejected as well. An absent or empty value still falls back to the default, so optional properties keep working unchanged.

This is a deliberate behaviour change: a client that previously sent an invalid enum value got the default, and now gets an error. That is the point of the fix.

## Verification

The repository has no test project, so the units were exercised through a standalone program compiled against them:

| Input | Result |
|-------|--------|
| `{"action":"search"}` | rejected, lists valid values |
| `{"action":"Confirm"}` | `Confirm` |
| `{}` (absent) | default `None` |
| `{"action":""}` | default `None` |
| `{"action":1}` | `Confirm` |
| `{"action":9}` | rejected, out of range |
| Boolean property | stays `"type":"boolean"`, no enum list |

`build.bat` completes with no hints or warnings from `src/`.