### PR TITLE
docs: add commercial support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,4 +551,7 @@ We welcome contributions! Here's how to help:
 
 - Create an issue on [GitHub](https://github.com/GDKsoftware/delphi-mcp-server/issues)
 - Visit our website at [www.gdksoftware.com](https://www.gdksoftware.com)
-- Contact us for commercial support
+
+## Commercial Support
+
+This library is MIT licensed and free to use. For companies that depend on it commercially we offer support and maintenance agreements with guaranteed response times, and sponsored development of features you need, such as upcoming MCP specification revisions. Contact us at [gdksoftware.com/contact-us](https://gdksoftware.com/contact-us) or open an issue to get in touch.


### PR DESCRIPTION
Adds a Commercial Support section to the README: the library stays MIT licensed and free, and companies that depend on it commercially can get a support or maintenance agreement, or sponsor development of features they need. Links to https://gdksoftware.com/contact-us.

The existing Support section only said "Contact us for commercial support" without explaining what that means; this spells it out, mentioning upcoming MCP specification revisions as an example of sponsored development.