### PR TITLE
Test harness, golden files and hygiene fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,11 @@ backup/
 # Claude Code specific
 
 # Dependencies
+
+# Test and conformance output
+tests/results/
+results/
+
+# Node tooling for conformance and Inspector runs
+node_modules/
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -91,14 +91,10 @@ backup/
 *.temp
 ~$*
 
-# Claude Code specific
-
 # Dependencies
+node_modules/
+package-lock.json
 
 # Test and conformance output
 tests/results/
 results/
-
-# Node tooling for conformance and Inspector runs
-node_modules/
-package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+Safety net for the MCP 2026-07-28 work: the legacy wire behaviour is pinned
+before any protocol change lands. No client-visible protocol change.
+
+### Added
+
+- DUnitX test project `tests\MCPServer.Tests.dpr` (Win32 and Win64) with an
+  in-process harness that builds the same registry as `MCPServer.dpr` and
+  drives `TMCPJsonRpcProcessor.ProcessRequest`.
+- Golden files that pin today's responses: 37 JSON-RPC cases in
+  `tests\golden\legacy` and 26 HTTP transport cases (status line, headers,
+  body) in `tests\golden\http`, recorded from the unchanged 2025-06-18 code.
+- `build-tests.bat` and `scripts\run-tests.ps1` (build and run, `-Record`
+  to re-record goldens), `scripts\capture-http-goldens.ps1`.
+- `scripts\run-conformance.ps1` for the official conformance CLI with one
+  expected-failures baseline per requirement set
+  (`conformance-baseline-2026-07-28.yml`, `conformance-baseline-2025-11-25.yml`),
+  `scripts\run-inspector-smoke.ps1` with `ci-servers.json` (legacy, auto and
+  modern eras plus stdio) and `scripts\run-stdio-smoke.ps1`.
+- `package.json` pinning the Node tooling (`@modelcontextprotocol/conformance`
+  0.2.0-alpha.11, `@modelcontextprotocol/inspector` 2.5.0).
+- Protocol constants in `MCPServer.Types`: revision names and sets
+  (`MCP_PROTOCOL_VERSION_*`, `MCP_LATEST_PROTOCOL_VERSION`,
+  `MCP_LEGACY_PROTOCOL_VERSIONS`, `MCP_MODERN_PROTOCOL_VERSIONS`), the MCP
+  error codes `MCP_ERROR_HEADER_MISMATCH` (-32020),
+  `MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY` (-32021),
+  `MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION` (-32022) and
+  `MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY` (-32002), the reserved `_meta` keys
+  (`MCP_META_*`) and `MCP_CACHEABLE_METHODS`.
+- `TLogger.StdoutReserved`: while set, console logging always goes to stderr
+  and `UseStdErr := False` is refused with a one-time warning.
+
+### Changed
+
+- The `JSONRPC_*` error-code constants are defined once in `MCPServer.Types`.
+  `MCPServer.JsonRpcProcessor` keeps them as aliases, so existing consumer
+  code compiles unchanged; the unused duplicate block in
+  `MCPServer.IdHTTPServer` is gone.
+- `TMCPRegistry` creates its dictionaries in a class constructor. Registration
+  must complete before the managers are created (before
+  `TMCPIdHTTPServer.Start` or `TMCPStdioTransport.Run`); this was already the
+  case and is now documented, also for `TServerStatusResource.SetNamePrefix`.
+- `TMCPStdioTransport.Create` forces `TLogger.UseStdErr := True` and sets
+  `TLogger.StdoutReserved`. Library consumers that create the transport with
+  console logging enabled and never set `UseStdErr` now get their log lines on
+  stderr instead of corrupting the MCP channel on stdout.
+- README: library checklist (register before start, stdout rules for stdio,
+  `server://status` is opt-in), automated-tests section, resource list matches
+  what the executable registers.
+
+### Fixed
+
+- `TServerStatusResource` request and connection counters and the SSE event-id
+  counter are updated atomically; they were plain increments shared by all
+  Indy connection threads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,16 @@ before any protocol change lands. No client-visible protocol change.
 - `TServerStatusResource` request and connection counters and the SSE event-id
   counter are updated atomically; they were plain increments shared by all
   Indy connection threads.
+- `logs://recent` answered "Error reading resource: Invalid pointer operation":
+  the copied log entries were owned by two lists and freed twice.
+- `TMCPSerializer` serialised `TList<T>` and `TObjectList<T>` properties as an
+  object with `count` and `capacity` members. They are JSON arrays now, so
+  `project://info` lists its features and `logs://recent` its entries.
+- `server://status` was declared but never registered by the executable; the
+  unit registers it by default now, and `SetNamePrefix` replaces that
+  registration instead of adding a second URI (`TMCPRegistry.UnregisterResource`
+  is new).
+- `resources/read` without `params` raised an access violation (returned as
+  `-32603`); it is now handled like a missing `uri`.
+- `tools/call` without `arguments` raised an access violation inside the tool
+  (returned as an `isError` result); the tool now receives an empty object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-Safety net for the MCP 2026-07-28 work: the legacy wire behaviour is pinned
-before any protocol change lands. No client-visible protocol change.
+Test harness, golden files and hygiene. No client-visible protocol change.
 
 ### Added
 
 - DUnitX test project `tests\MCPServer.Tests.dpr` (Win32 and Win64) with an
   in-process harness that builds the same registry as `MCPServer.dpr` and
   drives `TMCPJsonRpcProcessor.ProcessRequest`.
-- Golden files that pin today's responses: 37 JSON-RPC cases in
+- Golden files that pin the wire behaviour: 38 JSON-RPC cases in
   `tests\golden\legacy` and 26 HTTP transport cases (status line, headers,
-  body) in `tests\golden\http`, recorded from the unchanged 2025-06-18 code.
+  body) in `tests\golden\http`.
 - `build-tests.bat` and `scripts\run-tests.ps1` (build and run, `-Record`
   to re-record goldens), `scripts\capture-http-goldens.ps1`.
 - `scripts\run-conformance.ps1` for the official conformance CLI with one

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ end.
 
 - **Register before you start.** `TMCPToolsManager.Create` and `TMCPResourcesManager.Create` read `TMCPRegistry` once. Register your tools and resources (normally from unit `initialization` sections) before the managers are created, which means before `TMCPIdHTTPServer.Start` or `TMCPStdioTransport.Run`. Later registrations are not picked up.
 - **STDIO: keep stdout clean.** Everything on stdout must be an MCP message. `TMCPStdioTransport.Create` forces `TLogger.UseStdErr := True` and sets `TLogger.StdoutReserved`, so console logging goes to stderr and an attempt to switch it back is refused with a one-time warning. Never `Writeln` from tools, managers or resources; log through `TLogger`.
-- **`server://status` is opt-in.** Call `TServerStatusResource.RegisterServerStatusResource` (or `SetNamePrefix`) before the managers are created if you want it; the shipped executable registers `project://info`, `project://readme` and `logs://recent` only.
+- **`server://status` is registered by default** by the unit initialization of `MCPServer.Resource.Server`. `TServerStatusResource.SetNamePrefix('myapp_')` renames it to `server://myapp_status`; call it before the managers are created.
 - **Error codes and protocol constants** live in `MCPServer.Types` (`JSONRPC_*`, `MCP_ERROR_*`, `MCP_PROTOCOL_VERSION_*`, `MCP_META_*`). The `JSONRPC_*` names in `MCPServer.JsonRpcProcessor` remain as aliases.
 
 ### Creating Custom Tools
@@ -451,14 +451,11 @@ The Inspector provides a web interface to interact with your MCP server, making 
 
 ## Available Example resources
 
-The executable registers three resources:
+The server provides four resources accessible via URIs:
 
 - **project://info** - Project information (JSON metadata with collections)
 - **project://readme** - This README file (markdown content) 
 - **logs://recent** - Recent log entries from all categories (with thread safety)
-
-A fourth one ships with the library and is opt-in (see the library checklist):
-
 - **server://status** - Current server status and health information (request and connection counters)
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -579,10 +579,10 @@ The `tests` folder holds a DUnitX project that drives the JSON-RPC layer in-proc
 .\scripts\capture-http-goldens.ps1          # replay the HTTP golden cases with curl against Win64\Debug\MCPServer.exe
 .\scripts\run-stdio-smoke.ps1               # drive --stdio and check the framing of stdout/stderr
 .\scripts\run-conformance.ps1               # official conformance CLI, 2026-07-28 and 2025-11-25 requirement sets
-.\scripts\run-inspector-smoke.ps1           # Inspector CLI tools/list in the legacy, auto and modern eras and over stdio
+.\scripts\run-inspector-smoke.ps1 -ExpectedFailures delphi-modern   # Inspector CLI tools/list per protocol era and over stdio
 ```
 
-Known conformance failures are listed per requirement set in `conformance-baseline-<revision>.yml`; the conformance run fails on new failures and on entries that started to pass. `build-tests.bat [Config] [Platform]` compiles the test project on its own.
+Known conformance failures are listed per requirement set in `conformance-baseline-<revision>.yml`; the conformance run fails on new failures and on entries that started to pass. The Inspector smoke run takes the entries that must fail as a parameter (`delphi-modern` as long as the server has no `server/discover`). `build-tests.bat [Config] [Platform]` compiles the test project on its own.
 
 ## About GDK Software
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ begin
 end.
 ```
 
+#### Library checklist
+
+- **Register before you start.** `TMCPToolsManager.Create` and `TMCPResourcesManager.Create` read `TMCPRegistry` once. Register your tools and resources (normally from unit `initialization` sections) before the managers are created, which means before `TMCPIdHTTPServer.Start` or `TMCPStdioTransport.Run`. Later registrations are not picked up.
+- **STDIO: keep stdout clean.** Everything on stdout must be an MCP message. `TMCPStdioTransport.Create` forces `TLogger.UseStdErr := True` and sets `TLogger.StdoutReserved`, so console logging goes to stderr and an attempt to switch it back is refused with a one-time warning. Never `Writeln` from tools, managers or resources; log through `TLogger`.
+- **`server://status` is opt-in.** Call `TServerStatusResource.RegisterServerStatusResource` (or `SetNamePrefix`) before the managers are created if you want it; the shipped executable registers `project://info`, `project://readme` and `logs://recent` only.
+- **Error codes and protocol constants** live in `MCPServer.Types` (`JSONRPC_*`, `MCP_ERROR_*`, `MCP_PROTOCOL_VERSION_*`, `MCP_META_*`). The `JSONRPC_*` names in `MCPServer.JsonRpcProcessor` remain as aliases.
+
 ### Creating Custom Tools
 
 ```pascal
@@ -444,12 +451,15 @@ The Inspector provides a web interface to interact with your MCP server, making 
 
 ## Available Example resources
 
-The server provides four essential resources accessible via URIs:
+The executable registers three resources:
 
 - **project://info** - Project information (JSON metadata with collections)
 - **project://readme** - This README file (markdown content) 
 - **logs://recent** - Recent log entries from all categories (with thread safety)
-- **server://status** - Current server status and health information
+
+A fourth one ships with the library and is opt-in (see the library checklist):
+
+- **server://status** - Current server status and health information (request and connection counters)
 
 ## Configuration
 
@@ -561,6 +571,21 @@ We welcome contributions! Here's how to help:
 - Requires Delphi 12+ 
 - Open `MCPServer.dproj` or build with `build.bat`
 - Test with `npx @modelcontextprotocol/inspector` or Claude Code or similar
+
+### Automated tests
+
+The `tests` folder holds a DUnitX project that drives the JSON-RPC layer in-process and pins the wire behaviour with golden files (`tests\golden`, see the README there). The scripts under `scripts` wrap the build and the external tooling; the Node tools are pinned in `package.json`.
+
+```powershell
+.\scripts\run-tests.ps1                     # build tests\MCPServer.Tests.dpr (Win64 Debug) and run it
+.\scripts\run-tests.ps1 -Platform Win32
+.\scripts\capture-http-goldens.ps1          # replay the HTTP golden cases with curl against Win64\Debug\MCPServer.exe
+.\scripts\run-stdio-smoke.ps1               # drive --stdio and check the framing of stdout/stderr
+.\scripts\run-conformance.ps1               # official conformance CLI, 2026-07-28 and 2025-11-25 requirement sets
+.\scripts\run-inspector-smoke.ps1           # Inspector CLI tools/list in the legacy, auto and modern eras and over stdio
+```
+
+Known conformance failures are listed per requirement set in `conformance-baseline-<revision>.yml`; the conformance run fails on new failures and on entries that started to pass. `build-tests.bat [Config] [Platform]` compiles the test project on its own.
 
 ## About GDK Software
 

--- a/build-tests.bat
+++ b/build-tests.bat
@@ -1,0 +1,64 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+echo Delphi MCP Server Test Build Script (DUnitX)
+echo ============================================
+echo.
+
+REM Set Delphi installation path - adjust if needed (same as build.bat)
+set DELPHI_PATH=C:\Program Files (x86)\Embarcadero\Studio\37.0
+
+if not exist "!DELPHI_PATH!\bin\dcc32.exe" (
+    echo ERROR: dcc32.exe not found at !DELPHI_PATH!\bin\
+    echo Please update DELPHI_PATH in this script to point to your Delphi installation
+    exit /b 1
+)
+
+set DCC32="!DELPHI_PATH!\bin\dcc32.exe"
+set DCC64="!DELPHI_PATH!\bin\dcc64.exe"
+
+REM DUnitX ships with RAD Studio; the include path is needed for DUnitX.inc
+set DUNITX_PATH=!DELPHI_PATH!\source\DUnitX
+
+set CONFIG=%1
+if "%CONFIG%"=="" set CONFIG=Debug
+
+set PLATFORM=%2
+if "%PLATFORM%"=="" set PLATFORM=Win32
+
+set OUTPUT_DIR=.\tests\%PLATFORM%\%CONFIG%
+if not exist %OUTPUT_DIR% mkdir %OUTPUT_DIR%
+
+set UNIT_PATHS=src;src\Managers;src\Server;src\Tools;src\Core;src\Protocol;src\Libraries;src\Resources;tests
+set NAMESPACES=Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;System;Xml;Data;Datasnap;Web;Soap
+
+echo Building MCPServer.Tests - %CONFIG% %PLATFORM%
+echo.
+
+if "%PLATFORM%"=="Win32" (
+    !DCC32! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win32\debug";%UNIT_PATHS% -I"!DUNITX_PATH!" -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServer.Tests.dpr
+    goto :CheckBuildResult
+) else if "%PLATFORM%"=="Win64" (
+    !DCC64! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win64\debug";%UNIT_PATHS% -I"!DUNITX_PATH!" -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServer.Tests.dpr
+    goto :CheckBuildResult
+) else (
+    echo ERROR: Invalid platform. Use Win32 or Win64
+    echo.
+    echo Usage: build-tests.bat [Config] [Platform]
+    echo   Config: Debug or Release (default: Debug)
+    echo   Platform: Win32 or Win64 (default: Win32)
+    exit /b 1
+)
+
+:CheckBuildResult
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo Test build FAILED!
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo Test build completed successfully!
+echo Output: %OUTPUT_DIR%\MCPServer.Tests.exe
+
+endlocal

--- a/ci-servers.json
+++ b/ci-servers.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "delphi-legacy": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "protocolEra": "legacy"
+    },
+    "delphi-auto": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "protocolEra": "auto"
+    },
+    "delphi-modern": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "protocolEra": "modern"
+    },
+    "delphi-stdio": {
+      "type": "stdio",
+      "command": "Win64\\Release\\MCPServer.exe",
+      "args": ["--stdio"]
+    }
+  }
+}

--- a/conformance-baseline-2025-11-25.yml
+++ b/conformance-baseline-2025-11-25.yml
@@ -1,0 +1,27 @@
+# Known conformance failures for --requirements 2025-11-25
+# Scenarios listed here may fail; a listed scenario that passes fails the run (stale entry).
+# Regenerate after each phase with scripts/run-conformance.ps1 -NoBaseline and prune what passes.
+server:
+  - logging-set-level
+  - completion-complete
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-with-progress
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  - resources-read-binary
+  - resources-subscribe
+  - resources-unsubscribe
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection
+  # only a WARNING check (no session id on the SSE path); the runner counts it as not passed
+  - server-sse-multiple-streams

--- a/conformance-baseline-2025-11-25.yml
+++ b/conformance-baseline-2025-11-25.yml
@@ -1,6 +1,6 @@
 # Known conformance failures for --requirements 2025-11-25
 # Scenarios listed here may fail; a listed scenario that passes fails the run (stale entry).
-# Regenerate after each phase with scripts/run-conformance.ps1 -NoBaseline and prune what passes.
+# Regenerate with scripts/run-conformance.ps1 -NoBaseline after a change and prune what passes.
 server:
   - logging-set-level
   - completion-complete

--- a/conformance-baseline-2026-07-28.yml
+++ b/conformance-baseline-2026-07-28.yml
@@ -1,0 +1,40 @@
+# Known conformance failures for --requirements 2026-07-28
+# Scenarios listed here may fail; a listed scenario that passes fails the run (stale entry).
+# Regenerate after each phase with scripts/run-conformance.ps1 -NoBaseline and prune what passes.
+server:
+  - server-stateless
+  - completion-complete
+  - tools-list
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-error
+  - tools-call-with-progress
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - sep-2164-resource-not-found
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection
+  - caching
+  - input-required-result-basic-elicitation
+  - input-required-result-basic-sampling
+  - input-required-result-basic-list-roots
+  - input-required-result-request-state
+  - input-required-result-multiple-input-requests
+  - input-required-result-multi-round
+  - input-required-result-missing-input-response
+  - input-required-result-non-tool-request
+  - input-required-result-result-type
+  - input-required-result-unsupported-methods
+  - input-required-result-tampered-state
+  - input-required-result-capability-check
+  - input-required-result-ignore-extra-params
+  - input-required-result-validate-input

--- a/conformance-baseline-2026-07-28.yml
+++ b/conformance-baseline-2026-07-28.yml
@@ -1,6 +1,6 @@
 # Known conformance failures for --requirements 2026-07-28
 # Scenarios listed here may fail; a listed scenario that passes fails the run (stale entry).
-# Regenerate after each phase with scripts/run-conformance.ps1 -NoBaseline and prune what passes.
+# Regenerate with scripts/run-conformance.ps1 -NoBaseline after a change and prune what passes.
 server:
   - server-stateless
   - completion-complete

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "delphi-mcp-server-tooling",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned Node tooling for the conformance and Inspector smoke runs of the Delphi MCP Server (see scripts/).",
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "scripts": {
+    "conformance": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-conformance.ps1",
+    "inspector:smoke": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-inspector-smoke.ps1",
+    "stdio:smoke": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-stdio-smoke.ps1"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.11",
+    "@modelcontextprotocol/inspector": "2.5.0"
+  }
+}

--- a/scripts/McpServerProcess.ps1
+++ b/scripts/McpServerProcess.ps1
@@ -1,0 +1,156 @@
+# Helper functions for scripts that need a running server executable.
+# Dot-source this file: . "$PSScriptRoot\McpServerProcess.ps1"
+
+function Get-RepoRoot {
+    return Split-Path -Parent $PSScriptRoot
+}
+
+function Invoke-ServerBuild {
+    param(
+        [Parameter(Mandatory)] [string]$Configuration,
+        [Parameter(Mandatory)] [string]$Platform
+    )
+    $repoRoot = Get-RepoRoot
+    Write-Host "Building server ($Configuration $Platform)..."
+    & cmd.exe /c "cd /d `"$repoRoot`" && .\build.bat $Configuration $Platform"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Server build failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Wait-McpPort {
+    param(
+        [Parameter(Mandatory)] [int]$Port,
+        [int]$TimeoutSeconds = 15
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $client = New-Object System.Net.Sockets.TcpClient
+        try {
+            $client.Connect('127.0.0.1', $Port)
+            if ($client.Connected) { return $true }
+        } catch {
+        } finally {
+            $client.Dispose()
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+
+<#
+.SYNOPSIS
+    Starts the server executable on the given port and waits for it.
+
+.DESCRIPTION
+    The server reads settings.ini next to its executable, so a temporary one
+    with the requested port is written. Stop-McpServer restores the original.
+    Returns a handle object for Stop-McpServer.
+#>
+function Start-McpServer {
+    param(
+        [Parameter(Mandatory)] [string]$ServerExe,
+        [Parameter(Mandatory)] [int]$Port,
+        [Parameter(Mandatory)] [string]$LogDir
+    )
+
+    $ServerExe = (Resolve-Path $ServerExe).Path
+    $exeDir = Split-Path -Parent $ServerExe
+    $settingsFile = Join-Path $exeDir 'settings.ini'
+    $settingsBackup = $null
+    if (Test-Path $settingsFile) {
+        $settingsBackup = Get-Content -Raw $settingsFile
+    }
+
+    $settingsContent = @"
+[Server]
+Port=$Port
+Host=localhost
+Name=delphi-mcp-server
+Version=1.0.0
+Endpoint=/mcp
+
+[CORS]
+Enabled=1
+AllowedOrigins=http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1
+
+[SSL]
+Enabled=0
+"@
+    Set-Content -Path $settingsFile -Value $settingsContent -Encoding ASCII
+
+    New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+    $process = Start-Process -FilePath $ServerExe -WorkingDirectory $exeDir -PassThru -NoNewWindow `
+        -RedirectStandardOutput (Join-Path $LogDir 'server.log') `
+        -RedirectStandardError (Join-Path $LogDir 'server.err.log')
+
+    $handle = [pscustomobject]@{
+        Process        = $process
+        SettingsFile   = $settingsFile
+        SettingsBackup = $settingsBackup
+        Port           = $Port
+        Url            = "http://127.0.0.1:$Port/mcp"
+    }
+
+    if (-not (Wait-McpPort -Port $Port)) {
+        Stop-McpServer $handle
+        throw "Server did not open port $Port within the timeout (see $LogDir\server.log)"
+    }
+    return $handle
+}
+
+function Stop-McpServer {
+    param([Parameter(Mandatory)] $Handle)
+
+    if ($Handle.Process -and -not $Handle.Process.HasExited) {
+        Stop-Process -Id $Handle.Process.Id -Force
+        $Handle.Process.WaitForExit(5000) | Out-Null
+    }
+    if ($null -ne $Handle.SettingsBackup) {
+        Set-Content -Path $Handle.SettingsFile -Value $Handle.SettingsBackup -NoNewline
+    } else {
+        Remove-Item $Handle.SettingsFile -ErrorAction SilentlyContinue
+    }
+}
+
+<#
+.SYNOPSIS
+    Runs a native command line through cmd.exe with both streams in a log file.
+
+.DESCRIPTION
+    Windows PowerShell 5.1 turns stderr lines of native commands into error
+    records, which aborts scripts that run with ErrorActionPreference Stop.
+    Writing the command line to a batch file and redirecting inside cmd.exe
+    keeps the output intact. Returns the exit code.
+#>
+function Invoke-NativeToLog {
+    param(
+        [Parameter(Mandatory)] [string]$CommandLine,
+        [Parameter(Mandatory)] [string]$LogFile,
+        [Parameter(Mandatory)] [string]$WorkingDirectory
+    )
+    $batchFile = [System.IO.Path]::ChangeExtension($LogFile, '.cmd')
+    $content = @(
+        '@echo off'
+        "cd /d `"$WorkingDirectory`""
+        "$CommandLine > `"$LogFile`" 2>&1"
+        'exit /b %ERRORLEVEL%'
+    )
+    Set-Content -Path $batchFile -Value $content -Encoding ASCII
+    $process = Start-Process -FilePath 'cmd.exe' -ArgumentList @('/c', "`"$batchFile`"") -PassThru -NoNewWindow -Wait
+    return $process.ExitCode
+}
+
+function Assert-NodeTooling {
+    $repoRoot = Get-RepoRoot
+    if (-not (Test-Path (Join-Path $repoRoot 'node_modules\@modelcontextprotocol'))) {
+        Write-Host 'Installing pinned Node tooling (npm install)...'
+        Push-Location $repoRoot
+        try {
+            & npm.cmd install --no-audit --no-fund
+            if ($LASTEXITCODE -ne 0) { throw "npm install failed with exit code $LASTEXITCODE" }
+        } finally {
+            Pop-Location
+        }
+    }
+}

--- a/scripts/capture-http-goldens.ps1
+++ b/scripts/capture-http-goldens.ps1
@@ -181,7 +181,7 @@ try {
         }
 
         $raw = [System.Text.Encoding]::UTF8.GetString([System.IO.File]::ReadAllBytes($responseFile))
-        $actual = Normalize-Response $raw
+        $actual = (Normalize-Response $raw).TrimEnd("`n")
         $goldenFile = Join-Path $goldenDir "$($case.Name).txt"
 
         if ($Record) {

--- a/scripts/capture-http-goldens.ps1
+++ b/scripts/capture-http-goldens.ps1
@@ -1,0 +1,231 @@
+<#
+.SYNOPSIS
+    Records or verifies the HTTP transport golden files with curl.
+
+.DESCRIPTION
+    Starts the built server executable on a dedicated port, sends a fixed set
+    of requests with curl and stores status line, headers and body of each
+    response under tests\golden\http. In verify mode the stored files are
+    compared with a fresh capture.
+
+    Volatile parts are normalised before storing: the Date and Server
+    headers are dropped, GUIDs become <guid>, SSE "id:" lines become
+    "id: <n>", and line endings are LF.
+
+.PARAMETER Record
+    Overwrite the stored golden files with the current responses.
+
+.PARAMETER ServerExe
+    Path to the server executable. Default: Win64\Debug\MCPServer.exe.
+
+.PARAMETER Port
+    TCP port the server is started on. Default: 3939.
+
+.EXAMPLE
+    .\scripts\capture-http-goldens.ps1 -Record
+    .\scripts\capture-http-goldens.ps1
+#>
+[CmdletBinding()]
+param(
+    [switch]$Record,
+    [string]$ServerExe,
+    [int]$Port = 3939
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $ServerExe) {
+    $ServerExe = Join-Path $repoRoot 'Win64\Debug\MCPServer.exe'
+}
+$ServerExe = (Resolve-Path $ServerExe).Path
+$goldenDir = Join-Path $repoRoot 'tests\golden\http'
+$resultsDir = Join-Path $repoRoot 'tests\results\http-golden'
+$endpoint = "http://127.0.0.1:$Port/mcp"
+
+New-Item -ItemType Directory -Force -Path $goldenDir, $resultsDir | Out-Null
+
+$curl = Get-Command curl.exe -ErrorAction Stop
+
+# ---------------------------------------------------------------------------
+# Server lifecycle: the server reads settings.ini next to its executable, so a
+# temporary one with the test port is written and the original restored.
+# ---------------------------------------------------------------------------
+$exeDir = Split-Path -Parent $ServerExe
+$settingsFile = Join-Path $exeDir 'settings.ini'
+$settingsBackup = $null
+if (Test-Path $settingsFile) {
+    $settingsBackup = Get-Content -Raw $settingsFile
+}
+
+$settingsContent = @"
+[Server]
+Port=$Port
+Host=localhost
+Name=delphi-mcp-server
+Version=1.0.0
+Endpoint=/mcp
+
+[CORS]
+Enabled=1
+AllowedOrigins=http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1
+
+[SSL]
+Enabled=0
+"@
+Set-Content -Path $settingsFile -Value $settingsContent -Encoding ASCII
+
+function Wait-ForPort([int]$PortNumber, [int]$TimeoutSeconds = 15) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $client = New-Object System.Net.Sockets.TcpClient
+        try {
+            $client.Connect('127.0.0.1', $PortNumber)
+            if ($client.Connected) { return $true }
+        } catch {
+        } finally {
+            $client.Dispose()
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+
+$serverLog = Join-Path $resultsDir 'server.log'
+$serverErr = Join-Path $resultsDir 'server.err.log'
+$server = Start-Process -FilePath $ServerExe -WorkingDirectory $exeDir -PassThru -NoNewWindow `
+    -RedirectStandardOutput $serverLog -RedirectStandardError $serverErr
+
+try {
+    if (-not (Wait-ForPort $Port)) {
+        throw "Server did not open port $Port within the timeout (see $serverLog)"
+    }
+
+    # Observation for the PR description: which address does Indy bind to?
+    $listen = (netstat -ano | Select-String ":$Port\s" | Select-String 'LISTENING' | ForEach-Object { $_.Line.Trim() }) -join "`n"
+    Set-Content -Path (Join-Path $resultsDir 'listen.txt') -Value $listen -Encoding ASCII
+    Write-Host "Listening sockets:`n$listen"
+
+    # -----------------------------------------------------------------------
+    # Cases
+    # -----------------------------------------------------------------------
+    $jsonAccept = 'Accept: application/json'
+    $sseAccept = 'Accept: application/json, text/event-stream'
+    $jsonType = 'Content-Type: application/json'
+    $initialize = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"golden-client","version":"1.0.0"}}}'
+
+    $cases = @(
+        @{ Name = 'post-initialize';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = $initialize }
+        @{ Name = 'post-initialize-sse';           Method = 'POST';    Headers = @($jsonType, $sseAccept);  Body = $initialize }
+        @{ Name = 'post-tools-list';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' }
+        @{ Name = 'post-tools-list-sse';           Method = 'POST';    Headers = @($jsonType, $sseAccept);  Body = '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' }
+        @{ Name = 'post-tools-call-echo';          Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello golden"}}}' }
+        @{ Name = 'post-resources-list';           Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":4,"method":"resources/list"}' }
+        @{ Name = 'post-resources-read-project-info'; Method = 'POST'; Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"project://info"}}' }
+        @{ Name = 'post-notification-initialized'; Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","method":"notifications/initialized"}' }
+        @{ Name = 'post-client-response';          Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":1,"result":{}}' }
+        @{ Name = 'post-batch-notifications';      Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '[{"jsonrpc":"2.0","method":"notifications/initialized"}]' }
+        @{ Name = 'post-batch-requests';           Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '[{"jsonrpc":"2.0","id":6,"method":"ping"}]' }
+        @{ Name = 'post-unknown-method';           Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":7,"method":"prompts/list"}' }
+        @{ Name = 'post-parse-error';              Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":8,"method":' }
+        @{ Name = 'post-empty-body';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '' }
+        @{ Name = 'post-no-accept-header';         Method = 'POST';    Headers = @($jsonType);              Body = '{"jsonrpc":"2.0","id":9,"method":"ping"}' }
+        @{ Name = 'post-session-echo';             Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'Mcp-Session-Id: golden-session-1'); Body = '{"jsonrpc":"2.0","id":10,"method":"ping"}' }
+        @{ Name = 'post-session-echo-lowercase';   Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'mcp-session-id: golden-session-2'); Body = '{"jsonrpc":"2.0","id":11,"method":"ping"}' }
+        @{ Name = 'post-protocol-version-header';  Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'MCP-Protocol-Version: 2025-06-18'); Body = '{"jsonrpc":"2.0","id":12,"method":"ping"}' }
+        @{ Name = 'post-origin-allowed';           Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'Origin: http://localhost'); Body = '{"jsonrpc":"2.0","id":13,"method":"ping"}' }
+        @{ Name = 'post-origin-forbidden';         Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'Origin: http://evil.example'); Body = '{"jsonrpc":"2.0","id":14,"method":"ping"}' }
+        @{ Name = 'post-wrong-path';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":15,"method":"ping"}'; Path = '/other' }
+        @{ Name = 'get-endpoint-info';             Method = 'GET';     Headers = @($jsonAccept) }
+        @{ Name = 'get-sse-stream';                Method = 'GET';     Headers = @('Accept: text/event-stream') }
+        @{ Name = 'options-preflight';             Method = 'OPTIONS'; Headers = @('Origin: http://localhost', 'Access-Control-Request-Method: POST', 'Access-Control-Request-Headers: Content-Type') }
+        @{ Name = 'delete-endpoint';               Method = 'DELETE';  Headers = @($jsonAccept) }
+        @{ Name = 'put-endpoint';                  Method = 'PUT';     Headers = @($jsonType, $jsonAccept); Body = '{}' }
+    )
+
+    function Normalize-Response([string]$Text) {
+        $lines = ($Text -replace "`r`n", "`n").Split("`n")
+        $kept = New-Object System.Collections.Generic.List[string]
+        foreach ($line in $lines) {
+            if ($line -match '^(Date|Server):\s') { continue }
+            $normalized = $line
+            $normalized = [regex]::Replace($normalized, '\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?', '<guid>')
+            $normalized = [regex]::Replace($normalized, '^id: \d+$', 'id: <n>')
+            $kept.Add($normalized)
+        }
+        return ($kept -join "`n")
+    }
+
+    $failures = 0
+    $bodyFile = Join-Path $resultsDir 'request-body.tmp'
+    $responseFile = Join-Path $resultsDir 'response.tmp'
+
+    foreach ($case in $cases) {
+        $path = if ($case.Path) { $case.Path } else { '/mcp' }
+        $url = "http://127.0.0.1:$Port$path"
+        $arguments = @('-s', '-i', '--http1.1', '-X', $case.Method, '-o', $responseFile)
+        foreach ($header in $case.Headers) {
+            $arguments += @('-H', $header)
+        }
+        if ($case.ContainsKey('Body')) {
+            [System.IO.File]::WriteAllBytes($bodyFile, [System.Text.Encoding]::UTF8.GetBytes([string]$case.Body))
+            $arguments += @('--data-binary', "@$bodyFile")
+        }
+        $arguments += $url
+
+        & $curl.Source @arguments
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "[$($case.Name)] curl failed with exit code $LASTEXITCODE"
+            $failures++
+            continue
+        }
+
+        $raw = [System.Text.Encoding]::UTF8.GetString([System.IO.File]::ReadAllBytes($responseFile))
+        $actual = Normalize-Response $raw
+        $goldenFile = Join-Path $goldenDir "$($case.Name).txt"
+
+        if ($Record) {
+            [System.IO.File]::WriteAllText($goldenFile, $actual + "`n", (New-Object System.Text.UTF8Encoding($false)))
+            Write-Host "[$($case.Name)] recorded"
+            continue
+        }
+
+        if (-not (Test-Path $goldenFile)) {
+            Write-Host "[$($case.Name)] MISSING golden file (run with -Record)"
+            $failures++
+            continue
+        }
+
+        $expected = ([System.IO.File]::ReadAllText($goldenFile) -replace "`r`n", "`n").TrimEnd("`n")
+        if ($expected -eq $actual) {
+            Write-Host "[$($case.Name)] ok"
+        } else {
+            Write-Host "[$($case.Name)] MISMATCH"
+            Write-Host '--- expected ---'
+            Write-Host $expected
+            Write-Host '--- actual ---'
+            Write-Host $actual
+            Write-Host '---'
+            $failures++
+        }
+    }
+
+    Remove-Item $bodyFile, $responseFile -ErrorAction SilentlyContinue
+
+    if ($failures -gt 0) {
+        Write-Host "$failures case(s) failed"
+        exit 1
+    }
+    Write-Host 'All HTTP golden cases passed'
+}
+finally {
+    if ($server -and -not $server.HasExited) {
+        Stop-Process -Id $server.Id -Force
+        $server.WaitForExit(5000) | Out-Null
+    }
+    if ($null -ne $settingsBackup) {
+        Set-Content -Path $settingsFile -Value $settingsBackup -NoNewline
+    } else {
+        Remove-Item $settingsFile -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/run-conformance.ps1
+++ b/scripts/run-conformance.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Runs the official MCP conformance suite against the built server.
+
+.DESCRIPTION
+    Builds the server, starts it, and runs
+    "npx @modelcontextprotocol/conformance server" once per requirement set
+    (2026-07-28 and 2025-11-25 by default) against the same endpoint. Known
+    failures are read from conformance-baseline.yml; the run fails on new
+    failures and on stale baseline entries. Reports land in
+    tests\results\conformance\<revision>.
+
+    The pinned tool version comes from package.json (the --requirements flag
+    needs the 0.2.0 line of the conformance package).
+
+.PARAMETER Configuration
+    Release (default) or Debug.
+
+.PARAMETER Platform
+    Win64 (default) or Win32.
+
+.PARAMETER Port
+    Port to start the server on. Default: 3000.
+
+.PARAMETER Requirements
+    Requirement sets to run. Default: 2026-07-28 and 2025-11-25.
+
+.PARAMETER NoBuild
+    Use the existing executable.
+
+.PARAMETER NoBaseline
+    Run without the expected-failures file (to see the raw result).
+
+.EXAMPLE
+    .\scripts\run-conformance.ps1
+    .\scripts\run-conformance.ps1 -NoBuild -Requirements 2025-11-25
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+
+    [ValidateSet('Win32', 'Win64')]
+    [string]$Platform = 'Win64',
+
+    [int]$Port = 3000,
+
+    [string[]]$Requirements = @('2026-07-28', '2025-11-25'),
+
+    [switch]$NoBuild,
+
+    [switch]$NoBaseline
+)
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\McpServerProcess.ps1"
+
+$repoRoot = Get-RepoRoot
+$serverExe = Join-Path $repoRoot "$Platform\$Configuration\MCPServer.exe"
+$resultsRoot = Join-Path $repoRoot 'tests\results\conformance'
+$baseline = Join-Path $repoRoot 'conformance-baseline.yml'
+
+if (-not $NoBuild) {
+    Invoke-ServerBuild -Configuration $Configuration -Platform $Platform
+}
+Assert-NodeTooling
+
+New-Item -ItemType Directory -Force -Path $resultsRoot | Out-Null
+$server = Start-McpServer -ServerExe $serverExe -Port $Port -LogDir $resultsRoot
+
+$summary = @()
+try {
+    foreach ($revision in $Requirements) {
+        $outputDir = Join-Path $resultsRoot $revision
+        $logFile = Join-Path $resultsRoot "$revision.log"
+        $commandLine = "npx @modelcontextprotocol/conformance server --url $($server.Url) --requirements $revision -o `"$outputDir`""
+        # One baseline per requirement set: a scenario can pass on one wire
+        # and fail on the other, and a listed scenario that passes counts as a
+        # stale entry.
+        $baseline = Join-Path $repoRoot "conformance-baseline-$revision.yml"
+        if (-not $NoBaseline -and (Test-Path $baseline)) {
+            $commandLine += " --expected-failures `"$baseline`""
+        }
+
+        Write-Host ''
+        Write-Host "=== conformance --requirements $revision ==="
+        $exitCode = Invoke-NativeToLog -CommandLine $commandLine -LogFile $logFile -WorkingDirectory $repoRoot
+
+        # The per-scenario progress is in the log file; show the summary only.
+        $logText = [System.IO.File]::ReadAllText($logFile)
+        $summaryStart = $logText.LastIndexOf('=== SUMMARY ===')
+        if ($summaryStart -ge 0) { Write-Host $logText.Substring($summaryStart) } else { Write-Host $logText }
+        $summary += [pscustomobject]@{ Revision = $revision; ExitCode = $exitCode; Log = $logFile }
+    }
+}
+finally {
+    Stop-McpServer $server
+}
+
+Write-Host ''
+Write-Host 'Summary:'
+$summary | Format-Table -AutoSize | Out-String | Write-Host
+
+$failed = @($summary | Where-Object { $_.ExitCode -ne 0 })
+if ($failed.Count -gt 0) {
+    Write-Host "$($failed.Count) requirement set(s) did not match the baseline"
+    exit 1
+}
+Write-Host 'All requirement sets match the baseline'
+exit 0

--- a/scripts/run-inspector-smoke.ps1
+++ b/scripts/run-inspector-smoke.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Smoke-tests the server with the MCP Inspector CLI in every protocol era.
+
+.DESCRIPTION
+    Starts the built server and calls tools/list through
+    "npx @modelcontextprotocol/inspector --cli" for each entry in
+    ci-servers.json: delphi-legacy, delphi-auto, delphi-modern over HTTP and
+    delphi-stdio over a spawned process. The pinned Inspector version comes
+    from package.json.
+
+    Until the 2026-07-28 work lands, the modern entry is expected to fail;
+    pass -ExpectModern once it must succeed. The script exits non-zero when
+    an entry that is expected to work fails, or when the modern entry
+    unexpectedly passes or fails.
+
+.PARAMETER Configuration
+    Release (default) or Debug. The stdio entry in ci-servers.json points at
+    Win64\Release\MCPServer.exe.
+
+.PARAMETER Platform
+    Win64 (default) or Win32.
+
+.PARAMETER NoBuild
+    Use the existing executable.
+
+.PARAMETER ExpectModern
+    Treat a failing modern entry as an error.
+
+.EXAMPLE
+    .\scripts\run-inspector-smoke.ps1
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+
+    [ValidateSet('Win32', 'Win64')]
+    [string]$Platform = 'Win64',
+
+    [switch]$NoBuild,
+
+    [switch]$ExpectModern
+)
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\McpServerProcess.ps1"
+
+$repoRoot = Get-RepoRoot
+$serverExe = Join-Path $repoRoot "$Platform\$Configuration\MCPServer.exe"
+$resultsDir = Join-Path $repoRoot 'tests\results\inspector'
+$config = Join-Path $repoRoot 'ci-servers.json'
+$port = 3000   # ci-servers.json points at this port
+
+if (-not $NoBuild) {
+    Invoke-ServerBuild -Configuration $Configuration -Platform $Platform
+}
+Assert-NodeTooling
+
+New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+$server = Start-McpServer -ServerExe $serverExe -Port $port -LogDir $resultsDir
+
+$entries = @(
+    @{ Name = 'delphi-legacy'; ExpectSuccess = $true }
+    @{ Name = 'delphi-auto';   ExpectSuccess = $true }
+    @{ Name = 'delphi-modern'; ExpectSuccess = [bool]$ExpectModern }
+    @{ Name = 'delphi-stdio';  ExpectSuccess = $true }
+)
+
+$rows = @()
+try {
+    foreach ($entry in $entries) {
+        $logFile = Join-Path $resultsDir "$($entry.Name).log"
+        $commandLine = "npx @modelcontextprotocol/inspector --cli --config `"$config`" --server $($entry.Name) --method tools/list --format json"
+        $exitCode = Invoke-NativeToLog -CommandLine $commandLine -LogFile $logFile -WorkingDirectory $repoRoot
+        $text = [System.IO.File]::ReadAllText($logFile)
+
+        # The JSON result is one line on stdout. A stdio server's stderr log
+        # lines share the log file and can interleave with it, so locate the
+        # result object by its prefix and parse up to the end of that line.
+        $toolCount = $null
+        $resultStart = $text.LastIndexOf('{"result":')
+        if ($resultStart -ge 0) {
+            $resultEnd = $text.IndexOfAny([char[]]@("`r", "`n"), $resultStart)
+            if ($resultEnd -lt 0) { $resultEnd = $text.Length }
+            $jsonLine = $text.Substring($resultStart, $resultEnd - $resultStart)
+            try {
+                $json = $jsonLine | ConvertFrom-Json
+                if ($json.result -and $json.result.tools) { $toolCount = @($json.result.tools).Count }
+            } catch {
+            }
+        }
+
+        $succeeded = ($exitCode -eq 0) -and ($null -ne $toolCount)
+        $asExpected = ($succeeded -eq $entry.ExpectSuccess)
+        $rows += [pscustomobject]@{
+            Server     = $entry.Name
+            ExitCode   = $exitCode
+            Tools      = $toolCount
+            Succeeded  = $succeeded
+            Expected   = $entry.ExpectSuccess
+            AsExpected = $asExpected
+        }
+    }
+}
+finally {
+    Stop-McpServer $server
+}
+
+$rows | Format-Table -AutoSize | Out-String | Write-Host
+
+$unexpected = @($rows | Where-Object { -not $_.AsExpected })
+if ($unexpected.Count -gt 0) {
+    Write-Host "$($unexpected.Count) entr(y/ies) did not behave as expected (see $resultsDir)"
+    exit 1
+}
+Write-Host 'Inspector smoke run behaved as expected'
+exit 0

--- a/scripts/run-inspector-smoke.ps1
+++ b/scripts/run-inspector-smoke.ps1
@@ -9,10 +9,9 @@
     delphi-stdio over a spawned process. The pinned Inspector version comes
     from package.json.
 
-    Until the 2026-07-28 work lands, the modern entry is expected to fail;
-    pass -ExpectModern once it must succeed. The script exits non-zero when
-    an entry that is expected to work fails, or when the modern entry
-    unexpectedly passes or fails.
+    Every entry is expected to list the tools. Entries named in
+    -ExpectedFailures are expected to fail instead; the script exits non-zero
+    when an entry does not behave as expected in either direction.
 
 .PARAMETER Configuration
     Release (default) or Debug. The stdio entry in ci-servers.json points at
@@ -24,11 +23,13 @@
 .PARAMETER NoBuild
     Use the existing executable.
 
-.PARAMETER ExpectModern
-    Treat a failing modern entry as an error.
+.PARAMETER ExpectedFailures
+    Entry names that must fail (for example delphi-modern while the server
+    does not implement server/discover).
 
 .EXAMPLE
     .\scripts\run-inspector-smoke.ps1
+    .\scripts\run-inspector-smoke.ps1 -ExpectedFailures delphi-modern
 #>
 [CmdletBinding()]
 param(
@@ -40,7 +41,7 @@ param(
 
     [switch]$NoBuild,
 
-    [switch]$ExpectModern
+    [string[]]$ExpectedFailures = @()
 )
 
 $ErrorActionPreference = 'Stop'
@@ -60,12 +61,10 @@ Assert-NodeTooling
 New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 $server = Start-McpServer -ServerExe $serverExe -Port $port -LogDir $resultsDir
 
-$entries = @(
-    @{ Name = 'delphi-legacy'; ExpectSuccess = $true }
-    @{ Name = 'delphi-auto';   ExpectSuccess = $true }
-    @{ Name = 'delphi-modern'; ExpectSuccess = [bool]$ExpectModern }
-    @{ Name = 'delphi-stdio';  ExpectSuccess = $true }
-)
+$entries = @()
+foreach ($name in 'delphi-legacy', 'delphi-auto', 'delphi-modern', 'delphi-stdio') {
+    $entries += @{ Name = $name; ExpectSuccess = ($ExpectedFailures -notcontains $name) }
+}
 
 $rows = @()
 try {

--- a/scripts/run-stdio-smoke.ps1
+++ b/scripts/run-stdio-smoke.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Drives the server over stdio and checks the framing of the channel.
+
+.DESCRIPTION
+    Feeds a fixed set of JSON-RPC lines (initialize, initialized, tools/list,
+    tools/call echo with non-ASCII text) to "MCPServer.exe --stdio" through
+    cmd.exe redirection, exactly as a client spawning the process would, and
+    checks:
+      - stdout holds one JSON object per line and nothing else,
+      - every request id gets exactly one response,
+      - all log lines went to stderr.
+    It also reports whether the non-ASCII text survived the round trip; this
+    is an observation for the stdio work (Text I/O decodes stdin with the
+    ANSI code page on Windows) and does not fail the run.
+
+.PARAMETER ServerExe
+    Path to the executable. Default: Win64\Release\MCPServer.exe.
+
+.EXAMPLE
+    .\scripts\run-stdio-smoke.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$ServerExe
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $ServerExe) {
+    $ServerExe = Join-Path $repoRoot 'Win64\Release\MCPServer.exe'
+}
+$ServerExe = (Resolve-Path $ServerExe).Path
+$resultsDir = Join-Path $repoRoot 'tests\results\stdio'
+New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+$inputFile = Join-Path $resultsDir 'input.jsonl'
+$stdoutFile = Join-Path $resultsDir 'stdout.txt'
+$stderrFile = Join-Path $resultsDir 'stderr.txt'
+
+$probe = 'h' + [char]0x00E9 + 'llo w' + [char]0x00F6 + 'rld'
+$lines = @(
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"stdio-smoke","version":"1.0.0"}}}'
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+    ('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"message":"' + $probe + '"}}}')
+)
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllBytes($inputFile, $utf8.GetBytes(($lines -join "`n") + "`n"))
+
+# A batch file keeps the redirections out of PowerShell's argument quoting.
+$batchFile = Join-Path $resultsDir 'run.cmd'
+$command = "@`"$ServerExe`" --stdio < `"$inputFile`" > `"$stdoutFile`" 2> `"$stderrFile`""
+Set-Content -Path $batchFile -Value $command -Encoding ASCII
+$process = Start-Process -FilePath 'cmd.exe' -ArgumentList @('/c', "`"$batchFile`"") -WorkingDirectory (Split-Path -Parent $ServerExe) `
+    -PassThru -NoNewWindow -Wait
+if ($process.ExitCode -ne 0) {
+    Write-Host "Server exited with code $($process.ExitCode)"
+}
+
+$stdout = $utf8.GetString([System.IO.File]::ReadAllBytes($stdoutFile))
+$stderr = $utf8.GetString([System.IO.File]::ReadAllBytes($stderrFile))
+
+$failures = 0
+$stdoutLines = @($stdout -split "`r?`n" | Where-Object { $_ -ne '' })
+
+Write-Host "stdout lines: $($stdoutLines.Count)"
+$responses = @{}
+foreach ($line in $stdoutLines) {
+    try {
+        $message = $line | ConvertFrom-Json
+    } catch {
+        Write-Host "NOT JSON on stdout: $line"
+        $failures++
+        continue
+    }
+    if ($null -eq $message.jsonrpc) {
+        Write-Host "stdout line is not a JSON-RPC message: $line"
+        $failures++
+        continue
+    }
+    if ($null -ne $message.id) { $responses[[string]$message.id] = $message }
+}
+
+foreach ($id in '1', '2', '3') {
+    if (-not $responses.ContainsKey($id)) {
+        Write-Host "missing response for id $id"
+        $failures++
+    }
+}
+if ($stdoutLines.Count -ne 3) {
+    Write-Host "expected exactly 3 responses on stdout, got $($stdoutLines.Count)"
+    $failures++
+}
+
+if ($stdout -match '\[(INFO|WARN|ERROR|DEBUG)\s*\]') {
+    Write-Host 'log lines found on stdout'
+    $failures++
+}
+if ($stderr.Trim().Length -eq 0) {
+    Write-Host 'expected log lines on stderr, found none'
+    $failures++
+}
+
+if ($responses.ContainsKey('3')) {
+    $echoText = $responses['3'].result.content[0].text
+    if ($echoText -eq "Echo: $probe") {
+        Write-Host "observation: non-ASCII input survived the stdio round trip"
+    } else {
+        Write-Host "observation: non-ASCII input was altered on the stdio round trip: $echoText"
+    }
+}
+
+Write-Host "stderr: $($stderr.Length) characters (see $stderrFile)"
+if ($failures -gt 0) {
+    Write-Host "$failures check(s) failed"
+    exit 1
+}
+Write-Host 'stdio smoke run passed'
+exit 0

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Builds and runs the DUnitX test project.
+
+.DESCRIPTION
+    Compiles tests\MCPServer.Tests.dpr with build-tests.bat and runs the
+    resulting executable. Results are written as NUnit XML to tests\results.
+
+.PARAMETER Configuration
+    Debug (default) or Release.
+
+.PARAMETER Platform
+    Win64 (default) or Win32.
+
+.PARAMETER Record
+    Re-record the golden files from the current code instead of comparing.
+    Only do this on a commit whose behaviour you want to pin; review the diff.
+
+.PARAMETER Filter
+    Optional DUnitX run filter with fully qualified test names, comma separated,
+    for example "MCPServer.Tests.Golden.Legacy.TLegacyGoldenTests.Ping".
+
+.PARAMETER NoBuild
+    Skip the compile step and run the existing executable.
+
+.EXAMPLE
+    .\scripts\run-tests.ps1
+    .\scripts\run-tests.ps1 -Platform Win32
+    .\scripts\run-tests.ps1 -Record
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Debug',
+
+    [ValidateSet('Win32', 'Win64')]
+    [string]$Platform = 'Win64',
+
+    [switch]$Record,
+
+    [string]$Filter,
+
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$testExe = Join-Path $repoRoot "tests\$Platform\$Configuration\MCPServer.Tests.exe"
+$resultsDir = Join-Path $repoRoot 'tests\results'
+$xmlFile = Join-Path $resultsDir "dunitx-$Platform-$Configuration.xml"
+
+if (-not $NoBuild) {
+    Write-Host "Building tests ($Configuration $Platform)..."
+    & cmd.exe /c "cd /d `"$repoRoot`" && .\build-tests.bat $Configuration $Platform"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Test build failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+}
+
+if (-not (Test-Path $testExe)) {
+    Write-Error "Test executable not found: $testExe"
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+if ($Record) {
+    $env:MCP_GOLDEN_RECORD = '1'
+    Write-Host 'Golden record mode: expectations will be rewritten.'
+} else {
+    Remove-Item Env:\MCP_GOLDEN_RECORD -ErrorAction SilentlyContinue
+}
+
+$arguments = @('-exit:continue', "-xml:$xmlFile")
+if ($Filter) {
+    $arguments += "-run:$Filter"
+}
+
+Write-Host "Running $testExe $($arguments -join ' ')"
+& $testExe @arguments
+$exitCode = $LASTEXITCODE
+
+Remove-Item Env:\MCP_GOLDEN_RECORD -ErrorAction SilentlyContinue
+
+Write-Host "Results: $xmlFile"
+exit $exitCode

--- a/src/Core/MCPServer.Logger.pas
+++ b/src/Core/MCPServer.Logger.pas
@@ -26,13 +26,16 @@ type
     FMinLogLevel: TLogLevel;
     FOnLogMessage: TLogMessageProc;
     FUseStdErr: Boolean;
-    
+    FStdoutReserved: Boolean;
+    FStdoutWarningIssued: Boolean;
+
     class procedure SetLogToConsole(const Value: Boolean); static;
     class procedure SetLogToFile(const Value: Boolean); static;
     class procedure SetLogFileName(const Value: string); static;
     class procedure SetMinLogLevel(const Value: TLogLevel); static;
     class procedure SetOnLogMessage(const Value: TLogMessageProc); static;
     class procedure SetUseStdErr(const Value: Boolean); static;
+    class procedure SetStdoutReserved(const Value: Boolean); static;
 
     class function GetLogToConsole: Boolean; static;
     class function GetLogToFile: Boolean; static;
@@ -40,7 +43,8 @@ type
     class function GetMinLogLevel: TLogLevel; static;
     class function GetOnLogMessage: TLogMessageProc; static;
     class function GetUseStdErr: Boolean; static;
-    
+    class function GetStdoutReserved: Boolean; static;
+
     constructor CreateInstance;
     procedure DoWriteLog(const Level: TLogLevel; const Message: string);
     procedure EnsureLogFile;
@@ -71,6 +75,11 @@ type
     class property MinLogLevel: TLogLevel read GetMinLogLevel write SetMinLogLevel;
     class property OnLogMessage: TLogMessageProc read GetOnLogMessage write SetOnLogMessage;
     class property UseStdErr: Boolean read GetUseStdErr write SetUseStdErr;
+    /// True while a stdio transport owns stdout. Console logging then always
+    /// goes to stderr, and setting UseStdErr to False is refused with a
+    /// one-time warning, because anything on stdout that is not an MCP
+    /// message corrupts the channel. Set by TMCPStdioTransport.Create.
+    class property StdoutReserved: Boolean read GetStdoutReserved write SetStdoutReserved;
   end;
 
 implementation
@@ -152,29 +161,33 @@ procedure TLogger.DoWriteLog(const Level: TLogLevel; const Message: string);
 var
   Timestamp: string;
   LogLine: string;
+  ToStdErr: Boolean;
   {$IFDEF MSWINDOWS}
   ConsoleHandle: THandle;
   {$ENDIF}
 begin
   if Level < FMinLogLevel then
     Exit;
-    
+
   Timestamp := FormatDateTime('yyyy-mm-dd hh:nn:ss.zzz', Now);
   LogLine := Format('[%s] [%-5s] %s', [Timestamp, LOG_LEVEL_NAMES[Level], Message]);
-  
+
   FLock.Enter;
   try
     if FLogToConsole then
     begin
+      // Never touch stdout while a stdio transport owns it.
+      ToStdErr := FUseStdErr or FStdoutReserved;
+
       {$IFDEF MSWINDOWS}
-      if FUseStdErr then
+      if ToStdErr then
         ConsoleHandle := GetStdHandle(STD_ERROR_HANDLE)
       else
         ConsoleHandle := GetStdHandle(STD_OUTPUT_HANDLE);
       SetConsoleTextAttribute(ConsoleHandle, LOG_LEVEL_COLORS[Level]);
       {$ENDIF}
 
-      if FUseStdErr then
+      if ToStdErr then
         WriteLn(ErrOutput, LogLine)
       else
         WriteLn(LogLine);
@@ -331,10 +344,50 @@ end;
 class procedure TLogger.SetUseStdErr(const Value: Boolean);
 var
   lInstance: TLogger;
+  WarnOnce: Boolean;
 begin
   lInstance := Instance;
-  if Assigned(lInstance) then
+  if not Assigned(lInstance) then
+    Exit;
+
+  if Value or not lInstance.FStdoutReserved then
+  begin
     lInstance.FUseStdErr := Value;
+    Exit;
+  end;
+
+  // Refused: stdout belongs to the stdio transport. Warn once, on stderr.
+  FLock.Enter;
+  try
+    WarnOnce := not lInstance.FStdoutWarningIssued;
+    lInstance.FStdoutWarningIssued := True;
+  finally
+    FLock.Leave;
+  end;
+
+  if WarnOnce then
+    lInstance.DoWriteLog(TLogLevel.Warning,
+      'TLogger.UseStdErr := False ignored: stdout is reserved for MCP messages while the stdio transport runs');
+end;
+
+class function TLogger.GetStdoutReserved: Boolean;
+begin
+  Result := Instance.FStdoutReserved;
+end;
+
+class procedure TLogger.SetStdoutReserved(const Value: Boolean);
+var
+  lInstance: TLogger;
+begin
+  lInstance := Instance;
+  if not Assigned(lInstance) then
+    Exit;
+
+  lInstance.FStdoutReserved := Value;
+  if Value then
+    lInstance.FUseStdErr := True
+  else
+    lInstance.FStdoutWarningIssued := False;
 end;
 
 end.

--- a/src/Core/MCPServer.Registration.pas
+++ b/src/Core/MCPServer.Registration.pas
@@ -33,6 +33,9 @@ type
   public
     class procedure RegisterTool(const Name: string; Factory: TMCPToolFactory);
     class procedure RegisterResource(const URI: string; Factory: TMCPResourceFactory);
+    /// Removes a registration again (no-op for an unknown URI). Like
+    /// registration, only meaningful before the managers are created.
+    class procedure UnregisterResource(const URI: string);
 
     class function CreateTool(const Name: string): IMCPTool;
     class function CreateResource(const URI: string): IMCPResource;
@@ -70,6 +73,15 @@ class procedure TMCPRegistry.RegisterResource(const URI: string; Factory: TMCPRe
 begin
   FResources.AddOrSetValue(URI, Factory);
   TLogger.Info('Registered resource: ' + URI);
+end;
+
+class procedure TMCPRegistry.UnregisterResource(const URI: string);
+begin
+  if FResources.ContainsKey(URI) then
+  begin
+    FResources.Remove(URI);
+    TLogger.Info('Unregistered resource: ' + URI);
+  end;
 end;
 
 class function TMCPRegistry.CreateTool(const Name: string): IMCPTool;

--- a/src/Core/MCPServer.Registration.pas
+++ b/src/Core/MCPServer.Registration.pas
@@ -11,26 +11,35 @@ uses
 
 type
   TMCPToolClass = class of TMCPToolBase;
-  
+
   TMCPToolFactory = reference to function: IMCPTool;
   TMCPResourceFactory = reference to function: IMCPResource;
 
+  /// Process-wide registry of tool and resource factories.
+  ///
+  /// The dictionaries exist from the class constructor on, so registration
+  /// from unit initialization sections needs no lazy checks. Registration is
+  /// not synchronised: register everything before the managers are created.
+  /// TMCPToolsManager.Create and TMCPResourcesManager.Create read the
+  /// registry once, so in practice that means before TMCPIdHTTPServer.Start
+  /// or TMCPStdioTransport.Run.
   TMCPRegistry = class
   private
     class var FTools: TDictionary<string, TMCPToolFactory>;
     class var FResources: TDictionary<string, TMCPResourceFactory>;
-    
-    class procedure EnsureInitialized;
+
+    class constructor Create;
+    class destructor Destroy;
   public
     class procedure RegisterTool(const Name: string; Factory: TMCPToolFactory);
     class procedure RegisterResource(const URI: string; Factory: TMCPResourceFactory);
-    
+
     class function CreateTool(const Name: string): IMCPTool;
     class function CreateResource(const URI: string): IMCPResource;
-    
+
     class function GetToolNames: TArray<string>;
     class function GetResourceURIs: TArray<string>;
-    
+
     class function HasTool(const Name: string): Boolean;
     class function HasResource(const URI: string): Boolean;
   end;
@@ -39,27 +48,26 @@ implementation
 
 { TMCPRegistry }
 
-class procedure TMCPRegistry.EnsureInitialized;
+class constructor TMCPRegistry.Create;
 begin
-  if not Assigned(FTools) then
-    FTools := TDictionary<string, TMCPToolFactory>.Create;
+  FTools := TDictionary<string, TMCPToolFactory>.Create;
+  FResources := TDictionary<string, TMCPResourceFactory>.Create;
+end;
 
-  if not Assigned(FResources) then
-    FResources := TDictionary<string, TMCPResourceFactory>.Create;
+class destructor TMCPRegistry.Destroy;
+begin
+  FreeAndNil(FTools);
+  FreeAndNil(FResources);
 end;
 
 class procedure TMCPRegistry.RegisterTool(const Name: string; Factory: TMCPToolFactory);
 begin
-  EnsureInitialized;
-
   FTools.AddOrSetValue(Name, Factory);
   TLogger.Info('Registered tool: ' + Name);
 end;
 
 class procedure TMCPRegistry.RegisterResource(const URI: string; Factory: TMCPResourceFactory);
 begin
-  EnsureInitialized;
-
   FResources.AddOrSetValue(URI, Factory);
   TLogger.Info('Registered resource: ' + URI);
 end;
@@ -68,8 +76,6 @@ class function TMCPRegistry.CreateTool(const Name: string): IMCPTool;
 var
   Factory: TMCPToolFactory;
 begin
-  EnsureInitialized;
-
   if FTools.TryGetValue(Name, Factory) then
     Result := Factory()
   else
@@ -80,8 +86,6 @@ class function TMCPRegistry.CreateResource(const URI: string): IMCPResource;
 var
   Factory: TMCPResourceFactory;
 begin
-  EnsureInitialized;
-
   if FResources.TryGetValue(URI, Factory) then
     Result := Factory()
   else
@@ -90,38 +94,22 @@ end;
 
 class function TMCPRegistry.GetToolNames: TArray<string>;
 begin
-  EnsureInitialized;
-
   Result := FTools.Keys.ToArray;
 end;
 
 class function TMCPRegistry.GetResourceURIs: TArray<string>;
 begin
-  EnsureInitialized;
-
   Result := FResources.Keys.ToArray;
 end;
 
 class function TMCPRegistry.HasTool(const Name: string): Boolean;
 begin
-  EnsureInitialized;
-
   Result := FTools.ContainsKey(Name);
 end;
 
 class function TMCPRegistry.HasResource(const URI: string): Boolean;
 begin
-  EnsureInitialized;
-
   Result := FResources.ContainsKey(URI);
 end;
-
-initialization
-
-finalization
-  if Assigned(TMCPRegistry.FTools) then
-    TMCPRegistry.FTools.Free;
-  if Assigned(TMCPRegistry.FResources) then
-    TMCPRegistry.FResources.Free;
 
 end.

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -131,11 +131,15 @@ var
   URI: string;
   URIValue: TJSONValue;
 begin
-  URIValue := Params.GetValue('uri');
-  if Assigned(URIValue) then
-    URI := URIValue.Value
-  else
-    URI := '';
+  // Params is nil when the request carries no params object; treat that
+  // like a missing uri instead of dereferencing nil.
+  URI := '';
+  if Assigned(Params) then
+  begin
+    URIValue := Params.GetValue('uri');
+    if Assigned(URIValue) then
+      URI := URIValue.Value;
+  end;
 
   TLogger.Info('MCP ReadResource called for URI: ' + URI);
 

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -230,6 +230,7 @@ end;
 function TMCPToolsManager.CallTool(const Params: System.JSON.TJSONObject): TValue;
 var
   Arguments: TJSONObject;
+  EmptyArguments: TJSONObject;
   ResultValue: TValue;
   Tool: IMCPTool;
   ToolName: string;
@@ -242,11 +243,21 @@ begin
 
   TLogger.Info('MCP CallTool called for tool: ' + ToolName);
 
-  if FTools.TryGetValue(ToolName, Tool) then
-    resultValue := ExecuteTool(Tool, Arguments)
+  if not FTools.TryGetValue(ToolName, Tool) then
+    ResultValue := TValue.From('Error: Tool not found: ' + ToolName)
+  else if Assigned(Arguments) then
+    ResultValue := ExecuteTool(Tool, Arguments)
   else
-    ResultValue := TValue.From('Error: Tool not found: ' + ToolName);
-    
+  begin
+    // "arguments" is optional on the wire; a tool always receives an object.
+    EmptyArguments := TJSONObject.Create;
+    try
+      ResultValue := ExecuteTool(Tool, EmptyArguments);
+    finally
+      EmptyArguments.Free;
+    end;
+  end;
+
   Result := TValue.From<TJSONObject>(BuildToolCallResponse(ResultValue));
 end;
 

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -27,7 +27,7 @@ type
 const
   // The JSON-RPC error codes are defined in MCPServer.Types. These aliases
   // keep consumer code that references MCPServer.JsonRpcProcessor.JSONRPC_*
-  // compiling for one release.
+  // compiling.
   JSONRPC_PARSE_ERROR = MCPServer.Types.JSONRPC_PARSE_ERROR;
   JSONRPC_INVALID_REQUEST = MCPServer.Types.JSONRPC_INVALID_REQUEST;
   JSONRPC_METHOD_NOT_FOUND = MCPServer.Types.JSONRPC_METHOD_NOT_FOUND;

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -25,11 +25,14 @@ type
   end;
 
 const
-  JSONRPC_PARSE_ERROR = -32700;
-  JSONRPC_INVALID_REQUEST = -32600;
-  JSONRPC_METHOD_NOT_FOUND = -32601;
-  JSONRPC_INVALID_PARAMS = -32602;
-  JSONRPC_INTERNAL_ERROR = -32603;
+  // The JSON-RPC error codes are defined in MCPServer.Types. These aliases
+  // keep consumer code that references MCPServer.JsonRpcProcessor.JSONRPC_*
+  // compiling for one release.
+  JSONRPC_PARSE_ERROR = MCPServer.Types.JSONRPC_PARSE_ERROR;
+  JSONRPC_INVALID_REQUEST = MCPServer.Types.JSONRPC_INVALID_REQUEST;
+  JSONRPC_METHOD_NOT_FOUND = MCPServer.Types.JSONRPC_METHOD_NOT_FOUND;
+  JSONRPC_INVALID_PARAMS = MCPServer.Types.JSONRPC_INVALID_PARAMS;
+  JSONRPC_INTERNAL_ERROR = MCPServer.Types.JSONRPC_INTERNAL_ERROR;
 
 implementation
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -23,6 +23,7 @@ type
     class function ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
     class function ConvertValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
+    class function TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;
     class function CreateInstanceFromType(const RttiType: TRttiType): TObject;
 
     // Array deserialization helpers
@@ -364,7 +365,7 @@ begin
         begin
           Result := TJSONValue(Obj).Clone as TJSONValue;
         end
-        else
+        else if not TrySerializeList(Obj, Result) then
         begin
           ChildJson := TJSONObject.Create;
           Serialize(Obj, ChildJson);
@@ -372,6 +373,54 @@ begin
         end;
       end;
   end;
+end;
+
+// Serialises TList<T> and TObjectList<T> (anything with an integer-indexed
+// Items property and a Count) as a JSON array of their elements. Without
+// this a list came out as an object with count and capacity members.
+class function TMCPSerializer.TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;
+var
+  ListType: TRttiType;
+  CountProp: TRttiProperty;
+  ItemsProp: TRttiIndexedProperty;
+  IndexParams: TArray<TRttiParameter>;
+  Items: TJSONArray;
+  Item: TJSONValue;
+  Count: Integer;
+  I: Integer;
+begin
+  Result := False;
+  Json := nil;
+
+  ListType := FContext.GetType(Obj.ClassType);
+  CountProp := ListType.GetProperty('Count');
+  ItemsProp := ListType.GetIndexedProperty('Items');
+  if not Assigned(CountProp) or not Assigned(ItemsProp) or not ItemsProp.IsReadable
+    or not Assigned(ItemsProp.ReadMethod) then
+    Exit;
+
+  // Only integer indexes: TDictionary<TKey, TValue> also has Count and Items.
+  IndexParams := ItemsProp.ReadMethod.GetParameters;
+  if (Length(IndexParams) <> 1) or not (IndexParams[0].ParamType.TypeKind in [tkInteger, tkInt64]) then
+    Exit;
+
+  {$WARN UNSAFE_CAST OFF}
+  Count := Integer(CountProp.GetValue(Obj).AsInt64);
+  {$WARN UNSAFE_CAST ON}
+  Items := TJSONArray.Create;
+  for I := 0 to Count - 1 do
+  begin
+    {$WARN UNSAFE_CAST OFF}
+    Item := ConvertValueToJson(ItemsProp.GetValue(Obj, [I]), ItemsProp.PropertyType);
+    {$WARN UNSAFE_CAST ON}
+    if Assigned(Item) then
+      Items.AddElement(Item)
+    else
+      Items.AddElement(TJSONNull.Create);
+  end;
+
+  Json := Items;
+  Result := True;
 end;
 
 class function TMCPSerializer.DeserializeArray(RttiType: TRttiType; const JsonArray: TJSONArray): TValue;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -8,7 +8,62 @@ uses
   System.Rtti;
 
 const
+  /// Protocol version answered by the legacy initialize handshake today.
+  /// Kept under its historic name for library consumers.
   MCP_PROTOCOL_VERSION = '2025-06-18';
+
+  // Protocol revisions
+  MCP_PROTOCOL_VERSION_2025_03_26 = '2025-03-26';
+  MCP_PROTOCOL_VERSION_2025_06_18 = '2025-06-18';
+  MCP_PROTOCOL_VERSION_2025_11_25 = '2025-11-25';
+  MCP_PROTOCOL_VERSION_2026_07_28 = '2026-07-28';
+
+  /// Newest revision this server targets (stateless, per-request _meta).
+  MCP_LATEST_PROTOCOL_VERSION = MCP_PROTOCOL_VERSION_2026_07_28;
+  /// Newest revision served through the initialize handshake.
+  MCP_LATEST_LEGACY_PROTOCOL_VERSION = MCP_PROTOCOL_VERSION_2025_11_25;
+
+  MCP_LEGACY_PROTOCOL_VERSIONS: array[0..1] of string = (
+    MCP_PROTOCOL_VERSION_2025_06_18,
+    MCP_PROTOCOL_VERSION_2025_11_25
+  );
+  MCP_MODERN_PROTOCOL_VERSIONS: array[0..0] of string = (
+    MCP_PROTOCOL_VERSION_2026_07_28
+  );
+
+  // JSON-RPC 2.0 error codes
+  JSONRPC_PARSE_ERROR = -32700;
+  JSONRPC_INVALID_REQUEST = -32600;
+  JSONRPC_METHOD_NOT_FOUND = -32601;
+  JSONRPC_INVALID_PARAMS = -32602;
+  JSONRPC_INTERNAL_ERROR = -32603;
+
+  // MCP error codes reserved by the specification (basic/index.mdx, "Error Codes")
+  MCP_ERROR_HEADER_MISMATCH = -32020;
+  MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+  MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION = -32022;
+  /// Resource not found in 2025-11-25 and earlier; 2026-07-28 uses JSONRPC_INVALID_PARAMS.
+  MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY = -32002;
+
+  // Reserved _meta keys (2026-07-28)
+  MCP_META_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
+  MCP_META_CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
+  MCP_META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+  MCP_META_LOG_LEVEL = 'io.modelcontextprotocol/logLevel';
+  MCP_META_SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
+  MCP_META_SUBSCRIPTION_ID = 'io.modelcontextprotocol/subscriptionId';
+  MCP_META_PROGRESS_TOKEN = 'progressToken';
+
+  /// Methods whose complete results must carry ttlMs and cacheScope
+  /// (server/utilities/caching.mdx, "Cacheable Results").
+  MCP_CACHEABLE_METHODS: array[0..5] of string = (
+    'server/discover',
+    'tools/list',
+    'prompts/list',
+    'resources/list',
+    'resources/templates/list',
+    'resources/read'
+  );
 
 type
   OptionalAttribute = class(TCustomAttribute)

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -8,8 +8,8 @@ uses
   System.Rtti;
 
 const
-  /// Protocol version answered by the legacy initialize handshake today.
-  /// Kept under its historic name for library consumers.
+  /// Protocol version answered by the initialize handshake. Kept under its
+  /// historic name for library consumers.
   MCP_PROTOCOL_VERSION = '2025-06-18';
 
   // Protocol revisions

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -74,6 +74,9 @@ uses
   System.Math,
   MCPServer.Registration;
 
+const
+  MAX_RECENT_LOG_ENTRIES = 100;
+
 { TLogEntries }
 
 constructor TLogEntries.Create;
@@ -208,11 +211,14 @@ begin
   // Add access log entry
   TLogBuffer.Instance.AddLog('INFO', 'Resource accessed: logs://recent', 'ACCESS');
   
-  Logs := TLogBuffer.Instance.GetLogs(100);
+  Logs := TLogBuffer.Instance.GetLogs(MAX_RECENT_LOG_ENTRIES);
   try
-    Result.Entries.AddRange(Logs.ToArray);
+    Result.Entries.AddRange(Logs);
     Result.TotalCount := Logs.Count;
     Result.FilteredCount := Logs.Count;
+    // GetLogs returns copies in an owning list; Result.Entries owns them
+    // from here on, otherwise they would be freed twice.
+    Logs.OwnsObjects := False;
   finally
     Logs.Free;
   end;

--- a/src/Resources/MCPServer.Resource.Server.pas
+++ b/src/Resources/MCPServer.Resource.Server.pas
@@ -39,9 +39,19 @@ type
     function GetResourceData: TServerStatus; override;
   public
     constructor Create; override;
+    /// Resets the start time and the counters. Runs from the unit
+    /// initialization and again from MCPServer.dpr before a transport starts.
     class procedure Initialize;
+    /// Registers the resource as server://<Prefix>status. The registry is read
+    /// once, when TMCPResourcesManager is created, so call this before the
+    /// managers are built (before TMCPIdHTTPServer.Start or
+    /// TMCPStdioTransport.Run); a later call registers a URI nobody serves.
     class procedure SetNamePrefix(const Prefix: string);
+    /// Registers server://status (or the prefixed URI). MCPServer.dpr does not
+    /// call this; the resource is opt-in for library consumers.
     class procedure RegisterServerStatusResource;
+    // The counters are updated from every Indy connection thread, so they
+    // use atomic operations.
     class procedure IncrementRequestCount;
     class procedure ConnectionOpened;
     class procedure ConnectionClosed;
@@ -94,18 +104,25 @@ end;
 
 class procedure TServerStatusResource.IncrementRequestCount;
 begin
-  Inc(FRequestCount);
+  AtomicIncrement(FRequestCount);
 end;
 
 class procedure TServerStatusResource.ConnectionOpened;
 begin
-  Inc(FActiveConnections);
+  AtomicIncrement(FActiveConnections);
 end;
 
 class procedure TServerStatusResource.ConnectionClosed;
 begin
-  if FActiveConnections > 0 then
-    Dec(FActiveConnections);
+  // Never below zero, and without a moment in which a reader can see -1.
+  var Current := AtomicCmpExchange(FActiveConnections, 0, 0);
+  while Current > 0 do
+  begin
+    var Previous := AtomicCmpExchange(FActiveConnections, Current - 1, Current);
+    if Previous = Current then
+      Exit;
+    Current := Previous;
+  end;
 end;
 
 constructor TServerStatusResource.Create;
@@ -136,8 +153,8 @@ begin
   Result.StartTime := FServerStartTime;
   Result.CurrentTime := Now;
   Result.Uptime := SecondsBetween(Now, FServerStartTime);
-  Result.RequestCount := FRequestCount;
-  Result.ActiveConnections := FActiveConnections;
+  Result.RequestCount := AtomicCmpExchange(FRequestCount, 0, 0);
+  Result.ActiveConnections := AtomicCmpExchange(FActiveConnections, 0, 0);
   
   {$IFDEF MSWINDOWS}
   ProcessMemoryCounters.cb := SizeOf(ProcessMemoryCounters);

--- a/src/Resources/MCPServer.Resource.Server.pas
+++ b/src/Resources/MCPServer.Resource.Server.pas
@@ -35,6 +35,7 @@ type
     class var FRequestCount: Int64;
     class var FActiveConnections: Integer;
     class var FNamePrefix: string;
+    class function StatusURI: string;
   protected
     function GetResourceData: TServerStatus; override;
   public
@@ -42,13 +43,13 @@ type
     /// Resets the start time and the counters. Runs from the unit
     /// initialization and again from MCPServer.dpr before a transport starts.
     class procedure Initialize;
-    /// Registers the resource as server://<Prefix>status. The registry is read
-    /// once, when TMCPResourcesManager is created, so call this before the
-    /// managers are built (before TMCPIdHTTPServer.Start or
-    /// TMCPStdioTransport.Run); a later call registers a URI nobody serves.
+    /// Re-registers the resource as server://<Prefix>status and removes the
+    /// URI registered before. The registry is read once, when
+    /// TMCPResourcesManager is created, so call this before the managers are
+    /// built (before TMCPIdHTTPServer.Start or TMCPStdioTransport.Run).
     class procedure SetNamePrefix(const Prefix: string);
-    /// Registers server://status (or the prefixed URI). MCPServer.dpr does not
-    /// call this; the resource is opt-in for library consumers.
+    /// Registers server://status (or the prefixed URI). The unit
+    /// initialization does this once, so the resource is available by default.
     class procedure RegisterServerStatusResource;
     // The counters are updated from every Indy connection thread, so they
     // use atomic operations.
@@ -79,22 +80,21 @@ begin
   FNamePrefix := '';
 end;
 
+class function TServerStatusResource.StatusURI: string;
+begin
+  Result := 'server://' + FNamePrefix + 'status';
+end;
+
 class procedure TServerStatusResource.SetNamePrefix(const Prefix: string);
 begin
+  TMCPRegistry.UnregisterResource(StatusURI);
   FNamePrefix := Prefix;
   RegisterServerStatusResource;
 end;
 
 class procedure TServerStatusResource.RegisterServerStatusResource;
-var
-  URI: string;
 begin
-  if FNamePrefix <> '' then
-    URI := 'server://' + FNamePrefix + 'status'
-  else
-    URI := 'server://status';
-
-  TMCPRegistry.RegisterResource(URI,
+  TMCPRegistry.RegisterResource(StatusURI,
     function: IMCPResource
     begin
       Result := TServerStatusResource.Create;
@@ -128,16 +128,8 @@ end;
 constructor TServerStatusResource.Create;
 begin
   inherited;
-  if FNamePrefix <> '' then
-  begin
-    FURI := 'server://' + FNamePrefix + 'status';
-    FName := FNamePrefix + 'server_status';
-  end
-  else
-  begin
-    FURI := 'server://status';
-    FName := 'server_status';
-  end;
+  FURI := StatusURI;
+  FName := FNamePrefix + 'server_status';
   FDescription := 'Current server status and health information';
   FMimeType := 'application/json';
 end;
@@ -170,5 +162,6 @@ end;
 
 initialization
   TServerStatusResource.Initialize;
+  TServerStatusResource.RegisterServerStatusResource;
 
 end.

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -91,13 +91,6 @@ const
   // CORS Max Age (24 hours in seconds)
   CORS_MAX_AGE = 86400;
 
-  // JSON-RPC 2.0 Error Codes
-  JSONRPC_PARSE_ERROR = -32700;
-  JSONRPC_INVALID_REQUEST = -32600;
-  JSONRPC_METHOD_NOT_FOUND = -32601;
-  JSONRPC_INVALID_PARAMS = -32602;
-  JSONRPC_INTERNAL_ERROR = -32603;
-
   // SSE Message Format
   SSE_EVENT_PREFIX = 'event: ';
   SSE_DATA_PREFIX = 'data: ';

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -408,8 +408,8 @@ end;
 
 function TMCPIdHTTPServer.GetNextEventID: string;
 begin
-  Inc(FEventIDCounter);
-  Result := IntToStr(FEventIDCounter);
+  // Called from Indy connection threads.
+  Result := IntToStr(AtomicIncrement(FEventIDCounter));
 end;
 
 function TMCPIdHTTPServer.AcceptsSSE(const AcceptHeader: string): Boolean;

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -32,6 +32,11 @@ begin
   FManagerRegistry := ManagerRegistry;
   FCoreManager := CoreManager;
   FJsonRpcProcessor := TMCPJsonRpcProcessor.Create(ManagerRegistry);
+
+  // stdout carries MCP messages only; every log line must go to stderr,
+  // also for library consumers that never set UseStdErr themselves.
+  TLogger.UseStdErr := True;
+  TLogger.StdoutReserved := True;
 end;
 
 destructor TMCPStdioTransport.Destroy;

--- a/tests/MCPServer.Tests.Constants.pas
+++ b/tests/MCPServer.Tests.Constants.pas
@@ -1,0 +1,98 @@
+unit MCPServer.Tests.Constants;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  /// Guards the protocol constants in MCPServer.Types and the aliases that
+  /// keep MCPServer.JsonRpcProcessor.JSONRPC_* compiling for consumers.
+  [TestFixture]
+  TProtocolConstantsTests = class
+  public
+    [Test] procedure JsonRpcErrorCodes_HaveSpecValues;
+    [Test] procedure ProcessorAliases_MatchTypes;
+    [Test] procedure McpErrorCodes_HaveSpecValues;
+    [Test] procedure ProtocolVersions_AreConsistent;
+    [Test] procedure MetaKeys_UseReservedPrefix;
+    [Test] procedure CacheableMethods_MatchSpec;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Types,
+  MCPServer.JsonRpcProcessor;
+
+{ TProtocolConstantsTests }
+
+procedure TProtocolConstantsTests.JsonRpcErrorCodes_HaveSpecValues;
+begin
+  Assert.AreEqual(-32700, MCPServer.Types.JSONRPC_PARSE_ERROR);
+  Assert.AreEqual(-32600, MCPServer.Types.JSONRPC_INVALID_REQUEST);
+  Assert.AreEqual(-32601, MCPServer.Types.JSONRPC_METHOD_NOT_FOUND);
+  Assert.AreEqual(-32602, MCPServer.Types.JSONRPC_INVALID_PARAMS);
+  Assert.AreEqual(-32603, MCPServer.Types.JSONRPC_INTERNAL_ERROR);
+end;
+
+procedure TProtocolConstantsTests.ProcessorAliases_MatchTypes;
+begin
+  Assert.AreEqual(MCPServer.Types.JSONRPC_PARSE_ERROR, MCPServer.JsonRpcProcessor.JSONRPC_PARSE_ERROR);
+  Assert.AreEqual(MCPServer.Types.JSONRPC_INVALID_REQUEST, MCPServer.JsonRpcProcessor.JSONRPC_INVALID_REQUEST);
+  Assert.AreEqual(MCPServer.Types.JSONRPC_METHOD_NOT_FOUND, MCPServer.JsonRpcProcessor.JSONRPC_METHOD_NOT_FOUND);
+  Assert.AreEqual(MCPServer.Types.JSONRPC_INVALID_PARAMS, MCPServer.JsonRpcProcessor.JSONRPC_INVALID_PARAMS);
+  Assert.AreEqual(MCPServer.Types.JSONRPC_INTERNAL_ERROR, MCPServer.JsonRpcProcessor.JSONRPC_INTERNAL_ERROR);
+end;
+
+procedure TProtocolConstantsTests.McpErrorCodes_HaveSpecValues;
+begin
+  Assert.AreEqual(-32020, MCP_ERROR_HEADER_MISMATCH);
+  Assert.AreEqual(-32021, MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY);
+  Assert.AreEqual(-32022, MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION);
+  Assert.AreEqual(-32002, MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY);
+end;
+
+procedure TProtocolConstantsTests.ProtocolVersions_AreConsistent;
+begin
+  Assert.AreEqual('2025-06-18', MCP_PROTOCOL_VERSION, 'legacy default must not change without the allow-list');
+  Assert.AreEqual('2026-07-28', MCP_LATEST_PROTOCOL_VERSION);
+  Assert.AreEqual('2025-11-25', MCP_LATEST_LEGACY_PROTOCOL_VERSION);
+
+  Assert.AreEqual(2, Length(MCP_LEGACY_PROTOCOL_VERSIONS));
+  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_06_18, MCP_LEGACY_PROTOCOL_VERSIONS[0]);
+  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_11_25, MCP_LEGACY_PROTOCOL_VERSIONS[1]);
+
+  Assert.AreEqual(1, Length(MCP_MODERN_PROTOCOL_VERSIONS));
+  Assert.AreEqual(MCP_LATEST_PROTOCOL_VERSION, MCP_MODERN_PROTOCOL_VERSIONS[0]);
+end;
+
+procedure TProtocolConstantsTests.MetaKeys_UseReservedPrefix;
+const
+  RESERVED_PREFIX = 'io.modelcontextprotocol/';
+begin
+  Assert.IsTrue(MCP_META_PROTOCOL_VERSION.StartsWith(RESERVED_PREFIX));
+  Assert.IsTrue(MCP_META_CLIENT_CAPABILITIES.StartsWith(RESERVED_PREFIX));
+  Assert.IsTrue(MCP_META_CLIENT_INFO.StartsWith(RESERVED_PREFIX));
+  Assert.IsTrue(MCP_META_LOG_LEVEL.StartsWith(RESERVED_PREFIX));
+  Assert.IsTrue(MCP_META_SERVER_INFO.StartsWith(RESERVED_PREFIX));
+  Assert.IsTrue(MCP_META_SUBSCRIPTION_ID.StartsWith(RESERVED_PREFIX));
+  Assert.AreEqual('progressToken', MCP_META_PROGRESS_TOKEN);
+end;
+
+procedure TProtocolConstantsTests.CacheableMethods_MatchSpec;
+begin
+  Assert.AreEqual(6, Length(MCP_CACHEABLE_METHODS));
+  Assert.AreEqual('server/discover', MCP_CACHEABLE_METHODS[0]);
+  Assert.AreEqual('tools/list', MCP_CACHEABLE_METHODS[1]);
+  Assert.AreEqual('prompts/list', MCP_CACHEABLE_METHODS[2]);
+  Assert.AreEqual('resources/list', MCP_CACHEABLE_METHODS[3]);
+  Assert.AreEqual('resources/templates/list', MCP_CACHEABLE_METHODS[4]);
+  Assert.AreEqual('resources/read', MCP_CACHEABLE_METHODS[5]);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TProtocolConstantsTests);
+
+end.

--- a/tests/MCPServer.Tests.Constants.pas
+++ b/tests/MCPServer.Tests.Constants.pas
@@ -56,7 +56,7 @@ end;
 
 procedure TProtocolConstantsTests.ProtocolVersions_AreConsistent;
 begin
-  Assert.AreEqual('2025-06-18', MCP_PROTOCOL_VERSION, 'legacy default must not change without the allow-list');
+  Assert.AreEqual('2025-06-18', MCP_PROTOCOL_VERSION, 'the initialize handshake answers this revision');
   Assert.AreEqual('2026-07-28', MCP_LATEST_PROTOCOL_VERSION);
   Assert.AreEqual('2025-11-25', MCP_LATEST_LEGACY_PROTOCOL_VERSION);
 

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -1,0 +1,306 @@
+unit MCPServer.Tests.Golden.Legacy;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  MCPServer.Tests.Harness,
+  MCPServer.Tests.Golden;
+
+type
+  /// Pins the legacy (initialize-based) wire behaviour of the JSON-RPC layer.
+  ///
+  /// Every test replays one file from tests\golden\legacy through a fresh
+  /// harness and compares the normalised response with the recorded one.
+  /// The only differences allowed after the recording are the items in the
+  /// allow-list of docs\mcp-2026-07-28-implementation-plan.md, section 4.3.
+  [TestFixture]
+  TLegacyGoldenTests = class
+  private
+    FHarness: TMCPTestHarness;
+    procedure CheckGolden(const CaseName: string);
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // Lifecycle
+    [Test] procedure Initialize_2025_06_18;
+    [Test] procedure Initialize_2025_11_25;
+    [Test] procedure Initialize_2025_03_26;
+    [Test] procedure Initialize_UnknownVersion;
+    [Test] procedure Initialize_WithoutParams;
+    [Test] procedure Notifications_Initialized;
+    [Test] procedure Ping;
+
+    // Tools
+    [Test] procedure Tools_List;
+    [Test] procedure Tools_Call_Echo;
+    [Test] procedure Tools_Call_Echo_Unicode;
+    [Test] procedure Tools_Call_Calculate;
+    [Test] procedure Tools_Call_Calculate_DivideByZero;
+    [Test] procedure Tools_Call_GetTime;
+    [Test] procedure Tools_Call_ListFiles;
+    [Test] procedure Tools_Call_ListFiles_OutsideAllowedDirectory;
+    [Test] procedure Tools_Call_MissingArguments;
+    [Test] procedure Tools_Call_UnknownTool;
+    [Test] procedure Tools_Call_InvalidArgumentType;
+    [Test] procedure Tools_Call_WithoutParams;
+    [Test] procedure Tools_Call_EmptyName;
+
+    // Resources
+    [Test] procedure Resources_List;
+    [Test] procedure Resources_Read_ProjectInfo;
+    [Test] procedure Resources_Read_ProjectReadme;
+    [Test] procedure Resources_Read_LogsRecent;
+    [Test] procedure Resources_Read_UnknownUri;
+    [Test] procedure Resources_Read_WithoutParams;
+    [Test] procedure Resources_Templates_List;
+
+    // Method and message shape
+    [Test] procedure UnknownMethod;
+    [Test] procedure ServerDiscover_WithoutMeta;
+    [Test] procedure ParseError;
+    [Test] procedure EmptyBody;
+    [Test] procedure RequestNotAnObject;
+    [Test] procedure Id_Null;
+    [Test] procedure Id_String;
+    [Test] procedure MissingJsonRpcField;
+    [Test] procedure MissingMethod;
+    [Test] procedure ParamsNotAnObject;
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+{ TLegacyGoldenTests }
+
+procedure TLegacyGoldenTests.Setup;
+begin
+  FHarness := TMCPTestHarness.Create;
+end;
+
+procedure TLegacyGoldenTests.TearDown;
+begin
+  FreeAndNil(FHarness);
+end;
+
+procedure TLegacyGoldenTests.CheckGolden(const CaseName: string);
+begin
+  var GoldenCase := TGoldenCase.Create(TGoldenFiles.CaseFile(TGoldenFiles.LEGACY_SUITE, CaseName));
+  try
+    var Response: string;
+    var SavedDirectory := GetCurrentDir;
+    if GoldenCase.WorkingDirectory <> '' then
+      SetCurrentDir(GoldenCase.WorkingDirectory);
+    try
+      Response := FHarness.Process(GoldenCase.RequestBody);
+    finally
+      SetCurrentDir(SavedDirectory);
+    end;
+
+    if TGoldenFiles.RecordMode then
+    begin
+      GoldenCase.RecordExpected(Response);
+      Exit;
+    end;
+
+    Assert.AreEqual(GoldenCase.ExpectedText, GoldenCase.NormalizeResponse(Response),
+      'Golden mismatch for ' + CaseName);
+  finally
+    GoldenCase.Free;
+  end;
+end;
+
+procedure TLegacyGoldenTests.Initialize_2025_06_18;
+begin
+  CheckGolden('initialize-2025-06-18');
+end;
+
+procedure TLegacyGoldenTests.Initialize_2025_11_25;
+begin
+  CheckGolden('initialize-2025-11-25');
+end;
+
+procedure TLegacyGoldenTests.Initialize_2025_03_26;
+begin
+  CheckGolden('initialize-2025-03-26');
+end;
+
+procedure TLegacyGoldenTests.Initialize_UnknownVersion;
+begin
+  CheckGolden('initialize-unknown-version');
+end;
+
+procedure TLegacyGoldenTests.Initialize_WithoutParams;
+begin
+  CheckGolden('initialize-without-params');
+end;
+
+procedure TLegacyGoldenTests.Notifications_Initialized;
+begin
+  CheckGolden('notifications-initialized');
+end;
+
+procedure TLegacyGoldenTests.Ping;
+begin
+  CheckGolden('ping');
+end;
+
+procedure TLegacyGoldenTests.Tools_List;
+begin
+  CheckGolden('tools-list');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_Echo;
+begin
+  CheckGolden('tools-call-echo');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_Echo_Unicode;
+begin
+  CheckGolden('tools-call-echo-unicode');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_Calculate;
+begin
+  CheckGolden('tools-call-calculate');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_Calculate_DivideByZero;
+begin
+  CheckGolden('tools-call-calculate-divide-by-zero');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_GetTime;
+begin
+  CheckGolden('tools-call-get-time');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_ListFiles;
+begin
+  CheckGolden('tools-call-list-files');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_ListFiles_OutsideAllowedDirectory;
+begin
+  CheckGolden('tools-call-list-files-outside-allowed-directory');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_MissingArguments;
+begin
+  CheckGolden('tools-call-missing-arguments');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_UnknownTool;
+begin
+  CheckGolden('tools-call-unknown-tool');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_InvalidArgumentType;
+begin
+  CheckGolden('tools-call-invalid-argument-type');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_WithoutParams;
+begin
+  CheckGolden('tools-call-without-params');
+end;
+
+procedure TLegacyGoldenTests.Tools_Call_EmptyName;
+begin
+  CheckGolden('tools-call-empty-name');
+end;
+
+procedure TLegacyGoldenTests.Resources_List;
+begin
+  CheckGolden('resources-list');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_ProjectInfo;
+begin
+  CheckGolden('resources-read-project-info');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_ProjectReadme;
+begin
+  CheckGolden('resources-read-project-readme');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_LogsRecent;
+begin
+  CheckGolden('resources-read-logs-recent');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_UnknownUri;
+begin
+  CheckGolden('resources-read-unknown-uri');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_WithoutParams;
+begin
+  CheckGolden('resources-read-without-params');
+end;
+
+procedure TLegacyGoldenTests.Resources_Templates_List;
+begin
+  CheckGolden('resources-templates-list');
+end;
+
+procedure TLegacyGoldenTests.UnknownMethod;
+begin
+  CheckGolden('unknown-method');
+end;
+
+procedure TLegacyGoldenTests.ServerDiscover_WithoutMeta;
+begin
+  CheckGolden('server-discover-without-meta');
+end;
+
+procedure TLegacyGoldenTests.ParseError;
+begin
+  CheckGolden('parse-error');
+end;
+
+procedure TLegacyGoldenTests.EmptyBody;
+begin
+  CheckGolden('empty-body');
+end;
+
+procedure TLegacyGoldenTests.RequestNotAnObject;
+begin
+  CheckGolden('request-not-an-object');
+end;
+
+procedure TLegacyGoldenTests.Id_Null;
+begin
+  CheckGolden('id-null');
+end;
+
+procedure TLegacyGoldenTests.Id_String;
+begin
+  CheckGolden('id-string');
+end;
+
+procedure TLegacyGoldenTests.MissingJsonRpcField;
+begin
+  CheckGolden('missing-jsonrpc-field');
+end;
+
+procedure TLegacyGoldenTests.MissingMethod;
+begin
+  CheckGolden('missing-method');
+end;
+
+procedure TLegacyGoldenTests.ParamsNotAnObject;
+begin
+  CheckGolden('params-not-an-object');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TLegacyGoldenTests);
+
+end.

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -54,6 +54,7 @@ type
     [Test] procedure Resources_Read_ProjectInfo;
     [Test] procedure Resources_Read_ProjectReadme;
     [Test] procedure Resources_Read_LogsRecent;
+    [Test] procedure Resources_Read_ServerStatus;
     [Test] procedure Resources_Read_UnknownUri;
     [Test] procedure Resources_Read_WithoutParams;
     [Test] procedure Resources_Templates_List;
@@ -233,6 +234,11 @@ end;
 procedure TLegacyGoldenTests.Resources_Read_LogsRecent;
 begin
   CheckGolden('resources-read-logs-recent');
+end;
+
+procedure TLegacyGoldenTests.Resources_Read_ServerStatus;
+begin
+  CheckGolden('resources-read-server-status');
 end;
 
 procedure TLegacyGoldenTests.Resources_Read_UnknownUri;

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -12,8 +12,8 @@ type
   ///
   /// Every test replays one file from tests\golden\legacy through a fresh
   /// harness and compares the normalised response with the recorded one.
-  /// The only differences allowed after the recording are the items in the
-  /// allow-list of docs\mcp-2026-07-28-implementation-plan.md, section 4.3.
+  /// A golden file only changes when the wire behaviour changes on purpose;
+  /// such a change belongs in the CHANGELOG.
   [TestFixture]
   TLegacyGoldenTests = class
   private

--- a/tests/MCPServer.Tests.Golden.pas
+++ b/tests/MCPServer.Tests.Golden.pas
@@ -1,0 +1,406 @@
+unit MCPServer.Tests.Golden;
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.Generics.Collections,
+  System.JSON;
+
+type
+  EGoldenError = class(Exception);
+
+  /// Locates the golden directory and exposes the record switch.
+  ///
+  /// The golden root is the "golden" folder under "tests". It is found by
+  /// walking up from the test executable, or taken from the environment
+  /// variable MCP_GOLDEN_DIR. Setting MCP_GOLDEN_RECORD=1 makes the golden
+  /// tests overwrite the expected sections instead of comparing.
+  TGoldenFiles = class
+  public
+    const RECORD_ENVIRONMENT_VARIABLE = 'MCP_GOLDEN_RECORD';
+    const GOLDEN_DIR_ENVIRONMENT_VARIABLE = 'MCP_GOLDEN_DIR';
+    const GOLDEN_DIRECTORY_NAME = 'golden';
+    const LEGACY_SUITE = 'legacy';
+
+    class function GoldenRoot: string;
+    class function TestsRoot: string;
+    class function CaseFile(const Suite, CaseName: string): string;
+    class function RecordMode: Boolean;
+  end;
+
+  /// Replaces known-volatile values in a parsed JSON response so that two
+  /// runs can be compared byte for byte.
+  ///
+  /// A path is a dotted member path with array indexes, for example
+  /// "result.content[0].text". A pattern may use [*] to match any index.
+  /// Mask paths are replaced by the placeholder string; shape paths are
+  /// replaced by their shape (every leaf becomes its JSON type name, and a
+  /// string that itself contains a JSON document is parsed first). Paths must
+  /// end at an object member.
+  TGoldenNormalizer = class
+  private
+    class function ReplaceIndexes(const Segment: string): string;
+    class function SegmentMatches(const Segment, Pattern: string): Boolean;
+    class function ShapeOfString(const Value: string): TJSONValue;
+    class procedure NormalizeObject(const Obj: TJSONObject; const Path: string;
+      const MaskPaths, ShapePaths: TArray<string>);
+    class procedure NormalizeArray(const Arr: TJSONArray; const Path: string;
+      const MaskPaths, ShapePaths: TArray<string>);
+  public
+    const MASK_PLACEHOLDER = '<masked>';
+
+    class function PathMatches(const Path, Pattern: string): Boolean;
+    class function MatchesAny(const Path: string; const Patterns: TArray<string>): Boolean;
+    class function Shape(const Value: TJSONValue): TJSONValue;
+    class procedure Normalize(const Root: TJSONValue; const MaskPaths, ShapePaths: TArray<string>);
+  end;
+
+  /// One golden case file. Fields:
+  ///   request          JSON value sent as the request body, or
+  ///   requestText      raw request body for non-JSON input
+  ///   mask             optional list of paths replaced by "<masked>"
+  ///   shape            optional list of paths replaced by their shape
+  ///   workingDirectory optional directory (relative to "tests") made
+  ///                    current while the request runs
+  ///   expected         normalised JSON response, or
+  ///   expectedText     raw response when it is empty or not JSON
+  TGoldenCase = class
+  private
+    FFileName: string;
+    FDocument: TJSONObject;
+    function ReadStringArray(const Name: string): TArray<string>;
+    function GetRequestBody: string;
+    function GetWorkingDirectory: string;
+    function GetHasExpected: Boolean;
+    procedure RemoveExpected;
+    procedure Save;
+  public
+    const INDENTATION = 2;
+
+    constructor Create(const AFileName: string);
+    destructor Destroy; override;
+
+    /// Applies mask and shape rules to an actual response and returns the
+    /// formatted text used for comparison. Empty or non-JSON responses are
+    /// returned unchanged.
+    function NormalizeResponse(const ResponseBody: string): string;
+    /// The recorded expectation in the same formatted form.
+    function ExpectedText: string;
+    /// Stores the normalised response as the new expectation and saves the file.
+    procedure RecordExpected(const ResponseBody: string);
+
+    property FileName: string read FFileName;
+    property RequestBody: string read GetRequestBody;
+    property WorkingDirectory: string read GetWorkingDirectory;
+    property HasExpected: Boolean read GetHasExpected;
+  end;
+
+implementation
+
+uses
+  System.IOUtils;
+
+const
+  MAX_PARENT_LEVELS = 6;
+
+{ TGoldenFiles }
+
+class function TGoldenFiles.GoldenRoot: string;
+begin
+  Result := GetEnvironmentVariable(GOLDEN_DIR_ENVIRONMENT_VARIABLE);
+  if Result <> '' then
+    Exit(TPath.GetFullPath(Result));
+
+  var Dir := ExtractFilePath(ParamStr(0));
+  for var Level := 0 to MAX_PARENT_LEVELS do
+  begin
+    var Candidate := TPath.Combine(Dir, GOLDEN_DIRECTORY_NAME);
+    if TDirectory.Exists(TPath.Combine(Candidate, LEGACY_SUITE)) then
+      Exit(Candidate);
+    Dir := TPath.GetFullPath(TPath.Combine(Dir, '..'));
+  end;
+
+  raise EGoldenError.CreateFmt('Golden directory not found above %s (set %s)',
+    [ExtractFilePath(ParamStr(0)), GOLDEN_DIR_ENVIRONMENT_VARIABLE]);
+end;
+
+class function TGoldenFiles.TestsRoot: string;
+begin
+  Result := TPath.GetFullPath(TPath.Combine(GoldenRoot, '..'));
+end;
+
+class function TGoldenFiles.CaseFile(const Suite, CaseName: string): string;
+begin
+  Result := TPath.Combine(TPath.Combine(GoldenRoot, Suite), CaseName + '.json');
+end;
+
+class function TGoldenFiles.RecordMode: Boolean;
+begin
+  Result := GetEnvironmentVariable(RECORD_ENVIRONMENT_VARIABLE) = '1';
+end;
+
+{ TGoldenNormalizer }
+
+class function TGoldenNormalizer.ReplaceIndexes(const Segment: string): string;
+begin
+  Result := '';
+  var I := 1;
+  while I <= Length(Segment) do
+  begin
+    if Segment[I] = '[' then
+    begin
+      Result := Result + '[*';
+      Inc(I);
+      while (I <= Length(Segment)) and CharInSet(Segment[I], ['0'..'9']) do
+        Inc(I);
+    end
+    else
+    begin
+      Result := Result + Segment[I];
+      Inc(I);
+    end;
+  end;
+end;
+
+class function TGoldenNormalizer.SegmentMatches(const Segment, Pattern: string): Boolean;
+begin
+  Result := Segment = Pattern;
+  if (not Result) and Pattern.Contains('[*]') then
+    Result := ReplaceIndexes(Segment) = Pattern;
+end;
+
+class function TGoldenNormalizer.PathMatches(const Path, Pattern: string): Boolean;
+begin
+  var PathParts := Path.Split(['.']);
+  var PatternParts := Pattern.Split(['.']);
+  if Length(PathParts) <> Length(PatternParts) then
+    Exit(False);
+
+  for var I := 0 to High(PathParts) do
+    if not SegmentMatches(PathParts[I], PatternParts[I]) then
+      Exit(False);
+
+  Result := True;
+end;
+
+class function TGoldenNormalizer.MatchesAny(const Path: string; const Patterns: TArray<string>): Boolean;
+begin
+  for var Pattern in Patterns do
+    if PathMatches(Path, Pattern) then
+      Exit(True);
+  Result := False;
+end;
+
+class function TGoldenNormalizer.ShapeOfString(const Value: string): TJSONValue;
+begin
+  var Parsed := TJSONObject.ParseJSONValue(Value);
+  try
+    if (Parsed is TJSONObject) or (Parsed is TJSONArray) then
+      Result := Shape(Parsed)
+    else
+      Result := TJSONString.Create('string');
+  finally
+    Parsed.Free;
+  end;
+end;
+
+class function TGoldenNormalizer.Shape(const Value: TJSONValue): TJSONValue;
+begin
+  if Value is TJSONObject then
+  begin
+    var Obj := TJSONObject.Create;
+    for var Pair in TJSONObject(Value) do
+      Obj.AddPair(Pair.JsonString.Value, Shape(Pair.JsonValue));
+    Result := Obj;
+  end
+  else if Value is TJSONArray then
+  begin
+    var Arr := TJSONArray.Create;
+    for var Item in TJSONArray(Value) do
+      Arr.AddElement(Shape(Item));
+    Result := Arr;
+  end
+  else if Value is TJSONNull then
+    Result := TJSONString.Create('null')
+  else if Value is TJSONBool then
+    Result := TJSONString.Create('boolean')
+  else if Value is TJSONNumber then
+    Result := TJSONString.Create('number')
+  else if Value is TJSONString then
+    Result := ShapeOfString(TJSONString(Value).Value)
+  else
+    Result := TJSONString.Create(Value.ClassName);
+end;
+
+class procedure TGoldenNormalizer.NormalizeObject(const Obj: TJSONObject; const Path: string;
+  const MaskPaths, ShapePaths: TArray<string>);
+begin
+  for var Pair in Obj do
+  begin
+    var ChildPath := Pair.JsonString.Value;
+    if Path <> '' then
+      ChildPath := Path + '.' + ChildPath;
+
+    if MatchesAny(ChildPath, MaskPaths) then
+      Pair.JsonValue := TJSONString.Create(MASK_PLACEHOLDER)
+    else if MatchesAny(ChildPath, ShapePaths) then
+      Pair.JsonValue := Shape(Pair.JsonValue)
+    else if Pair.JsonValue is TJSONObject then
+      NormalizeObject(TJSONObject(Pair.JsonValue), ChildPath, MaskPaths, ShapePaths)
+    else if Pair.JsonValue is TJSONArray then
+      NormalizeArray(TJSONArray(Pair.JsonValue), ChildPath, MaskPaths, ShapePaths);
+  end;
+end;
+
+class procedure TGoldenNormalizer.NormalizeArray(const Arr: TJSONArray; const Path: string;
+  const MaskPaths, ShapePaths: TArray<string>);
+begin
+  for var I := 0 to Arr.Count - 1 do
+  begin
+    var ChildPath := Path + '[' + I.ToString + ']';
+    var Item := Arr.Items[I];
+    if Item is TJSONObject then
+      NormalizeObject(TJSONObject(Item), ChildPath, MaskPaths, ShapePaths)
+    else if Item is TJSONArray then
+      NormalizeArray(TJSONArray(Item), ChildPath, MaskPaths, ShapePaths);
+  end;
+end;
+
+class procedure TGoldenNormalizer.Normalize(const Root: TJSONValue; const MaskPaths, ShapePaths: TArray<string>);
+begin
+  if Root is TJSONObject then
+    NormalizeObject(TJSONObject(Root), '', MaskPaths, ShapePaths)
+  else if Root is TJSONArray then
+    NormalizeArray(TJSONArray(Root), '', MaskPaths, ShapePaths);
+end;
+
+{ TGoldenCase }
+
+constructor TGoldenCase.Create(const AFileName: string);
+begin
+  inherited Create;
+  FFileName := AFileName;
+
+  if not TFile.Exists(FFileName) then
+    raise EGoldenError.CreateFmt('Golden file not found: %s', [FFileName]);
+
+  var Parsed := TJSONObject.ParseJSONValue(TFile.ReadAllText(FFileName, TEncoding.UTF8));
+  if not (Parsed is TJSONObject) then
+  begin
+    Parsed.Free;
+    raise EGoldenError.CreateFmt('Golden file is not a JSON object: %s', [FFileName]);
+  end;
+  FDocument := TJSONObject(Parsed);
+end;
+
+destructor TGoldenCase.Destroy;
+begin
+  FDocument.Free;
+  inherited;
+end;
+
+function TGoldenCase.ReadStringArray(const Name: string): TArray<string>;
+begin
+  Result := nil;
+  var Value := FDocument.GetValue(Name);
+  if not (Value is TJSONArray) then
+    Exit;
+
+  var Arr := TJSONArray(Value);
+  SetLength(Result, Arr.Count);
+  for var I := 0 to Arr.Count - 1 do
+    Result[I] := Arr.Items[I].Value;
+end;
+
+function TGoldenCase.GetRequestBody: string;
+begin
+  var Request := FDocument.GetValue('request');
+  if Assigned(Request) then
+    Exit(Request.ToJSON);
+
+  var RequestText := FDocument.GetValue('requestText');
+  if Assigned(RequestText) then
+    Exit(RequestText.Value);
+
+  raise EGoldenError.CreateFmt('Golden file has neither "request" nor "requestText": %s', [FFileName]);
+end;
+
+function TGoldenCase.GetWorkingDirectory: string;
+begin
+  var Value := FDocument.GetValue('workingDirectory');
+  if Assigned(Value) and (Value.Value <> '') then
+    Result := TPath.GetFullPath(TPath.Combine(TGoldenFiles.TestsRoot, Value.Value))
+  else
+    Result := '';
+end;
+
+function TGoldenCase.GetHasExpected: Boolean;
+begin
+  Result := Assigned(FDocument.GetValue('expected')) or Assigned(FDocument.GetValue('expectedText'));
+end;
+
+function TGoldenCase.NormalizeResponse(const ResponseBody: string): string;
+begin
+  if ResponseBody.Trim = '' then
+    Exit(ResponseBody);
+
+  var Parsed := TJSONObject.ParseJSONValue(ResponseBody);
+  if not Assigned(Parsed) then
+    Exit(ResponseBody);
+
+  try
+    TGoldenNormalizer.Normalize(Parsed, ReadStringArray('mask'), ReadStringArray('shape'));
+    Result := Parsed.Format(INDENTATION);
+  finally
+    Parsed.Free;
+  end;
+end;
+
+function TGoldenCase.ExpectedText: string;
+begin
+  var Expected := FDocument.GetValue('expected');
+  if Assigned(Expected) then
+    Exit(Expected.Format(INDENTATION));
+
+  var ExpectedText := FDocument.GetValue('expectedText');
+  if Assigned(ExpectedText) then
+    Exit(ExpectedText.Value);
+
+  raise EGoldenError.CreateFmt('No expectation recorded in %s (run once with %s=1)',
+    [FFileName, TGoldenFiles.RECORD_ENVIRONMENT_VARIABLE]);
+end;
+
+procedure TGoldenCase.RemoveExpected;
+begin
+  FDocument.RemovePair('expected').Free;
+  FDocument.RemovePair('expectedText').Free;
+end;
+
+procedure TGoldenCase.RecordExpected(const ResponseBody: string);
+begin
+  RemoveExpected;
+
+  var Parsed: TJSONValue := nil;
+  if ResponseBody.Trim <> '' then
+    Parsed := TJSONObject.ParseJSONValue(ResponseBody);
+
+  if Assigned(Parsed) then
+  begin
+    TGoldenNormalizer.Normalize(Parsed, ReadStringArray('mask'), ReadStringArray('shape'));
+    FDocument.AddPair('expected', Parsed);
+  end
+  else
+    FDocument.AddPair('expectedText', ResponseBody);
+
+  Save;
+end;
+
+procedure TGoldenCase.Save;
+begin
+  var Text := FDocument.Format(INDENTATION) + sLineBreak;
+  TFile.WriteAllBytes(FFileName, TEncoding.UTF8.GetBytes(Text));
+end;
+
+end.

--- a/tests/MCPServer.Tests.Harness.pas
+++ b/tests/MCPServer.Tests.Harness.pas
@@ -1,0 +1,76 @@
+unit MCPServer.Tests.Harness;
+
+interface
+
+uses
+  System.SysUtils,
+  MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.JsonRpcProcessor;
+
+type
+  /// Builds the same manager registry as MCPServer.dpr (core, tools and
+  /// resources managers on top of the built-in registrations) and drives the
+  /// transport-independent JSON-RPC processor directly.
+  TMCPTestHarness = class
+  private
+    FSettings: TMCPSettings;
+    FManagerRegistry: IMCPManagerRegistry;
+    FCoreManager: IMCPCapabilityManager;
+    FProcessor: TMCPJsonRpcProcessor;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    /// Sends one JSON-RPC message through the processor and returns the raw
+    /// response body; an empty string means "no response" (notification).
+    function Process(const RequestBody: string): string;
+
+    property Settings: TMCPSettings read FSettings;
+    property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
+    property CoreManager: IMCPCapabilityManager read FCoreManager;
+  end;
+
+implementation
+
+uses
+  MCPServer.ManagerRegistry,
+  MCPServer.CoreManager,
+  MCPServer.ToolsManager,
+  MCPServer.ResourcesManager;
+
+{ TMCPTestHarness }
+
+constructor TMCPTestHarness.Create;
+begin
+  inherited Create;
+
+  // Never create a settings.ini next to the test executable; the defaults are
+  // the same values the server writes into a fresh settings.ini.
+  FSettings := TMCPSettings.Create('', False);
+
+  FManagerRegistry := TMCPManagerRegistry.Create;
+  FCoreManager := TMCPCoreManager.Create(FSettings);
+
+  FManagerRegistry.RegisterManager(FCoreManager);
+  FManagerRegistry.RegisterManager(TMCPToolsManager.Create);
+  FManagerRegistry.RegisterManager(TMCPResourcesManager.Create);
+
+  FProcessor := TMCPJsonRpcProcessor.Create(FManagerRegistry);
+end;
+
+destructor TMCPTestHarness.Destroy;
+begin
+  FProcessor.Free;
+  FCoreManager := nil;
+  FManagerRegistry := nil;
+  FSettings.Free;
+  inherited;
+end;
+
+function TMCPTestHarness.Process(const RequestBody: string): string;
+begin
+  Result := FProcessor.ProcessRequest(RequestBody, '');
+end;
+
+end.

--- a/tests/MCPServer.Tests.Logger.pas
+++ b/tests/MCPServer.Tests.Logger.pas
@@ -1,0 +1,115 @@
+unit MCPServer.Tests.Logger;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  /// The stdout guard: while a stdio transport runs, console logging must
+  /// never reach stdout, whatever a consumer sets on TLogger.
+  [TestFixture]
+  TLoggerStdoutGuardTests = class
+  private
+    FOriginalUseStdErr: Boolean;
+    FOriginalStdoutReserved: Boolean;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test] procedure StdoutReserved_ForcesUseStdErr;
+    [Test] procedure StdoutReserved_RefusesUseStdErrFalse_AndWarnsOnce;
+    [Test] procedure StdoutReleased_AllowsUseStdErrFalseAgain;
+    [Test] procedure StdioTransport_Create_ReservesStdout;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Classes,
+  MCPServer.Logger,
+  MCPServer.StdioTransport,
+  MCPServer.Tests.Harness;
+
+{ TLoggerStdoutGuardTests }
+
+procedure TLoggerStdoutGuardTests.Setup;
+begin
+  FOriginalUseStdErr := TLogger.UseStdErr;
+  FOriginalStdoutReserved := TLogger.StdoutReserved;
+  TLogger.StdoutReserved := False;
+  TLogger.UseStdErr := False;
+end;
+
+procedure TLoggerStdoutGuardTests.TearDown;
+begin
+  TLogger.OnLogMessage := nil;
+  TLogger.StdoutReserved := FOriginalStdoutReserved;
+  TLogger.UseStdErr := FOriginalUseStdErr;
+end;
+
+procedure TLoggerStdoutGuardTests.StdoutReserved_ForcesUseStdErr;
+begin
+  Assert.IsFalse(TLogger.UseStdErr);
+
+  TLogger.StdoutReserved := True;
+
+  Assert.IsTrue(TLogger.UseStdErr);
+end;
+
+procedure TLoggerStdoutGuardTests.StdoutReserved_RefusesUseStdErrFalse_AndWarnsOnce;
+begin
+  var Warnings := TStringList.Create;
+  try
+    TLogger.OnLogMessage :=
+      procedure(const Message: string)
+      begin
+        if Message.Contains('[WARN ]') and Message.Contains('stdout is reserved') then
+          Warnings.Add(Message);
+      end;
+
+    TLogger.StdoutReserved := True;
+    TLogger.UseStdErr := False;
+    TLogger.UseStdErr := False;
+
+    Assert.IsTrue(TLogger.UseStdErr, 'UseStdErr must stay True while stdout is reserved');
+    Assert.AreEqual(1, Warnings.Count, 'the refusal is logged once');
+  finally
+    TLogger.OnLogMessage := nil;
+    Warnings.Free;
+  end;
+end;
+
+procedure TLoggerStdoutGuardTests.StdoutReleased_AllowsUseStdErrFalseAgain;
+begin
+  TLogger.StdoutReserved := True;
+  TLogger.StdoutReserved := False;
+
+  TLogger.UseStdErr := False;
+
+  Assert.IsFalse(TLogger.UseStdErr);
+end;
+
+procedure TLoggerStdoutGuardTests.StdioTransport_Create_ReservesStdout;
+begin
+  var Harness := TMCPTestHarness.Create;
+  try
+    var Transport := TMCPStdioTransport.Create(Harness.ManagerRegistry, Harness.CoreManager);
+    try
+      Assert.IsTrue(TLogger.StdoutReserved);
+      Assert.IsTrue(TLogger.UseStdErr);
+    finally
+      Transport.Free;
+    end;
+  finally
+    Harness.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TLoggerStdoutGuardTests);
+
+end.

--- a/tests/MCPServer.Tests.Registration.pas
+++ b/tests/MCPServer.Tests.Registration.pas
@@ -1,0 +1,86 @@
+unit MCPServer.Tests.Registration;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  /// TMCPRegistry is filled from unit initialization sections; these tests
+  /// only read it so the golden tests keep seeing the shipped registry.
+  [TestFixture]
+  TRegistryTests = class
+  public
+    [Test] procedure BuiltInTools_AreRegisteredFromInitialization;
+    [Test] procedure BuiltInResources_AreRegisteredFromInitialization;
+    [Test] procedure ServerStatus_IsNotRegisteredByDefault;
+    [Test] procedure CreateTool_UnknownName_Raises;
+    [Test] procedure CreateResource_UnknownUri_Raises;
+    [Test] procedure CreateTool_ReturnsFreshInstances;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Registration,
+  MCPServer.Tool.Base;
+
+{ TRegistryTests }
+
+procedure TRegistryTests.BuiltInTools_AreRegisteredFromInitialization;
+begin
+  Assert.IsTrue(TMCPRegistry.HasTool('echo'));
+  Assert.IsTrue(TMCPRegistry.HasTool('get_time'));
+  Assert.IsTrue(TMCPRegistry.HasTool('list_files'));
+  Assert.IsTrue(TMCPRegistry.HasTool('calculate'));
+  Assert.AreEqual(4, Integer(Length(TMCPRegistry.GetToolNames)));
+end;
+
+procedure TRegistryTests.BuiltInResources_AreRegisteredFromInitialization;
+begin
+  Assert.IsTrue(TMCPRegistry.HasResource('project://info'));
+  Assert.IsTrue(TMCPRegistry.HasResource('project://readme'));
+  Assert.IsTrue(TMCPRegistry.HasResource('logs://recent'));
+  Assert.AreEqual(3, Integer(Length(TMCPRegistry.GetResourceURIs)));
+end;
+
+procedure TRegistryTests.ServerStatus_IsNotRegisteredByDefault;
+begin
+  // Documented in tests\golden\README.md: only SetNamePrefix registers it.
+  Assert.IsFalse(TMCPRegistry.HasResource('server://status'));
+end;
+
+procedure TRegistryTests.CreateTool_UnknownName_Raises;
+begin
+  var Probe: TProc :=
+    procedure
+    begin
+      TMCPRegistry.CreateTool('no_such_tool');
+    end;
+  Assert.WillRaise(Probe, Exception);
+end;
+
+procedure TRegistryTests.CreateResource_UnknownUri_Raises;
+begin
+  var Probe: TProc :=
+    procedure
+    begin
+      TMCPRegistry.CreateResource('nope://missing');
+    end;
+  Assert.WillRaise(Probe, Exception);
+end;
+
+procedure TRegistryTests.CreateTool_ReturnsFreshInstances;
+begin
+  var First: IMCPTool := TMCPRegistry.CreateTool('echo');
+  var Second: IMCPTool := TMCPRegistry.CreateTool('echo');
+
+  Assert.AreEqual('echo', First.Name);
+  Assert.AreNotSame(First, Second);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TRegistryTests);
+
+end.

--- a/tests/MCPServer.Tests.Registration.pas
+++ b/tests/MCPServer.Tests.Registration.pas
@@ -13,7 +13,7 @@ type
   public
     [Test] procedure BuiltInTools_AreRegisteredFromInitialization;
     [Test] procedure BuiltInResources_AreRegisteredFromInitialization;
-    [Test] procedure ServerStatus_IsNotRegisteredByDefault;
+    [Test] procedure ServerStatus_IsRegisteredByDefault;
     [Test] procedure CreateTool_UnknownName_Raises;
     [Test] procedure CreateResource_UnknownUri_Raises;
     [Test] procedure CreateTool_ReturnsFreshInstances;
@@ -42,13 +42,16 @@ begin
   Assert.IsTrue(TMCPRegistry.HasResource('project://info'));
   Assert.IsTrue(TMCPRegistry.HasResource('project://readme'));
   Assert.IsTrue(TMCPRegistry.HasResource('logs://recent'));
-  Assert.AreEqual(3, Integer(Length(TMCPRegistry.GetResourceURIs)));
+  Assert.IsTrue(TMCPRegistry.HasResource('server://status'));
+  Assert.AreEqual(4, Integer(Length(TMCPRegistry.GetResourceURIs)));
 end;
 
-procedure TRegistryTests.ServerStatus_IsNotRegisteredByDefault;
+procedure TRegistryTests.ServerStatus_IsRegisteredByDefault;
 begin
-  // Documented in tests\golden\README.md: only SetNamePrefix registers it.
-  Assert.IsFalse(TMCPRegistry.HasResource('server://status'));
+  // Registered by the initialization section of MCPServer.Resource.Server.
+  var Status := TMCPRegistry.CreateResource('server://status');
+  Assert.AreEqual('server://status', Status.URI);
+  Assert.AreEqual('server_status', Status.Name);
 end;
 
 procedure TRegistryTests.CreateTool_UnknownName_Raises;

--- a/tests/MCPServer.Tests.ServerStatus.pas
+++ b/tests/MCPServer.Tests.ServerStatus.pas
@@ -1,0 +1,129 @@
+unit MCPServer.Tests.ServerStatus;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  /// The counters behind server://status are updated from every Indy
+  /// connection thread; these tests guard the atomic implementation.
+  [TestFixture]
+  TServerStatusResourceTests = class
+  private
+    procedure ReadCounters(out RequestCount: Int64; out ActiveConnections: Integer);
+  public
+    [Setup]
+    procedure Setup;
+
+    [Test] procedure Counters_StartAtZero;
+    [Test] procedure Counters_AreExactUnderConcurrentUpdates;
+    [Test] procedure ConnectionClosed_NeverGoesBelowZero;
+    [Test] procedure Read_ProducesJsonWithStatusFields;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.JSON,
+  System.Threading,
+  MCPServer.Resource.Base,
+  MCPServer.Resource.Server;
+
+const
+  THREAD_COUNT = 8;
+  ITERATIONS_PER_THREAD = 20000;
+
+{ TServerStatusResourceTests }
+
+procedure TServerStatusResourceTests.Setup;
+begin
+  TServerStatusResource.Initialize;
+end;
+
+procedure TServerStatusResourceTests.ReadCounters(out RequestCount: Int64; out ActiveConnections: Integer);
+begin
+  var Resource: IMCPResource := TServerStatusResource.Create;
+  var Status := TJSONObject.ParseJSONValue(Resource.Read) as TJSONObject;
+  try
+    Assert.IsNotNull(Status, 'server://status must return a JSON object');
+    RequestCount := Status.GetValue<Int64>('requestcount');
+    ActiveConnections := Status.GetValue<Integer>('activeconnections');
+  finally
+    Status.Free;
+  end;
+end;
+
+procedure TServerStatusResourceTests.Counters_StartAtZero;
+begin
+  var RequestCount: Int64;
+  var ActiveConnections: Integer;
+  ReadCounters(RequestCount, ActiveConnections);
+
+  Assert.AreEqual(Int64(0), RequestCount);
+  Assert.AreEqual(0, ActiveConnections);
+end;
+
+procedure TServerStatusResourceTests.Counters_AreExactUnderConcurrentUpdates;
+begin
+  var Tasks: TArray<ITask>;
+  SetLength(Tasks, THREAD_COUNT);
+  for var I := 0 to High(Tasks) do
+    Tasks[I] := TTask.Run(
+      procedure
+      begin
+        for var J := 1 to ITERATIONS_PER_THREAD do
+        begin
+          TServerStatusResource.ConnectionOpened;
+          TServerStatusResource.IncrementRequestCount;
+          TServerStatusResource.ConnectionClosed;
+        end;
+      end);
+  TTask.WaitForAll(Tasks);
+
+  var RequestCount: Int64;
+  var ActiveConnections: Integer;
+  ReadCounters(RequestCount, ActiveConnections);
+
+  Assert.AreEqual(Int64(THREAD_COUNT) * ITERATIONS_PER_THREAD, RequestCount, 'lost request increments');
+  Assert.AreEqual(0, ActiveConnections, 'every opened connection was closed');
+end;
+
+procedure TServerStatusResourceTests.ConnectionClosed_NeverGoesBelowZero;
+begin
+  TServerStatusResource.ConnectionClosed;
+  TServerStatusResource.ConnectionClosed;
+  TServerStatusResource.ConnectionOpened;
+  TServerStatusResource.ConnectionClosed;
+  TServerStatusResource.ConnectionClosed;
+
+  var RequestCount: Int64;
+  var ActiveConnections: Integer;
+  ReadCounters(RequestCount, ActiveConnections);
+
+  Assert.AreEqual(0, ActiveConnections);
+end;
+
+procedure TServerStatusResourceTests.Read_ProducesJsonWithStatusFields;
+begin
+  var Resource: IMCPResource := TServerStatusResource.Create;
+  Assert.AreEqual('server://status', Resource.URI);
+  Assert.AreEqual('application/json', Resource.MimeType);
+
+  var Status := TJSONObject.ParseJSONValue(Resource.Read) as TJSONObject;
+  try
+    Assert.IsNotNull(Status);
+    Assert.AreEqual('running', Status.GetValue<string>('status'));
+    Assert.IsNotNull(Status.GetValue('uptime'));
+    Assert.IsNotNull(Status.GetValue('memoryused'));
+  finally
+    Status.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TServerStatusResourceTests);
+
+end.

--- a/tests/MCPServer.Tests.dpr
+++ b/tests/MCPServer.Tests.dpr
@@ -1,0 +1,72 @@
+program MCPServer.Tests;
+
+{$APPTYPE CONSOLE}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.SysUtils,
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  DUnitX.TestFramework,
+  MCPServer.Types in '..\src\Protocol\MCPServer.Types.pas',
+  MCPServer.Serializer in '..\src\Protocol\MCPServer.Serializer.pas',
+  MCPServer.Schema.Generator in '..\src\Protocol\MCPServer.Schema.Generator.pas',
+  MCPServer.Logger in '..\src\Core\MCPServer.Logger.pas',
+  MCPServer.Settings in '..\src\Core\MCPServer.Settings.pas',
+  MCPServer.Registration in '..\src\Core\MCPServer.Registration.pas',
+  MCPServer.ManagerRegistry in '..\src\Core\MCPServer.ManagerRegistry.pas',
+  MCPServer.Tool.Base in '..\src\Tools\MCPServer.Tool.Base.pas',
+  MCPServer.Resource.Base in '..\src\Resources\MCPServer.Resource.Base.pas',
+  MCPServer.JsonRpcProcessor in '..\src\Protocol\MCPServer.JsonRpcProcessor.pas',
+  MCPServer.CoreManager in '..\src\Managers\MCPServer.CoreManager.pas',
+  MCPServer.ToolsManager in '..\src\Managers\MCPServer.ToolsManager.pas',
+  MCPServer.ResourcesManager in '..\src\Managers\MCPServer.ResourcesManager.pas',
+  // The built-in tools and resources register themselves in their
+  // initialization sections. Keep the order identical to MCPServer.dpr so the
+  // registry (and therefore tools/list and resources/list) matches the server.
+  MCPServer.Resource.Server in '..\src\Resources\MCPServer.Resource.Server.pas',
+  MCPServer.Tool.Echo in '..\src\Tools\MCPServer.Tool.Echo.pas',
+  MCPServer.Tool.GetTime in '..\src\Tools\MCPServer.Tool.GetTime.pas',
+  MCPServer.Tool.ListFiles in '..\src\Tools\MCPServer.Tool.ListFiles.pas',
+  MCPServer.Tool.Calculate in '..\src\Tools\MCPServer.Tool.Calculate.pas',
+  MCPServer.Resource.Logs in '..\src\Resources\MCPServer.Resource.Logs.pas',
+  MCPServer.Resource.Project in '..\src\Resources\MCPServer.Resource.Project.pas',
+  MCPServer.Tests.Harness in 'MCPServer.Tests.Harness.pas',
+  MCPServer.Tests.Golden in 'MCPServer.Tests.Golden.pas',
+  MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas';
+
+procedure RunTests;
+begin
+  TDUnitX.CheckCommandLine;
+
+  var Runner := TDUnitX.CreateRunner;
+  Runner.UseRTTI := True;
+  Runner.FailsOnNoAsserts := False;
+
+  if TDUnitX.Options.ConsoleMode <> TDunitXConsoleMode.Off then
+    Runner.AddLogger(TDUnitXConsoleLogger.Create(TDUnitX.Options.ConsoleMode = TDunitXConsoleMode.Quiet));
+
+  Runner.AddLogger(TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile));
+
+  var Results := Runner.Execute;
+  if not Results.AllPassed then
+    System.ExitCode := EXIT_ERRORS;
+
+  if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+  begin
+    System.Write('Done. Press <Enter> to quit.');
+    System.Readln;
+  end;
+end;
+
+begin
+  try
+    RunTests;
+  except
+    on E: Exception do
+    begin
+      System.Writeln(E.ClassName, ': ', E.Message);
+      System.ExitCode := EXIT_ERRORS;
+    end;
+  end;
+end.

--- a/tests/MCPServer.Tests.dpr
+++ b/tests/MCPServer.Tests.dpr
@@ -21,6 +21,7 @@ uses
   MCPServer.CoreManager in '..\src\Managers\MCPServer.CoreManager.pas',
   MCPServer.ToolsManager in '..\src\Managers\MCPServer.ToolsManager.pas',
   MCPServer.ResourcesManager in '..\src\Managers\MCPServer.ResourcesManager.pas',
+  MCPServer.StdioTransport in '..\src\Server\MCPServer.StdioTransport.pas',
   // The built-in tools and resources register themselves in their
   // initialization sections. Keep the order identical to MCPServer.dpr so the
   // registry (and therefore tools/list and resources/list) matches the server.
@@ -36,7 +37,8 @@ uses
   MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas',
   MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas',
   MCPServer.Tests.ServerStatus in 'MCPServer.Tests.ServerStatus.pas',
-  MCPServer.Tests.Registration in 'MCPServer.Tests.Registration.pas';
+  MCPServer.Tests.Registration in 'MCPServer.Tests.Registration.pas',
+  MCPServer.Tests.Logger in 'MCPServer.Tests.Logger.pas';
 
 procedure RunTests;
 begin

--- a/tests/MCPServer.Tests.dpr
+++ b/tests/MCPServer.Tests.dpr
@@ -34,7 +34,9 @@ uses
   MCPServer.Tests.Harness in 'MCPServer.Tests.Harness.pas',
   MCPServer.Tests.Golden in 'MCPServer.Tests.Golden.pas',
   MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas',
-  MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas';
+  MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas',
+  MCPServer.Tests.ServerStatus in 'MCPServer.Tests.ServerStatus.pas',
+  MCPServer.Tests.Registration in 'MCPServer.Tests.Registration.pas';
 
 procedure RunTests;
 begin

--- a/tests/MCPServer.Tests.dpr
+++ b/tests/MCPServer.Tests.dpr
@@ -33,7 +33,8 @@ uses
   MCPServer.Resource.Project in '..\src\Resources\MCPServer.Resource.Project.pas',
   MCPServer.Tests.Harness in 'MCPServer.Tests.Harness.pas',
   MCPServer.Tests.Golden in 'MCPServer.Tests.Golden.pas',
-  MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas';
+  MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas',
+  MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas';
 
 procedure RunTests;
 begin

--- a/tests/MCPServer.Tests.dproj
+++ b/tests/MCPServer.Tests.dproj
@@ -85,6 +85,7 @@
         <DCCReference Include="..\src\Managers\MCPServer.CoreManager.pas"/>
         <DCCReference Include="..\src\Managers\MCPServer.ToolsManager.pas"/>
         <DCCReference Include="..\src\Managers\MCPServer.ResourcesManager.pas"/>
+        <DCCReference Include="..\src\Server\MCPServer.StdioTransport.pas"/>
         <DCCReference Include="..\src\Resources\MCPServer.Resource.Server.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.Echo.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.GetTime.pas"/>
@@ -98,6 +99,7 @@
         <DCCReference Include="MCPServer.Tests.Constants.pas"/>
         <DCCReference Include="MCPServer.Tests.ServerStatus.pas"/>
         <DCCReference Include="MCPServer.Tests.Registration.pas"/>
+        <DCCReference Include="MCPServer.Tests.Logger.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/tests/MCPServer.Tests.dproj
+++ b/tests/MCPServer.Tests.dproj
@@ -1,0 +1,128 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{5C1E6B2A-7D4F-4E8B-9A3C-2F1D0E9B8C7A}</ProjectGuid>
+        <MainSource>MCPServer.Tests.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <TargetedPlatforms>3</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <ProjectVersion>20.3</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <ProjectName Condition="'$(ProjectName)'==''">MCPServer.Tests</ProjectName>
+        <FrameworkType>None</FrameworkType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <SanitizedProjectName>MCPServer_Tests</SanitizedProjectName>
+        <DCC_ConsoleTarget>true</DCC_ConsoleTarget>
+        <DCC_UnitSearchPath>..\src;..\src\Managers;..\src\Server;..\src\Tools;..\src\Core;..\src\Protocol;..\src\Libraries;..\src\Resources;$(DUnitX);$(BDS)\source\DUnitX;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="..\src\Protocol\MCPServer.Types.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.Serializer.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.Schema.Generator.pas"/>
+        <DCCReference Include="..\src\Core\MCPServer.Logger.pas"/>
+        <DCCReference Include="..\src\Core\MCPServer.Settings.pas"/>
+        <DCCReference Include="..\src\Core\MCPServer.Registration.pas"/>
+        <DCCReference Include="..\src\Core\MCPServer.ManagerRegistry.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.Base.pas"/>
+        <DCCReference Include="..\src\Resources\MCPServer.Resource.Base.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.JsonRpcProcessor.pas"/>
+        <DCCReference Include="..\src\Managers\MCPServer.CoreManager.pas"/>
+        <DCCReference Include="..\src\Managers\MCPServer.ToolsManager.pas"/>
+        <DCCReference Include="..\src\Managers\MCPServer.ResourcesManager.pas"/>
+        <DCCReference Include="..\src\Resources\MCPServer.Resource.Server.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.Echo.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.GetTime.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.ListFiles.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.Calculate.pas"/>
+        <DCCReference Include="..\src\Resources\MCPServer.Resource.Logs.pas"/>
+        <DCCReference Include="..\src\Resources\MCPServer.Resource.Project.pas"/>
+        <DCCReference Include="MCPServer.Tests.Harness.pas"/>
+        <DCCReference Include="MCPServer.Tests.Golden.pas"/>
+        <DCCReference Include="MCPServer.Tests.Golden.Legacy.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>Application</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">MCPServer.Tests.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/tests/MCPServer.Tests.dproj
+++ b/tests/MCPServer.Tests.dproj
@@ -96,6 +96,8 @@
         <DCCReference Include="MCPServer.Tests.Golden.pas"/>
         <DCCReference Include="MCPServer.Tests.Golden.Legacy.pas"/>
         <DCCReference Include="MCPServer.Tests.Constants.pas"/>
+        <DCCReference Include="MCPServer.Tests.ServerStatus.pas"/>
+        <DCCReference Include="MCPServer.Tests.Registration.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/tests/MCPServer.Tests.dproj
+++ b/tests/MCPServer.Tests.dproj
@@ -95,6 +95,7 @@
         <DCCReference Include="MCPServer.Tests.Harness.pas"/>
         <DCCReference Include="MCPServer.Tests.Golden.pas"/>
         <DCCReference Include="MCPServer.Tests.Golden.Legacy.pas"/>
+        <DCCReference Include="MCPServer.Tests.Constants.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/tests/fixtures/files/alpha.txt
+++ b/tests/fixtures/files/alpha.txt
@@ -1,0 +1,1 @@
+alpha fixture file

--- a/tests/fixtures/files/beta.txt
+++ b/tests/fixtures/files/beta.txt
@@ -1,0 +1,1 @@
+beta fixture file

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -62,17 +62,17 @@ formatted `expected` value, so key order and array order matter.
 
 ## Notes on the recorded behaviour
 
-- `server://status` is declared in `MCPServer.Resource.Server.pas` but the
-  executable never registers it (`SetNamePrefix` is the only caller of
-  `RegisterServerStatusResource`), so `resources/list` returns three resources.
-- `resources/read` without `params` dereferences nil and answers `-32603` with
-  an access-violation message; the message is masked. `tools/call` without
-  `arguments` fails the same way inside the tool and comes back as an `isError`
-  text result; that text is masked too.
-- `logs://recent` answers "Error reading resource: Invalid pointer operation":
-  `TLogsRecentResource.GetResourceData` puts the copied entries into a second
-  owning list, so they are freed twice. The golden pins this current behaviour
-  until the resource is fixed in a later phase.
+- Six cases were re-recorded after defects found during the first recording
+  were fixed in the same branch (see CHANGELOG): `resources-list` and
+  `resources-read-server-status` (`server://status` was never registered by
+  the executable), `resources-read-logs-recent` (the entries were freed twice
+  and the read failed), `resources-read-project-info` and again
+  `resources-read-logs-recent` (lists were serialised as an object with
+  `count` and `capacity`), `resources-read-without-params` and
+  `tools-call-missing-arguments` (nil dereferences). Every other legacy case
+  is byte-identical to the 2025-06-18 code.
+- `server://status` and `logs://recent` contain timestamps, counters and log
+  text, so their `text` field is compared by shape.
 - `tools/call` with `id: null` is treated as a notification and gets no
   response.
 - HTTP responses are normalised: `Date` and `Server` headers are dropped, GUIDs

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,20 +1,15 @@
 # Golden files
 
-The golden files pin the wire behaviour of the server so that every later change
-can prove "no regression for existing clients". They were recorded from the
-unchanged 2025-06-18 code before the MCP 2026-07-28 work started. After that
-recording the only differences allowed on the legacy wire are the items in the
-allow-list of `docs/mcp-2026-07-28-implementation-plan.md`, section 4.3. Anything
-else that changes a golden file is a bug.
+The golden files pin the wire behaviour of the server. A change in a golden
+file is a deliberate change of what clients receive and belongs in the
+CHANGELOG; an unintended change is a regression.
 
 ## Layout
 
 | Directory | Layer | Recorded by | Verified by |
 |---|---|---|---|
-| `legacy/` | JSON-RPC processor (`TMCPJsonRpcProcessor.ProcessRequest`) with the same registry as `MCPServer.dpr` | `scripts\run-tests.ps1 -Record` | `scripts\run-tests.ps1` (DUnitX fixture `TLegacyGoldenTests`) |
+| `legacy/` | JSON-RPC processor (`TMCPJsonRpcProcessor.ProcessRequest`) with the same registry as `MCPServer.dpr`, initialize-based protocol revisions | `scripts\run-tests.ps1 -Record` | `scripts\run-tests.ps1` (DUnitX fixture `TLegacyGoldenTests`) |
 | `http/` | Streamable HTTP transport (`TMCPIdHTTPServer`) of the built executable, captured with curl | `scripts\capture-http-goldens.ps1 -Record` | `scripts\capture-http-goldens.ps1` |
-
-Later phases add `modern/` for 2026-07-28 requests.
 
 ## Legacy case files
 
@@ -33,10 +28,11 @@ One JSON file per case in `legacy/`:
 - `request` is sent as the request body. Use `requestText` instead for input that
   is not JSON (parse errors, empty body, arrays).
 - `mask` lists paths whose value is replaced by `"<masked>"` before comparing
-  (session ids, timestamps, exception text with addresses).
+  (session ids, timestamps).
 - `shape` lists paths whose value is replaced by its shape: every leaf becomes
   its JSON type name. A string that contains a JSON document is parsed first, so
-  resource contents such as `logs://recent` are compared structurally.
+  resource contents such as `logs://recent` and `server://status` are compared
+  structurally.
 - Paths are dotted member paths with array indexes; `[*]` matches any index.
   A path must end at an object member.
 - `workingDirectory` (relative to `tests/`) is made current while the request
@@ -49,31 +45,23 @@ formatted `expected` value, so key order and array order matter.
 
 ## Recording procedure
 
-1. Check out the commit whose behaviour must be pinned.
-2. `build.bat Debug Win64` and `build-tests.bat Debug Win64`.
-3. `.\scripts\run-tests.ps1 -Record -NoBuild` rewrites the `expected` sections
-   in `legacy/`.
-4. `.\scripts\capture-http-goldens.ps1 -Record` starts `Win64\Debug\MCPServer.exe`
+1. `build.bat Debug Win64` and `build-tests.bat Debug Win64`.
+2. `.\scripts\run-tests.ps1 -Record -NoBuild` rewrites the `expected` sections
+   in `legacy/`. Use `-Filter` with the fully qualified test names to
+   re-record single cases.
+3. `.\scripts\capture-http-goldens.ps1 -Record` starts `Win64\Debug\MCPServer.exe`
    on port 3939 and writes `http/*.txt`.
-5. Review the diff. Only the intended cases may change, and only within the
-   allow-list.
-6. `.\scripts\run-tests.ps1` and `.\scripts\capture-http-goldens.ps1` must be
+4. Review the diff: only the cases whose behaviour changed on purpose may
+   differ.
+5. `.\scripts\run-tests.ps1` and `.\scripts\capture-http-goldens.ps1` must be
    green before committing.
 
 ## Notes on the recorded behaviour
 
-- Six cases were re-recorded after defects found during the first recording
-  were fixed in the same branch (see CHANGELOG): `resources-list` and
-  `resources-read-server-status` (`server://status` was never registered by
-  the executable), `resources-read-logs-recent` (the entries were freed twice
-  and the read failed), `resources-read-project-info` and again
-  `resources-read-logs-recent` (lists were serialised as an object with
-  `count` and `capacity`), `resources-read-without-params` and
-  `tools-call-missing-arguments` (nil dereferences). Every other legacy case
-  is byte-identical to the 2025-06-18 code.
-- `server://status` and `logs://recent` contain timestamps, counters and log
+- `logs://recent` and `server://status` contain timestamps, counters and log
   text, so their `text` field is compared by shape.
-- `tools/call` with `id: null` is treated as a notification and gets no
+- A request with `id: null` is treated as a notification and gets no
   response.
 - HTTP responses are normalised: `Date` and `Server` headers are dropped, GUIDs
-  become `<guid>`, SSE `id:` lines become `id: <n>`, line endings are LF.
+  become `<guid>`, SSE `id:` lines become `id: <n>`, line endings are LF and
+  trailing newlines are trimmed.

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,79 @@
+# Golden files
+
+The golden files pin the wire behaviour of the server so that every later change
+can prove "no regression for existing clients". They were recorded from the
+unchanged 2025-06-18 code before the MCP 2026-07-28 work started. After that
+recording the only differences allowed on the legacy wire are the items in the
+allow-list of `docs/mcp-2026-07-28-implementation-plan.md`, section 4.3. Anything
+else that changes a golden file is a bug.
+
+## Layout
+
+| Directory | Layer | Recorded by | Verified by |
+|---|---|---|---|
+| `legacy/` | JSON-RPC processor (`TMCPJsonRpcProcessor.ProcessRequest`) with the same registry as `MCPServer.dpr` | `scripts\run-tests.ps1 -Record` | `scripts\run-tests.ps1` (DUnitX fixture `TLegacyGoldenTests`) |
+| `http/` | Streamable HTTP transport (`TMCPIdHTTPServer`) of the built executable, captured with curl | `scripts\capture-http-goldens.ps1 -Record` | `scripts\capture-http-goldens.ps1` |
+
+Later phases add `modern/` for 2026-07-28 requests.
+
+## Legacy case files
+
+One JSON file per case in `legacy/`:
+
+```json
+{
+  "request": { "jsonrpc": "2.0", "id": 1, "method": "ping" },
+  "mask": ["result.sessionId"],
+  "shape": ["result.contents[0].text"],
+  "workingDirectory": "fixtures",
+  "expected": { "jsonrpc": "2.0", "id": 1, "result": {} }
+}
+```
+
+- `request` is sent as the request body. Use `requestText` instead for input that
+  is not JSON (parse errors, empty body, arrays).
+- `mask` lists paths whose value is replaced by `"<masked>"` before comparing
+  (session ids, timestamps, exception text with addresses).
+- `shape` lists paths whose value is replaced by its shape: every leaf becomes
+  its JSON type name. A string that contains a JSON document is parsed first, so
+  resource contents such as `logs://recent` are compared structurally.
+- Paths are dotted member paths with array indexes; `[*]` matches any index.
+  A path must end at an object member.
+- `workingDirectory` (relative to `tests/`) is made current while the request
+  runs; `list_files` restricts itself to the current directory.
+- `expected` holds the normalised response. `expectedText` is used when the
+  response is empty (notification) or not JSON.
+
+The tests compare the formatted JSON text of the normalised response with the
+formatted `expected` value, so key order and array order matter.
+
+## Recording procedure
+
+1. Check out the commit whose behaviour must be pinned.
+2. `build.bat Debug Win64` and `build-tests.bat Debug Win64`.
+3. `.\scripts\run-tests.ps1 -Record -NoBuild` rewrites the `expected` sections
+   in `legacy/`.
+4. `.\scripts\capture-http-goldens.ps1 -Record` starts `Win64\Debug\MCPServer.exe`
+   on port 3939 and writes `http/*.txt`.
+5. Review the diff. Only the intended cases may change, and only within the
+   allow-list.
+6. `.\scripts\run-tests.ps1` and `.\scripts\capture-http-goldens.ps1` must be
+   green before committing.
+
+## Notes on the recorded behaviour
+
+- `server://status` is declared in `MCPServer.Resource.Server.pas` but the
+  executable never registers it (`SetNamePrefix` is the only caller of
+  `RegisterServerStatusResource`), so `resources/list` returns three resources.
+- `resources/read` without `params` dereferences nil and answers `-32603` with
+  an access-violation message; the message is masked. `tools/call` without
+  `arguments` fails the same way inside the tool and comes back as an `isError`
+  text result; that text is masked too.
+- `logs://recent` answers "Error reading resource: Invalid pointer operation":
+  `TLogsRecentResource.GetResourceData` puts the copied entries into a second
+  owning list, so they are freed twice. The golden pins this current behaviour
+  until the resource is fixed in a later phase.
+- `tools/call` with `id: null` is treated as a notification and gets no
+  response.
+- HTTP responses are normalised: `Date` and `Server` headers are dropped, GUIDs
+  become `<guid>`, SSE `id:` lines become `id: <n>`, line endings are LF.

--- a/tests/golden/http/delete-endpoint.txt
+++ b/tests/golden/http/delete-endpoint.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 405 Method Not Allowed
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 55
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>405 Method Not Allowed</B></BODY></HTML>

--- a/tests/golden/http/get-endpoint-info.txt
+++ b/tests/golden/http/get-endpoint-info.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 57
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Cache-Control: no-cache
+Connection: keep-alive
+
+{"url": "http://localhost:3939/mcp", "transport": "http"}

--- a/tests/golden/http/get-sse-stream.txt
+++ b/tests/golden/http/get-sse-stream.txt
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 39
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+
+<HTML><BODY><B>200 OK</B></BODY></HTML>

--- a/tests/golden/http/options-preflight.txt
+++ b/tests/golden/http/options-preflight.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 39
+Access-Control-Allow-Origin: http://localhost
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>200 OK</B></BODY></HTML>

--- a/tests/golden/http/post-batch-notifications.txt
+++ b/tests/golden/http/post-batch-notifications.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 202 Accepted
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 45
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>202 Accepted</B></BODY></HTML>

--- a/tests/golden/http/post-batch-requests.txt
+++ b/tests/golden/http/post-batch-requests.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 98
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"JSON-RPC request must be an object"}}

--- a/tests/golden/http/post-client-response.txt
+++ b/tests/golden/http/post-client-response.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 202 Accepted
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 45
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>202 Accepted</B></BODY></HTML>

--- a/tests/golden/http/post-empty-body.txt
+++ b/tests/golden/http/post-empty-body.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 76
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Invalid JSON"}}

--- a/tests/golden/http/post-initialize-sse.txt
+++ b/tests/golden/http/post-initialize-sse.txt
@@ -14,5 +14,3 @@ X-Accel-Buffering: no
 id: <n>
 event: message
 data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"supportsProgress":false,"supportsCancellation":false},"resources":{"subscribe":false,"listChanged":false}},"sessionId":"<guid>","serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}
-
-

--- a/tests/golden/http/post-initialize-sse.txt
+++ b/tests/golden/http/post-initialize-sse.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: text/event-stream; charset=utf-8
+Content-Length: 341
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+
+id: <n>
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"supportsProgress":false,"supportsCancellation":false},"resources":{"subscribe":false,"listChanged":false}},"sessionId":"<guid>","serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}
+
+

--- a/tests/golden/http/post-initialize.txt
+++ b/tests/golden/http/post-initialize.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 312
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+Mcp-Session-Id: <guid>
+
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"supportsProgress":false,"supportsCancellation":false},"resources":{"subscribe":false,"listChanged":false}},"sessionId":"<guid>","serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}

--- a/tests/golden/http/post-no-accept-header.txt
+++ b/tests/golden/http/post-no-accept-header.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 36
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":9,"result":{}}

--- a/tests/golden/http/post-notification-initialized.txt
+++ b/tests/golden/http/post-notification-initialized.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 202 Accepted
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 45
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>202 Accepted</B></BODY></HTML>

--- a/tests/golden/http/post-origin-allowed.txt
+++ b/tests/golden/http/post-origin-allowed.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 37
+Access-Control-Allow-Origin: http://localhost
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":13,"result":{}}

--- a/tests/golden/http/post-origin-forbidden.txt
+++ b/tests/golden/http/post-origin-forbidden.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 403 Forbidden - Origin not allowed
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 67
+
+<HTML><BODY><B>403 Forbidden - Origin not allowed</B></BODY></HTML>

--- a/tests/golden/http/post-parse-error.txt
+++ b/tests/golden/http/post-parse-error.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 76
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Invalid JSON"}}

--- a/tests/golden/http/post-protocol-version-header.txt
+++ b/tests/golden/http/post-protocol-version-header.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 37
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":12,"result":{}}

--- a/tests/golden/http/post-resources-list.txt
+++ b/tests/golden/http/post-resources-list.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 451
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":4,"result":{"resources":[{"uri":"project://readme","name":"Project README","description":"README.md file contents","mimeType":"text/markdown"},{"uri":"logs://recent","name":"Recent Logs","description":"Recent log entries from all categories","mimeType":"application/json"},{"uri":"project://info","name":"Project Information","description":"Basic information about the Delphi MCP Server project","mimeType":"application/json"}]}}

--- a/tests/golden/http/post-resources-list.txt
+++ b/tests/golden/http/post-resources-list.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 451
+Content-Length: 591
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":4,"result":{"resources":[{"uri":"project://readme","name":"Project README","description":"README.md file contents","mimeType":"text/markdown"},{"uri":"logs://recent","name":"Recent Logs","description":"Recent log entries from all categories","mimeType":"application/json"},{"uri":"project://info","name":"Project Information","description":"Basic information about the Delphi MCP Server project","mimeType":"application/json"}]}}
+{"jsonrpc":"2.0","id":4,"result":{"resources":[{"uri":"project://readme","name":"Project README","description":"README.md file contents","mimeType":"text/markdown"},{"uri":"logs://recent","name":"Recent Logs","description":"Recent log entries from all categories","mimeType":"application/json"},{"uri":"project://info","name":"Project Information","description":"Basic information about the Delphi MCP Server project","mimeType":"application/json"},{"uri":"server://status","name":"server_status","description":"Current server status and health information","mimeType":"application/json"}]}}

--- a/tests/golden/http/post-resources-read-project-info.txt
+++ b/tests/golden/http/post-resources-read-project-info.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 547
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":5,"result":{"contents":[{"uri":"project://info","mimeType":"application/json","text":"{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":{\"capacity\":4,\"count\":4,\"isempty\":false}}"}]}}

--- a/tests/golden/http/post-resources-read-project-info.txt
+++ b/tests/golden/http/post-resources-read-project-info.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 547
+Content-Length: 590
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":5,"result":{"contents":[{"uri":"project://info","mimeType":"application/json","text":"{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":{\"capacity\":4,\"count\":4,\"isempty\":false}}"}]}}
+{"jsonrpc":"2.0","id":5,"result":{"contents":[{"uri":"project://info","mimeType":"application/json","text":"{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":[\"Tools capability\",\"Resources capability\",\"JSON-RPC 2.0 support\",\"CORS support\"]}"}]}}

--- a/tests/golden/http/post-session-echo-lowercase.txt
+++ b/tests/golden/http/post-session-echo-lowercase.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 37
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+Mcp-Session-Id: golden-session-2
+
+{"jsonrpc":"2.0","id":11,"result":{}}

--- a/tests/golden/http/post-session-echo.txt
+++ b/tests/golden/http/post-session-echo.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 37
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+Mcp-Session-Id: golden-session-1
+
+{"jsonrpc":"2.0","id":10,"result":{}}

--- a/tests/golden/http/post-tools-call-echo.txt
+++ b/tests/golden/http/post-tools-call-echo.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 91
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Echo: hello golden"}]}}

--- a/tests/golden/http/post-tools-list-sse.txt
+++ b/tests/golden/http/post-tools-list-sse.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: text/event-stream; charset=utf-8
+Content-Length: 1085
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+
+id: <n>
+event: message
+data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"get_time","description":"Get the current server time in ISO format","inputSchema":{"type":"object","properties":{}}},{"name":"calculate","description":"Perform basic arithmetic calculations","inputSchema":{"type":"object","properties":{"operation":{"type":"string","description":"Operation: add, subtract, multiply, divide","enum":["add","subtract","multiply","divide"]},"a":{"type":"number","description":"First number"},"b":{"type":"number","description":"Second number"}},"required":["operation","a","b"]}},{"name":"echo","description":"Echo a message back to the user","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Message to echo back"}},"required":["message"]}},{"name":"list_files","description":"List files in a directory","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list files from"},"includehidden":{"type":"boolean","description":"Include hidden files in the listing"}},"required":["path"]}}]}}
+
+

--- a/tests/golden/http/post-tools-list-sse.txt
+++ b/tests/golden/http/post-tools-list-sse.txt
@@ -14,5 +14,3 @@ X-Accel-Buffering: no
 id: <n>
 event: message
 data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"get_time","description":"Get the current server time in ISO format","inputSchema":{"type":"object","properties":{}}},{"name":"calculate","description":"Perform basic arithmetic calculations","inputSchema":{"type":"object","properties":{"operation":{"type":"string","description":"Operation: add, subtract, multiply, divide","enum":["add","subtract","multiply","divide"]},"a":{"type":"number","description":"First number"},"b":{"type":"number","description":"Second number"}},"required":["operation","a","b"]}},{"name":"echo","description":"Echo a message back to the user","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Message to echo back"}},"required":["message"]}},{"name":"list_files","description":"List files in a directory","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list files from"},"includehidden":{"type":"boolean","description":"Include hidden files in the listing"}},"required":["path"]}}]}}
-
-

--- a/tests/golden/http/post-tools-list.txt
+++ b/tests/golden/http/post-tools-list.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 1056
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"get_time","description":"Get the current server time in ISO format","inputSchema":{"type":"object","properties":{}}},{"name":"calculate","description":"Perform basic arithmetic calculations","inputSchema":{"type":"object","properties":{"operation":{"type":"string","description":"Operation: add, subtract, multiply, divide","enum":["add","subtract","multiply","divide"]},"a":{"type":"number","description":"First number"},"b":{"type":"number","description":"Second number"}},"required":["operation","a","b"]}},{"name":"echo","description":"Echo a message back to the user","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Message to echo back"}},"required":["message"]}},{"name":"list_files","description":"List files in a directory","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list files from"},"includehidden":{"type":"boolean","description":"Include hidden files in the listing"}},"required":["path"]}}]}}

--- a/tests/golden/http/post-unknown-method.txt
+++ b/tests/golden/http/post-unknown-method.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 140
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":7,"error":{"code":-32601,"message":"Method [prompts/list] not found. The method does not exist or is not available."}}

--- a/tests/golden/http/post-wrong-path.txt
+++ b/tests/golden/http/post-wrong-path.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 404 Not Found
+Connection: close
+Content-Type: text/html; charset=utf-8
+Content-Length: 46
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>404 Not Found</B></BODY></HTML>

--- a/tests/golden/http/put-endpoint.txt
+++ b/tests/golden/http/put-endpoint.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 405 Method Not Allowed
+Connection: keep-alive
+Content-Type: text/html; charset=utf-8
+Content-Length: 55
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+
+<HTML><BODY><B>405 Method Not Allowed</B></BODY></HTML>

--- a/tests/golden/legacy/empty-body.json
+++ b/tests/golden/legacy/empty-body.json
@@ -1,0 +1,11 @@
+{
+  "requestText": "",
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+      "code": -32700,
+      "message": "Invalid JSON"
+    }
+  }
+}

--- a/tests/golden/legacy/id-null.json
+++ b/tests/golden/legacy/id-null.json
@@ -1,0 +1,8 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "method": "ping"
+  },
+  "expectedText": ""
+}

--- a/tests/golden/legacy/id-string.json
+++ b/tests/golden/legacy/id-string.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": "request-24",
+    "method": "ping"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": "request-24",
+    "result": {
+    }
+  }
+}

--- a/tests/golden/legacy/initialize-2025-03-26.json
+++ b/tests/golden/legacy/initialize-2025-03-26.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {
+      },
+      "clientInfo": {
+        "name": "golden-client",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "mask": [
+    "result.sessionId"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+        "tools": {
+          "supportsProgress": false,
+          "supportsCancellation": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "sessionId": "<masked>",
+      "serverInfo": {
+        "name": "delphi-mcp-server",
+        "version": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/golden/legacy/initialize-2025-06-18.json
+++ b/tests/golden/legacy/initialize-2025-06-18.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+      },
+      "clientInfo": {
+        "name": "golden-client",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "mask": [
+    "result.sessionId"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+        "tools": {
+          "supportsProgress": false,
+          "supportsCancellation": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "sessionId": "<masked>",
+      "serverInfo": {
+        "name": "delphi-mcp-server",
+        "version": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/golden/legacy/initialize-2025-11-25.json
+++ b/tests/golden/legacy/initialize-2025-11-25.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-11-25",
+      "capabilities": {
+      },
+      "clientInfo": {
+        "name": "golden-client",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "mask": [
+    "result.sessionId"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+        "tools": {
+          "supportsProgress": false,
+          "supportsCancellation": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "sessionId": "<masked>",
+      "serverInfo": {
+        "name": "delphi-mcp-server",
+        "version": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/golden/legacy/initialize-unknown-version.json
+++ b/tests/golden/legacy/initialize-unknown-version.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "1900-01-01",
+      "capabilities": {
+      },
+      "clientInfo": {
+        "name": "golden-client",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "mask": [
+    "result.sessionId"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+        "tools": {
+          "supportsProgress": false,
+          "supportsCancellation": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "sessionId": "<masked>",
+      "serverInfo": {
+        "name": "delphi-mcp-server",
+        "version": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/golden/legacy/initialize-without-params.json
+++ b/tests/golden/legacy/initialize-without-params.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize"
+  },
+  "mask": [
+    "result.sessionId"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {
+        "tools": {
+          "supportsProgress": false,
+          "supportsCancellation": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "sessionId": "<masked>",
+      "serverInfo": {
+        "name": "delphi-mcp-server",
+        "version": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/golden/legacy/missing-jsonrpc-field.json
+++ b/tests/golden/legacy/missing-jsonrpc-field.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "id": 25,
+    "method": "ping"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 25,
+    "result": {
+    }
+  }
+}

--- a/tests/golden/legacy/missing-method.json
+++ b/tests/golden/legacy/missing-method.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 26
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 26,
+    "error": {
+      "code": -32601,
+      "message": "Method [] not found. The method does not exist or is not available."
+    }
+  }
+}

--- a/tests/golden/legacy/notifications-initialized.json
+++ b/tests/golden/legacy/notifications-initialized.json
@@ -1,0 +1,7 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "method": "notifications/initialized"
+  },
+  "expectedText": ""
+}

--- a/tests/golden/legacy/params-not-an-object.json
+++ b/tests/golden/legacy/params-not-an-object.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 27,
+    "method": "tools/call",
+    "params": [
+      1,
+      2
+    ]
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 27,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Invalid tool parameters"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/parse-error.json
+++ b/tests/golden/legacy/parse-error.json
@@ -1,0 +1,11 @@
+{
+  "requestText": "{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":",
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+      "code": -32700,
+      "message": "Invalid JSON"
+    }
+  }
+}

--- a/tests/golden/legacy/ping.json
+++ b/tests/golden/legacy/ping.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "ping"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {
+    }
+  }
+}

--- a/tests/golden/legacy/request-not-an-object.json
+++ b/tests/golden/legacy/request-not-an-object.json
@@ -1,0 +1,11 @@
+{
+  "requestText": "[{\"jsonrpc\":\"2.0\",\"id\":23,\"method\":\"ping\"}]",
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+      "code": -32700,
+      "message": "JSON-RPC request must be an object"
+    }
+  }
+}

--- a/tests/golden/legacy/resources-list.json
+++ b/tests/golden/legacy/resources-list.json
@@ -26,6 +26,12 @@
           "name": "Project Information",
           "description": "Basic information about the Delphi MCP Server project",
           "mimeType": "application/json"
+        },
+        {
+          "uri": "server://status",
+          "name": "server_status",
+          "description": "Current server status and health information",
+          "mimeType": "application/json"
         }
       ]
     }

--- a/tests/golden/legacy/resources-list.json
+++ b/tests/golden/legacy/resources-list.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 13,
+    "method": "resources/list"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 13,
+    "result": {
+      "resources": [
+        {
+          "uri": "project://readme",
+          "name": "Project README",
+          "description": "README.md file contents",
+          "mimeType": "text/markdown"
+        },
+        {
+          "uri": "logs://recent",
+          "name": "Recent Logs",
+          "description": "Recent log entries from all categories",
+          "mimeType": "application/json"
+        },
+        {
+          "uri": "project://info",
+          "name": "Project Information",
+          "description": "Basic information about the Delphi MCP Server project",
+          "mimeType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-logs-recent.json
+++ b/tests/golden/legacy/resources-read-logs-recent.json
@@ -7,6 +7,9 @@
       "uri": "logs://recent"
     }
   },
+  "shape": [
+    "result.contents[0].text"
+  ],
   "expected": {
     "jsonrpc": "2.0",
     "id": 16,
@@ -15,7 +18,54 @@
         {
           "uri": "logs://recent",
           "mimeType": "application/json",
-          "text": "Error reading resource: Invalid pointer operation"
+          "text": {
+            "entries": [
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              },
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              },
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              },
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              },
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              },
+              {
+                "timestamp": "number",
+                "level": "string",
+                "message": "string",
+                "threadid": "number",
+                "category": "string"
+              }
+            ],
+            "totalcount": "number",
+            "filteredcount": "number"
+          }
         }
       ]
     }

--- a/tests/golden/legacy/resources-read-logs-recent.json
+++ b/tests/golden/legacy/resources-read-logs-recent.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 16,
+    "method": "resources/read",
+    "params": {
+      "uri": "logs://recent"
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 16,
+    "result": {
+      "contents": [
+        {
+          "uri": "logs://recent",
+          "mimeType": "application/json",
+          "text": "Error reading resource: Invalid pointer operation"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-project-info.json
+++ b/tests/golden/legacy/resources-read-project-info.json
@@ -15,7 +15,7 @@
         {
           "uri": "project://info",
           "mimeType": "application/json",
-          "text": "{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":{\"capacity\":4,\"count\":4,\"isempty\":false}}"
+          "text": "{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":[\"Tools capability\",\"Resources capability\",\"JSON-RPC 2.0 support\",\"CORS support\"]}"
         }
       ]
     }

--- a/tests/golden/legacy/resources-read-project-info.json
+++ b/tests/golden/legacy/resources-read-project-info.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 14,
+    "method": "resources/read",
+    "params": {
+      "uri": "project://info"
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 14,
+    "result": {
+      "contents": [
+        {
+          "uri": "project://info",
+          "mimeType": "application/json",
+          "text": "{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":{\"capacity\":4,\"count\":4,\"isempty\":false}}"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-project-readme.json
+++ b/tests/golden/legacy/resources-read-project-readme.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 15,
+    "method": "resources/read",
+    "params": {
+      "uri": "project://readme"
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 15,
+    "result": {
+      "contents": [
+        {
+          "uri": "project://readme",
+          "mimeType": "text/markdown",
+          "text": "\r\n# Delphi MCP Server\r\n\r\nA Model Context Protocol (MCP) server implementation in Delphi using Indy HTTP Server.\r\n\r\n## Features\r\n- Tools capability with automatic schema generation\r\n- Resources capability for read-only data access\r\n- JSON-RPC 2.0 protocol support\r\n- CORS support for cross-origin requests\r\n\r\n## Building\r\n```bash\r\nbuild.bat\r\n```\r\n\r\n## Running\r\n```bash\r\nWin32\\Debug\\MCPServer.exe\r\n```\r\n\r\n## Testing\r\n```bash\r\nnpx @wong2/mcp-cli --url http://localhost:8080/mcp\r\n```\r\n'"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-server-status.json
+++ b/tests/golden/legacy/resources-read-server-status.json
@@ -1,0 +1,34 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 28,
+    "method": "resources/read",
+    "params": {
+      "uri": "server://status"
+    }
+  },
+  "shape": [
+    "result.contents[0].text"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 28,
+    "result": {
+      "contents": [
+        {
+          "uri": "server://status",
+          "mimeType": "application/json",
+          "text": {
+            "status": "string",
+            "uptime": "number",
+            "starttime": "number",
+            "currenttime": "number",
+            "memoryused": "number",
+            "requestcount": "number",
+            "activeconnections": "number"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-unknown-uri.json
+++ b/tests/golden/legacy/resources-read-unknown-uri.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 17,
+    "method": "resources/read",
+    "params": {
+      "uri": "nope://missing"
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 17,
+    "result": {
+      "contents": [
+        {
+          "uri": "nope://missing",
+          "mimeType": "text/plain",
+          "text": "Error: Resource not found: nope://missing"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/resources-read-without-params.json
+++ b/tests/golden/legacy/resources-read-without-params.json
@@ -4,15 +4,17 @@
     "id": 18,
     "method": "resources/read"
   },
-  "mask": [
-    "error.message"
-  ],
   "expected": {
     "jsonrpc": "2.0",
     "id": 18,
-    "error": {
-      "code": -32603,
-      "message": "<masked>"
+    "result": {
+      "contents": [
+        {
+          "uri": "",
+          "mimeType": "text/plain",
+          "text": "Error: Resource not found: "
+        }
+      ]
     }
   }
 }

--- a/tests/golden/legacy/resources-read-without-params.json
+++ b/tests/golden/legacy/resources-read-without-params.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 18,
+    "method": "resources/read"
+  },
+  "mask": [
+    "error.message"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 18,
+    "error": {
+      "code": -32603,
+      "message": "<masked>"
+    }
+  }
+}

--- a/tests/golden/legacy/resources-templates-list.json
+++ b/tests/golden/legacy/resources-templates-list.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 19,
+    "method": "resources/templates/list"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 19,
+    "result": {
+      "resourceTemplates": [
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/server-discover-without-meta.json
+++ b/tests/golden/legacy/server-discover-without-meta.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 21,
+    "method": "server/discover"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 21,
+    "error": {
+      "code": -32601,
+      "message": "Method [server/discover] not found. The method does not exist or is not available."
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-calculate-divide-by-zero.json
+++ b/tests/golden/legacy/tools-call-calculate-divide-by-zero.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "tools/call",
+    "params": {
+      "name": "calculate",
+      "arguments": {
+        "operation": "divide",
+        "a": 1,
+        "b": 0
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Division by zero"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-calculate.json
+++ b/tests/golden/legacy/tools-call-calculate.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "tools/call",
+    "params": {
+      "name": "calculate",
+      "arguments": {
+        "operation": "add",
+        "a": 2,
+        "b": 3.5
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "2 add 3,5 = 5,5"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-echo-unicode.json
+++ b/tests/golden/legacy/tools-call-echo-unicode.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "echo",
+      "arguments": {
+        "message": "héllo wörld ✓ 😀"
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Echo: héllo wörld ✓ 😀"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-echo.json
+++ b/tests/golden/legacy/tools-call-echo.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "echo",
+      "arguments": {
+        "message": "hello golden"
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Echo: hello golden"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-empty-name.json
+++ b/tests/golden/legacy/tools-call-empty-name.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 12,
+    "method": "tools/call",
+    "params": {
+      "name": "",
+      "arguments": {
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 12,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Invalid tool parameters"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-get-time.json
+++ b/tests/golden/legacy/tools-call-get-time.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "tools/call",
+    "params": {
+      "name": "get_time",
+      "arguments": {
+      }
+    }
+  },
+  "mask": [
+    "result.content[0].text"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 6,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "<masked>"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-invalid-argument-type.json
+++ b/tests/golden/legacy/tools-call-invalid-argument-type.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "method": "tools/call",
+    "params": {
+      "name": "calculate",
+      "arguments": {
+        "operation": "add",
+        "a": "two",
+        "b": 3
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "0 add 3 = 3"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-list-files-outside-allowed-directory.json
+++ b/tests/golden/legacy/tools-call-list-files-outside-allowed-directory.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "tools/call",
+    "params": {
+      "name": "list_files",
+      "arguments": {
+        "path": "../../.."
+      }
+    }
+  },
+  "workingDirectory": "fixtures",
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Access denied - path outside allowed directory"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-list-files.json
+++ b/tests/golden/legacy/tools-call-list-files.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "tools/call",
+    "params": {
+      "name": "list_files",
+      "arguments": {
+        "path": "files"
+      }
+    }
+  },
+  "workingDirectory": "fixtures",
+  "mask": [
+    "result.content[0].text"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "<masked>"
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-missing-arguments.json
+++ b/tests/golden/legacy/tools-call-missing-arguments.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "method": "tools/call",
+    "params": {
+      "name": "echo"
+    }
+  },
+  "mask": [
+    "result.content[0].text"
+  ],
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "<masked>"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-missing-arguments.json
+++ b/tests/golden/legacy/tools-call-missing-arguments.json
@@ -7,9 +7,6 @@
       "name": "echo"
     }
   },
-  "mask": [
-    "result.content[0].text"
-  ],
   "expected": {
     "jsonrpc": "2.0",
     "id": 8,
@@ -17,10 +14,9 @@
       "content": [
         {
           "type": "text",
-          "text": "<masked>"
+          "text": "Echo: "
         }
-      ],
-      "isError": true
+      ]
     }
   }
 }

--- a/tests/golden/legacy/tools-call-unknown-tool.json
+++ b/tests/golden/legacy/tools-call-unknown-tool.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "tools/call",
+    "params": {
+      "name": "no_such_tool",
+      "arguments": {
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Tool not found: no_such_tool"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-call-without-params.json
+++ b/tests/golden/legacy/tools-call-without-params.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 11,
+    "method": "tools/call"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 11,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Invalid tool parameters"
+        }
+      ],
+      "isError": true
+    }
+  }
+}

--- a/tests/golden/legacy/tools-list.json
+++ b/tests/golden/legacy/tools-list.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/list"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "result": {
+      "tools": [
+        {
+          "name": "get_time",
+          "description": "Get the current server time in ISO format",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+            }
+          }
+        },
+        {
+          "name": "calculate",
+          "description": "Perform basic arithmetic calculations",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "description": "Operation: add, subtract, multiply, divide",
+                "enum": [
+                  "add",
+                  "subtract",
+                  "multiply",
+                  "divide"
+                ]
+              },
+              "a": {
+                "type": "number",
+                "description": "First number"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number"
+              }
+            },
+            "required": [
+              "operation",
+              "a",
+              "b"
+            ]
+          }
+        },
+        {
+          "name": "echo",
+          "description": "Echo a message back to the user",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "description": "Message to echo back"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        {
+          "name": "list_files",
+          "description": "List files in a directory",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Directory path to list files from"
+              },
+              "includehidden": {
+                "type": "boolean",
+                "description": "Include hidden files in the listing"
+              }
+            },
+            "required": [
+              "path"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/golden/legacy/unknown-method.json
+++ b/tests/golden/legacy/unknown-method.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 20,
+    "method": "prompts/list"
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 20,
+    "error": {
+      "code": -32601,
+      "message": "Method [prompts/list] not found. The method does not exist or is not available."
+    }
+  }
+}


### PR DESCRIPTION
## Test harness, golden files and hygiene fixes

Adds automated tests that pin the wire behaviour of the server, consolidates the protocol constants, makes the shared state thread-safe, keeps stdout clean in stdio mode, and fixes the defects the recording brought to light. No client-visible protocol change.

### Tests and tooling

- **DUnitX harness** (`tests/`): builds the same registry as `MCPServer.dpr` and drives `TMCPJsonRpcProcessor.ProcessRequest` in-process. 58 tests, green on Win32 and Win64.
- **Golden files**: 38 JSON-RPC cases (`tests/golden/legacy`) and 26 HTTP transport cases captured with curl (`tests/golden/http`). Volatile fields are masked or compared by shape; `tests/golden/README.md` documents the format and the recording procedure.
- **Scripts**: `run-tests.ps1`, `capture-http-goldens.ps1`, `run-conformance.ps1`, `run-inspector-smoke.ps1`, `run-stdio-smoke.ps1`, plus `build-tests.bat`. `package.json` pins the conformance CLI (0.2.0-alpha.11, the line with `--requirements`) and Inspector 2.5.0.
- **Conformance baselines**: `conformance-baseline-2026-07-28.yml` (36 scored failures) and `conformance-baseline-2025-11-25.yml` (22). One file per requirement set, because a scenario can pass on one wire and fail on the other and a passing baseline entry counts as stale.

### Code

- Protocol constants once in `MCPServer.Types` (`JSONRPC_*`, `MCP_ERROR_*`, revisions, `_meta` keys, cacheable methods); `MCPServer.JsonRpcProcessor` keeps aliases so consumers compile unchanged.
- Atomic counters in `TServerStatusResource` and for the SSE event id; `TMCPRegistry` uses a class constructor; "register before Start/Run" documented.
- `TMCPStdioTransport.Create` forces stderr logging and sets `TLogger.StdoutReserved`.
- Fixes: `logs://recent` freed its entries twice; `TMCPSerializer` wrote lists as `{"count":…,"capacity":…}` instead of arrays; `server://status` was never registered; `resources/read` without `params` and `tools/call` without `arguments` dereferenced nil.
- `CHANGELOG.md`, README library checklist and test section.

### Verified on Windows (Studio 37.0, Win64 Release build, curl 8.17)

| Observation | Result |
|---|---|
| Empty 202 in Indy | `Content-Type: text/html` with body `<HTML><BODY><B>202 Accepted</B></BODY></HTML>`. A GET with `Accept: text/event-stream` and `ContentText := ''` gets the `200 OK` HTML body, not an event stream. |
| Default `Bindings` | Listens on `0.0.0.0:port` and `[::]:port`. |
| Header names | `mcp-session-id` in lower case is read and echoed back. |
| stdin code page | `héllo wörld` sent as UTF-8 comes back as `hÃ©llo wÃ¶rld`. |
| `Connection` header | JSON and SSE responses carry `Connection: keep-alive` twice. |
| `Origin` with port | `Origin: http://127.0.0.1:3000` is rejected with 403 by the default allow-list (conformance `dns-rebinding-protection`). |
| stdio side effect | The server creates `settings.ini` next to the executable in stdio mode. |

### Runs

- `scripts\run-tests.ps1` Win64 and Win32: 58/58.
- `scripts\capture-http-goldens.ps1`: 26/26.
- `scripts\run-stdio-smoke.ps1`: passed.
- `scripts\run-conformance.ps1`: both requirement sets match their baselines.
- `scripts\run-inspector-smoke.ps1 -ExpectedFailures delphi-modern`: legacy, auto and stdio list 4 tools; modern fails (no `server/discover` yet).
