### PR TITLE
docs: update TaurusTLS and OpenSSL deployment information

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ build.bat Debug Win32
 build.bat Release Win64
 ```
 
+The script picks up the highest TaurusTLS version installed in the CatalogRepository of the Studio release that `DELPHI_PATH` points at. To build against a copy somewhere else, set `TAURUS_PATH` to its `Source` directory first:
+```bash
+set TAURUS_PATH=C:\path\to\TaurusTLS\Source
+build.bat Release Win64
+```
+
 #### Linux Build
 
 **Prerequisites:**
@@ -529,8 +535,8 @@ Instead of copying DLLs by hand, the OpenSSL-Distribution releases also ship aut
 - **Cloudflare Tunnel**: Standard Indy SSL lacks ECDHE cipher support. Use TaurusTLS or run Cloudflare Tunnel with HTTP: `cloudflared tunnel --url http://localhost:8080`
 - **Self-Signed Certificates**: Claude Desktop doesn't accept self-signed certificates. Use Cloudflare Tunnel or a valid certificate from a trusted CA
 - **"No shared cipher" error**: Install and enable TaurusTLS for modern cipher support
-- **`Could not load SSL library`**: no matching OpenSSL library was found. Either the DLLs are missing next to the executable, or your TaurusTLS version predates 4.x support (see above)
-- **The wrong OpenSSL gets loaded**: TaurusTLS tries the library names in order (4.x first, then 3.x, 1.1, 1.0). If the version you deployed is not the one it settles on, it silently falls back to any other OpenSSL on the Windows search path, and PHP, Git and similar tools all ship one. Set the `OPENSSL_LIBRARY_PATH` environment variable to the directory you want to pin it to
+- **`Could not load SSL library`**: no OpenSSL library TaurusTLS recognises was found. Either the libraries are not where the platform looks for them, or your TaurusTLS version predates 4.x support (see above)
+- **The wrong OpenSSL gets loaded**: TaurusTLS asks the OS for the libraries by name, trying the version suffixes newest first, and takes the first hit anywhere on the platform's library search path. Another OpenSSL installation can therefore win over the one you shipped, and your application runs on a version you never tested. Set the `OPENSSL_LIBRARY_PATH` environment variable to an absolute directory to pin the choice; it applies on every platform
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ Edit `src\Server\MCPServer.IdHTTPServer.pas`:
 
 TaurusTLS runs on OpenSSL 3.x and 4.x. Pre-compiled binaries for every supported platform, including Windows on ARM64, are published at https://github.com/TaurusTLS-Developers/OpenSSL-Distribution/releases. Full deployment instructions: https://taurustls.org/deployapps.xhtml
 
+> **OpenSSL 4.x requires TaurusTLS 1.0.5.42 or newer.** Earlier releases only look for the 3.x, 1.1 and 1.0 library names, so a build linked against them fails at startup with `ETaurusTLSCouldNotLoadSSLLibrary: Could not load SSL library` when only 4.x libraries are present. Check `DefaultLibVersions` in `TaurusTLSConsts.pas` if you are unsure which version you have.
+
 *Windows (dynamic linking):*
 
 Ship the OpenSSL DLLs and `LICENSE.txt` alongside your executable:
@@ -527,6 +529,8 @@ Instead of copying DLLs by hand, the OpenSSL-Distribution releases also ship aut
 - **Cloudflare Tunnel**: Standard Indy SSL lacks ECDHE cipher support. Use TaurusTLS or run Cloudflare Tunnel with HTTP: `cloudflared tunnel --url http://localhost:8080`
 - **Self-Signed Certificates**: Claude Desktop doesn't accept self-signed certificates. Use Cloudflare Tunnel or a valid certificate from a trusted CA
 - **"No shared cipher" error**: Install and enable TaurusTLS for modern cipher support
+- **`Could not load SSL library`**: no matching OpenSSL library was found. Either the DLLs are missing next to the executable, or your TaurusTLS version predates 4.x support (see above)
+- **The wrong OpenSSL gets loaded**: TaurusTLS tries the library names in order (4.x first, then 3.x, 1.1, 1.0). If the version you deployed is not the one it settles on, it silently falls back to any other OpenSSL on the Windows search path, and PHP, Git and similar tools all ship one. Set the `OPENSSL_LIBRARY_PATH` environment variable to the directory you want to pin it to
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -454,60 +454,69 @@ The server supports configuration through `settings.ini` files. A default `setti
 The Delphi MCP Server supports two SSL/TLS implementations:
 
 1. **Standard Indy SSL** - Uses OpenSSL 1.0.2 (default if TaurusTLS not available)
-2. **TaurusTLS** - Uses OpenSSL 3.x with modern cipher support (recommended)
+2. **TaurusTLS** - Uses OpenSSL 3.x or 4.x with modern cipher support (recommended)
 
 #### Installing TaurusTLS
 
-TaurusTLS provides OpenSSL 3.x support with modern ECDHE cipher suites required by services like Cloudflare.
+TaurusTLS provides OpenSSL 3.x and 4.x support with modern ECDHE cipher suites required by services like Cloudflare.
 
-**Via GetIt Package Manager (Easiest):**
-1. Open Delphi IDE
-2. Go to Tools > GetIt Package Manager
-3. Search for "TaurusTLS"
-4. Click Install
+**Via a package manager (easiest):**
+- **GetIt** (RAD Studio): Tools > GetIt Package Manager, search for "TaurusTLS", click Install
+- **DPM**: `dpm install TaurusTLS_Developers.TaurusTLS`
+- **TMS Smart Setup**: `tms install taurustls_developers.taurustls`
 
 **Manual Installation:**
-1. Clone from https://github.com/JPeterMugaas/TaurusTLS
+1. Clone from https://github.com/TaurusTLS-Developers/TaurusTLS
 2. Open `TaurusTLS\Packages\d12\TaurusAll.groupproj`
 3. Compile `TaurusTLS_RT`
 4. Compile and install `TaurusTLS_DT`
+
+All installation options are documented at https://taurustls.org/download.xhtml
 
 #### Switching Between SSL Implementations
 
 Edit `src\Server\MCPServer.IdHTTPServer.pas`:
 
 ```pascal
-// To use TaurusTLS (OpenSSL 3.x):
+// To use TaurusTLS (OpenSSL 3.x/4.x):
 {$DEFINE USE_TAURUS_TLS}  // Keep this line uncommented
 
 // To use Standard Indy SSL (OpenSSL 1.0.2):
 // {$DEFINE USE_TAURUS_TLS}  // Comment out this line
 ```
 
-#### OpenSSL DLL Requirements
+#### OpenSSL Requirements
 
 **For TaurusTLS:**
 
-*Windows:*
-- Requires OpenSSL 3.x DLLs:
-  - Win32: `libcrypto-3.dll`, `libssl-3.dll`
-  - Win64: `libcrypto-3-x64.dll`, `libssl-3-x64.dll`
-- Pre-compiled binaries:
-  - https://github.com/TaurusTLS-Developers/OpenSSL-Distribution/releases
-  - https://github.com/TurboPack/OpenSSL-Distribution/releases
-- Current versions: 3.0.17, 3.2.5, 3.3.4, 3.4.2, 3.5.1, 3.5.2
-- Place DLLs in the same directory as your executable
+TaurusTLS runs on OpenSSL 3.x and 4.x. Pre-compiled binaries for every supported platform, including Windows on ARM64, are published at https://github.com/TaurusTLS-Developers/OpenSSL-Distribution/releases. Full deployment instructions: https://taurustls.org/deployapps.xhtml
 
-*Linux:*
-- OpenSSL is usually installed by default
+*Windows (dynamic linking):*
+
+Ship the OpenSSL DLLs and `LICENSE.txt` alongside your executable:
+
+| Target | OpenSSL 3.x | OpenSSL 4.x |
+|--------|-------------|-------------|
+| Win32 | `libcrypto-3.dll`, `libssl-3.dll` | `libcrypto-4.dll`, `libssl-4.dll` |
+| Win64 | `libcrypto-3-x64.dll`, `libssl-3-x64.dll` | `libcrypto-4-x64.dll`, `libssl-4-x64.dll` |
+| Windows ARM64EC | `libcrypto-3-arm64.dll`, `libssl-3-arm64.dll` | `libcrypto-4-arm64.dll`, `libssl-4-arm64.dll` |
+
+Instead of copying DLLs by hand, the OpenSSL-Distribution releases also ship automated installers you can run yourself or chain from your own installer:
+
+- **InnoSetup installer** (`openssl-<version>-Windows-installer.exe`) - one setup covering x86, x64 and ARM64EC, picking the matching runtime by CPU detection. Silent install:
+  ```
+  openssl-<version>-Windows-installer.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  ```
+- **MSIX framework packages** (`openssl-<version>-Windows-x64.msix`, `-x86.msix`, `-arm64ec.msix`) - reference them from your own `AppxManifest.xml` as a `PackageDependency` on `TaurusTLS.OpenSSL`.
+
+*Linux (dynamic linking):*
+- OpenSSL is usually installed by default; document the dependency for your end users
 - Update if needed: `sudo apt-get install libssl-dev` (Debian/Ubuntu) or `sudo yum install openssl-devel` (RHEL/CentOS)
-- Pre-compiled binaries: https://github.com/TurboPack/OpenSSL-Distribution/releases
+- To pin a specific version, redistribute the Linux package from the OpenSSL-Distribution releases
 
-*macOS:*
-- Use static libraries (.a files) for OpenSSL 3.x
-- Install via Homebrew: `brew install openssl@3`
-- Or use pre-compiled libraries from TaurusTLS distributions
-- Pre-compiled binaries: https://github.com/TurboPack/OpenSSL-Distribution/releases
+*macOS, iOS and Android (static linking):*
+- OpenSSL is compiled into the application binary; build against the `.a` files in the `lib\static` folder of the platform archive (for example `openssl-<version>-macOS-arm64.zip`)
+- Nothing to redistribute besides your application package and `LICENSE.txt`
 
 **For Standard Indy:**
 - Requires OpenSSL 1.0.2 DLLs (`libeay32.dll`, `ssleay32.dll`)

--- a/build.bat
+++ b/build.bat
@@ -47,15 +47,22 @@ if "%PLATFORM%"=="" set PLATFORM=Win32
 echo Building MCPServer - %CONFIG% %PLATFORM%
 echo.
 
-REM Add TaurusTLS path if it exists - try multiple possible locations
-set TAURUS_PATH=
-if exist "%USERPROFILE%\Documents\Embarcadero\Studio\37.0\CatalogRepository\TaurusTLS\1.0.2.39\Source" (
-    set TAURUS_PATH=%USERPROFILE%\Documents\Embarcadero\Studio\37.0\CatalogRepository\TaurusTLS\1.0.2.39\Source
-) else if exist "%USERPROFILE%\Documents\Embarcadero\Studio\37.0\CatalogRepository\TaurusTLS-12\Source" (
-    set TAURUS_PATH=%USERPROFILE%\Documents\Embarcadero\Studio\37.0\CatalogRepository\TaurusTLS-12\Source
-)
+REM Locate TaurusTLS. Set TAURUS_PATH yourself to override; otherwise the
+REM highest version installed in the CatalogRepository of this Studio release
+REM is used, so a GetIt update is picked up without editing this script.
+REM Note: OpenSSL 4.x needs TaurusTLS 1.0.5.42 or newer.
+for %%i in ("!DELPHI_PATH!") do set STUDIO_VER=%%~nxi
+set CATALOG_DIR=%USERPROFILE%\Documents\Embarcadero\Studio\!STUDIO_VER!\CatalogRepository
 
+if not "%TAURUS_PATH%"=="" goto :TaurusResolved
+
+for /f "usebackq delims=" %%d in (`powershell -NoProfile -Command "$root = '!CATALOG_DIR!\TaurusTLS'; if (Test-Path $root) { Get-ChildItem $root -Directory ^| Where-Object { Test-Path (Join-Path $_.FullName 'Source') } ^| Sort-Object { try { [version]$_.Name } catch { [version]'0.0' } } ^| Select-Object -Last 1 -ExpandProperty FullName }"`) do set "TAURUS_PATH=%%d\Source"
+
+if "!TAURUS_PATH!"=="" if exist "!CATALOG_DIR!\TaurusTLS-12\Source" set "TAURUS_PATH=!CATALOG_DIR!\TaurusTLS-12\Source"
+
+:TaurusResolved
 if not "!TAURUS_PATH!"=="" (
+    echo Using TaurusTLS: !TAURUS_PATH!
     set EXTRA_UNITS=;!TAURUS_PATH!
 ) else (
     set EXTRA_UNITS=

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -2,8 +2,8 @@ unit MCPServer.IdHTTPServer;
 
 interface
 
-// TaurusTLS provides OpenSSL 3.x support with modern ECDHE cipher suites
-// Install via GetIt Package Manager: Search for "TaurusTLS" or get from https://github.com/JPeterMugaas/TaurusTLS
+// TaurusTLS provides OpenSSL 3.x/4.x support with modern ECDHE cipher suites
+// Install via GetIt Package Manager: Search for "TaurusTLS" or get from https://github.com/TaurusTLS-Developers/TaurusTLS
 {$DEFINE USE_TAURUS_TLS}  // Comment this line to use standard Indy SSL (OpenSSL 1.0.2)
 
 uses
@@ -378,7 +378,7 @@ begin
   
   // Create and configure SSL handler
   {$IFDEF USE_TAURUS_TLS}
-  // TaurusTLS with OpenSSL 3.x support
+  // TaurusTLS with OpenSSL 3.x/4.x support
   FSSLHandler := TTaurusTLSServerIOHandler.Create(Self);
   FSSLHandler.DefaultCert.PublicKey := FSettings.SSLCertFile;
   FSSLHandler.DefaultCert.PrivateKey := FSettings.SSLKeyFile;


### PR DESCRIPTION
Fixes #20.

The README claimed TaurusTLS requires OpenSSL 3.x DLLs. That is out of date: TaurusTLS runs on OpenSSL 3.x and 4.x, the 4.x libraries have different file names, Windows on ARM64 is supported, and the OpenSSL-Distribution project now ships automated installers that developers can run or chain from their own installer.

## Documentation

- OpenSSL 3.x and 4.x throughout, instead of 3.x only.
- DLL requirements as a table per target, covering the 4.x names and Windows ARM64EC, and mentioning `LICENSE.txt` as a required redistributable.
- New section on the automated installers: the InnoSetup multi-architecture setup with its silent-install flags, and the MSIX framework packages with the `TaurusTLS.OpenSSL` package dependency.
- Removed the hardcoded list of OpenSSL patch versions (already stale) in favour of a link to the releases page.
- Corrected the platform notes: Linux uses dynamic linking, macOS/iOS/Android use static linking with the `.a` files from `lib\static` and require no separate redistributables.
- Removed dead links to `TurboPack/OpenSSL-Distribution`; repository links now point at `TaurusTLS-Developers`.
- Added DPM and TMS Smart Setup as installation options next to GetIt.
- Same corrections applied to the outdated comments in `MCPServer.IdHTTPServer.pas` (comments only, no code changes).

## Verified against a running server

A Win64 build serving HTTPS, answering real MCP `initialize` and `tools/list` requests, with only the libraries under test present and a stripped `PATH`:

| TaurusTLS | OpenSSL 3.6.4 | OpenSSL 4.0.2 |
|---|---|---|
| 1.0.2.39 | works | fails: `ETaurusTLSCouldNotLoadSSLLibrary` |
| 1.0.8 | works | works (TLS 1.3, `libcrypto-4-x64.dll` loaded) |

`DefaultLibVersions` in `TaurusTLSConsts.pas` gained the `-4-` suffixes in TaurusTLS 1.0.5.42; releases up to 1.0.4.41 only look for 3.x, 1.1 and 1.0. That minimum is now documented, along with two failure modes the testing exposed: the load error itself, and TaurusTLS silently resolving to an unrelated OpenSSL elsewhere on the library search path, which `OPENSSL_LIBRARY_PATH` pins down.

## Build script

`build.bat` pinned the TaurusTLS path to version 1.0.2.39, one of the versions that cannot load 4.x, so the default build contradicted the documentation. It now selects the highest version installed in the CatalogRepository of the Studio release `DELPHI_PATH` points at, and honours a preset `TAURUS_PATH`. Sorting is numeric, so 1.0.10.52 wins over 1.0.9.51.

Not verified here: Windows ARM64, and the static-linking notes for macOS, iOS and Android. Those follow the upstream documentation.

Sources: https://taurustls.org/deployapps.xhtml, https://taurustls.org/download.xhtml and https://github.com/TaurusTLS-Developers/OpenSSL-Distribution/releases