### PR TITLE
Dual-era JSON-RPC core: server/discover and per-request _meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,43 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-Test harness, golden files and hygiene. No client-visible protocol change.
-
 ### Added
 
+- MCP 2026-07-28 at the JSON-RPC layer, on both transports, next to the
+  initialize-based revisions 2025-06-18 and 2025-11-25. The era is decided per
+  request in `TMCPJsonRpcProcessor.BuildRequestContext`: `initialize` is always
+  legacy, a `params._meta` with `io.modelcontextprotocol/protocolVersion` is
+  modern, everything else is legacy.
+- `server/discover` (`MCPServer.CoreManager`): supported versions,
+  capabilities, `_meta.serverInfo`, optional `instructions`, `ttlMs` and
+  `cacheScope: "public"`.
+- Modern requests: `_meta` validation (`clientCapabilities` required,
+  `logLevel` checked, `-32602`), `-32022` with `data.supported` and
+  `data.requested` for an unknown revision, `-32020` when the HTTP header and
+  the body disagree, `-32601` for the legacy-only methods `ping`,
+  `logging/setLevel`, `resources/subscribe` and `resources/unsubscribe`.
+- Modern results carry `resultType: "complete"`,
+  `_meta.io.modelcontextprotocol/serverInfo` and, for the cacheable methods,
+  `ttlMs` and `cacheScope` when the handler did not set them.
+- `MCPServer.Errors` (`EMCPError` with code, data and HTTP status, plus
+  factories), `MCPServer.RequestContext` (`IMCPRequestContext`, thread-local
+  `TMCPRequestContext.Current`, `TMCPTransportHints`), `MCPServer.Capabilities`
+  (`TMCPCapabilityBuilder` derives the capabilities from the registered
+  managers), and the interfaces `IMCPCapabilityManagerEx`,
+  `IMCPCapabilityProvider`, `IMCPManagerEnumerator` and `IMCPRegistryAware` in
+  `MCPServer.Types`.
+- `TMCPJsonRpcProcessor.ProcessRequestEx` returns body, HTTP status and era;
+  `Create(Registry, Settings)` overload; `TMCPStdioTransport.Settings`.
+- `settings.ini`: `[Server] Title`, `Description`, `WebsiteUrl`,
+  `Instructions`; `[Protocol] LenientModernPing`,
+  `DiscoverListsLegacyVersions`, `DiscoverTtlMs`.
 - DUnitX test project `tests\MCPServer.Tests.dpr` (Win32 and Win64) with an
   in-process harness that builds the same registry as `MCPServer.dpr` and
-  drives `TMCPJsonRpcProcessor.ProcessRequest`.
-- Golden files that pin the wire behaviour: 38 JSON-RPC cases in
-  `tests\golden\legacy` and 26 HTTP transport cases (status line, headers,
-  body) in `tests\golden\http`.
+  drives the JSON-RPC processor; era-detection, processor, capability-builder
+  and concurrency tests.
+- Golden files that pin the wire behaviour: JSON-RPC cases for the legacy and
+  the modern era in `tests\golden\legacy` and `tests\golden\modern`, and HTTP
+  transport cases (status line, headers, body) in `tests\golden\http`.
 - `build-tests.bat` and `scripts\run-tests.ps1` (build and run, `-Record`
   to re-record goldens), `scripts\capture-http-goldens.ps1`.
 - `scripts\run-conformance.ps1` for the official conformance CLI with one
@@ -34,9 +61,25 @@ Test harness, golden files and hygiene. No client-visible protocol change.
   (`MCP_META_*`) and `MCP_CACHEABLE_METHODS`.
 - `TLogger.StdoutReserved`: while set, console logging always goes to stderr
   and `UseStdErr := False` is refused with a one-time warning.
+- README sections "Protocol Versions and Dual-Era Behaviour", the library
+  checklist and "Automated tests".
 
 ### Changed
 
+- `initialize` answers the requested revision when it is `2025-06-18` or
+  `2025-11-25`, otherwise `2025-11-25` (it always answered `2025-06-18`). The
+  result no longer contains the non-standard `sessionId` and the
+  `tools.supportsProgress` / `tools.supportsCancellation` keys;
+  `tools.listChanged: false` is added. No `Mcp-Session-Id` header is minted;
+  `TMCPCoreManager.SessionID` returns an empty string.
+- Message-shape errors use the JSON-RPC codes: `-32600` for batch arrays,
+  `id: null`, a missing or non-string `method` and a missing `jsonrpc`
+  (batch arrays were `-32700`, `id: null` was treated as a notification and
+  a missing `jsonrpc` was accepted); `-32602` for a `params` that is not an
+  object. Client responses (`result` or `error` without `method`) are ignored.
+- The `initialize` capabilities come from the registered managers
+  (`IMCPCapabilityProvider`); a registry with only a tools manager no longer
+  advertises resources.
 - The `JSONRPC_*` error-code constants are defined once in `MCPServer.Types`.
   `MCPServer.JsonRpcProcessor` keeps them as aliases, so existing consumer
   code compiles unchanged; the unused duplicate block in
@@ -49,9 +92,6 @@ Test harness, golden files and hygiene. No client-visible protocol change.
   `TLogger.StdoutReserved`. Library consumers that create the transport with
   console logging enabled and never set `UseStdErr` now get their log lines on
   stderr instead of corrupting the MCP channel on stdout.
-- README: library checklist (register before start, stdout rules for stdio,
-  `server://status` is opt-in), automated-tests section, resource list matches
-  what the executable registers.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Delphi](https://img.shields.io/badge/Delphi-12%2B-red)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey)
 ![License](https://img.shields.io/badge/license-MIT-blue)
-![MCP](https://img.shields.io/badge/MCP-2025--06--18-green)
+![MCP](https://img.shields.io/badge/MCP-2026--07--28%20(dual--era)-green)
 
 A Model Context Protocol (MCP) server implementation in Delphi, designed to integrate with Claude Code, Codex, and other MCP-compatible clients for AI-powered Delphi development workflows.
 
@@ -13,6 +13,7 @@ A Model Context Protocol (MCP) server implementation in Delphi, designed to inte
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Transport Modes](#transport-modes)
+- [Protocol Versions and Dual-Era Behaviour](#protocol-versions-and-dual-era-behaviour)
 - [Using as a Library](#using-as-a-library)
 - [Integration with Claude Code](#integration-with-claude-code)
 - [Integration with Codex](#integration-with-codex)
@@ -27,7 +28,7 @@ A Model Context Protocol (MCP) server implementation in Delphi, designed to inte
 
 ## Features
 
-- **Full MCP Protocol Support**: Implements MCP specification 2025-06-18 with Streamable HTTP and SSE
+- **Dual-era MCP**: Serves MCP 2026-07-28 (per-request `_meta`, `server/discover`) and the initialize-based revisions 2025-06-18 and 2025-11-25 on the same endpoint and the same stdio process; see [Protocol versions](#protocol-versions-and-dual-era-behaviour)
 - **Dual Transport Support**: HTTP (Streamable HTTP with SSE) and STDIO (stdin/stdout)
 - **Dual Response Mode**: Supports both JSON-RPC and Server-Sent Events in the same server
 - **Tool System**: Extensible tool system with RTTI-based discovery and execution
@@ -128,6 +129,25 @@ The server will:
 - Automated testing and scripting
 
 **Supported flag variants:** `--stdio`, `-stdio`, `/stdio`
+
+## Protocol Versions and Dual-Era Behaviour
+
+The server decides per request which protocol era it is speaking; nothing is negotiated per connection and no session is minted.
+
+| Request | Era | Served as |
+|---|---|---|
+| `initialize` | legacy | The requested revision when it is `2025-06-18` or `2025-11-25`, otherwise `2025-11-25`. The result carries `capabilities` and `serverInfo` only. |
+| `params._meta` with `io.modelcontextprotocol/protocolVersion` | modern | `2026-07-28`. `clientCapabilities` is required (`-32602`); an unknown revision gets `-32022` with the supported list; `ping`, `logging/setLevel` and `resources/subscribe` do not exist in this era (`-32601`). |
+| `server/discover` without `_meta` | modern, malformed | `-32602` |
+| Anything else | legacy | The revision negotiated by `initialize` on this stdio process, the `MCP-Protocol-Version` header on HTTP, or `2025-11-25` when nothing is known. |
+
+Modern results carry `resultType`, `_meta.io.modelcontextprotocol/serverInfo` and, on `server/discover`, `tools/list`, `resources/list`, `resources/templates/list` and `resources/read`, the cache hints `ttlMs` and `cacheScope`. Legacy results are unchanged. Client responses (`result` or `error` without `method`) are ignored.
+
+Handlers can read the era, the negotiated revision and the client's declared capabilities through `TMCPRequestContext.Current` (`MCPServer.RequestContext`) or by implementing `IMCPCapabilityManagerEx`, and can raise `EMCPError` (`MCPServer.Errors`) to send a specific JSON-RPC error code.
+
+`settings.ini` keys: `[Server] Title`, `Description`, `WebsiteUrl` and `Instructions` fill `serverInfo` and `instructions`; `[Protocol] LenientModernPing` answers `ping` in the modern era anyway, `DiscoverListsLegacyVersions` also lists the legacy revisions in `server/discover`, and `DiscoverTtlMs` is the cache hint on `server/discover`.
+
+`2025-03-26` is accepted on `initialize` but answered with `2025-11-25`; JSON-RPC batch arrays are rejected with `-32600`.
 
 ## Using as a Library
 
@@ -579,10 +599,10 @@ The `tests` folder holds a DUnitX project that drives the JSON-RPC layer in-proc
 .\scripts\capture-http-goldens.ps1          # replay the HTTP golden cases with curl against Win64\Debug\MCPServer.exe
 .\scripts\run-stdio-smoke.ps1               # drive --stdio and check the framing of stdout/stderr
 .\scripts\run-conformance.ps1               # official conformance CLI, 2026-07-28 and 2025-11-25 requirement sets
-.\scripts\run-inspector-smoke.ps1 -ExpectedFailures delphi-modern   # Inspector CLI tools/list per protocol era and over stdio
+.\scripts\run-inspector-smoke.ps1           # Inspector CLI tools/list per protocol era (legacy, auto, modern) and over stdio
 ```
 
-Known conformance failures are listed per requirement set in `conformance-baseline-<revision>.yml`; the conformance run fails on new failures and on entries that started to pass. The Inspector smoke run takes the entries that must fail as a parameter (`delphi-modern` as long as the server has no `server/discover`). `build-tests.bat [Config] [Platform]` compiles the test project on its own.
+Known conformance failures are listed per requirement set in `conformance-baseline-<revision>.yml`; the conformance run fails on new failures and on entries that started to pass. The Inspector smoke run takes entries that are expected to fail as `-ExpectedFailures`. `build-tests.bat [Config] [Platform]` compiles the test project on its own.
 
 ## About GDK Software
 

--- a/conformance-baseline-2026-07-28.yml
+++ b/conformance-baseline-2026-07-28.yml
@@ -4,18 +4,12 @@
 server:
   - server-stateless
   - completion-complete
-  - tools-list
-  - tools-call-simple-text
   - tools-call-image
   - tools-call-audio
   - tools-call-embedded-resource
   - tools-call-mixed-content
-  - tools-call-error
   - tools-call-with-progress
-  - resources-list
-  - resources-read-text
   - resources-read-binary
-  - resources-templates-read
   - sep-2164-resource-not-found
   - prompts-list
   - prompts-get-simple
@@ -30,11 +24,10 @@ server:
   - input-required-result-request-state
   - input-required-result-multiple-input-requests
   - input-required-result-multi-round
-  - input-required-result-missing-input-response
   - input-required-result-non-tool-request
   - input-required-result-result-type
-  - input-required-result-unsupported-methods
   - input-required-result-tampered-state
   - input-required-result-capability-check
-  - input-required-result-ignore-extra-params
+  # only WARNING checks (MRTR is not implemented); the runner counts them as not passed
+  - input-required-result-missing-input-response
   - input-required-result-validate-input

--- a/scripts/capture-http-goldens.ps1
+++ b/scripts/capture-http-goldens.ps1
@@ -113,8 +113,16 @@ try {
     $sseAccept = 'Accept: application/json, text/event-stream'
     $jsonType = 'Content-Type: application/json'
     $initialize = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"golden-client","version":"1.0.0"}}}'
+    $modernHeader = 'MCP-Protocol-Version: 2026-07-28'
+    $modernMeta = '"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"golden-client","version":"1.0.0"}}'
 
     $cases = @(
+        @{ Name = 'modern-discover';               Method = 'POST';    Headers = @($jsonType, $jsonAccept, $modernHeader); Body = '{"jsonrpc":"2.0","id":"d1","method":"server/discover","params":{' + $modernMeta + '}}' }
+        @{ Name = 'modern-tools-list';             Method = 'POST';    Headers = @($jsonType, $jsonAccept, $modernHeader); Body = '{"jsonrpc":"2.0","id":20,"method":"tools/list","params":{' + $modernMeta + '}}' }
+        @{ Name = 'modern-unknown-method';         Method = 'POST';    Headers = @($jsonType, $jsonAccept, $modernHeader); Body = '{"jsonrpc":"2.0","id":21,"method":"prompts/list","params":{' + $modernMeta + '}}' }
+        @{ Name = 'modern-missing-version-header'; Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":22,"method":"tools/list","params":{' + $modernMeta + '}}' }
+        @{ Name = 'modern-unsupported-version';    Method = 'POST';    Headers = @($jsonType, $jsonAccept, 'MCP-Protocol-Version: 1900-01-01'); Body = '{"jsonrpc":"2.0","id":23,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"1900-01-01","io.modelcontextprotocol/clientCapabilities":{}}}}' }
+        @{ Name = 'modern-missing-client-capabilities'; Method = 'POST'; Headers = @($jsonType, $jsonAccept, $modernHeader); Body = '{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}' }
         @{ Name = 'post-initialize';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = $initialize }
         @{ Name = 'post-initialize-sse';           Method = 'POST';    Headers = @($jsonType, $sseAccept);  Body = $initialize }
         @{ Name = 'post-tools-list';               Method = 'POST';    Headers = @($jsonType, $jsonAccept); Body = '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' }

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -8,6 +8,22 @@ Host=localhost
 Name=delphi-mcp-server
 Version=1.0.0
 Endpoint=/mcp
+; Optional identity reported to clients (initialize and server/discover)
+Title=
+Description=
+WebsiteUrl=
+; Optional guidance for LLM clients on how to use this server
+Instructions=
+
+[Protocol]
+; Boolean values: use 1 (true) or 0 (false)
+; Answer ping for MCP 2026-07-28 requests although that revision removed it
+LenientModernPing=0
+; Also list the initialize-based revisions (2025-06-18, 2025-11-25) in
+; server/discover and in unsupported-version errors
+DiscoverListsLegacyVersions=0
+; Cache hint (milliseconds) on server/discover results; 0 = immediately stale
+DiscoverTtlMs=0
 
 [CORS]
 ; Cross-Origin Resource Sharing configuration

--- a/src/Core/MCPServer.ManagerRegistry.pas
+++ b/src/Core/MCPServer.ManagerRegistry.pas
@@ -8,15 +8,18 @@ uses
   MCPServer.Types;
 
 type
-  TMCPManagerRegistry = class(TInterfacedObject, IMCPManagerRegistry)
+  /// Registration-ordered list of capability managers. Managers that
+  /// implement IMCPRegistryAware receive a reference to this registry.
+  TMCPManagerRegistry = class(TInterfacedObject, IMCPManagerRegistry, IMCPManagerEnumerator)
   private
     FManagers: TList<IMCPCapabilityManager>;
   public
     constructor Create;
     destructor Destroy; override;
-    
+
     procedure RegisterManager(const Manager: IMCPCapabilityManager);
     function GetManagerForMethod(const Method: string): IMCPCapabilityManager;
+    function GetManagers: TArray<IMCPCapabilityManager>;
   end;
 
 implementation
@@ -37,9 +40,15 @@ begin
 end;
 
 procedure TMCPManagerRegistry.RegisterManager(const Manager: IMCPCapabilityManager);
+var
+  Aware: IMCPRegistryAware;
 begin
-  if not FManagers.Contains(Manager) then
-    FManagers.Add(Manager);
+  if FManagers.Contains(Manager) then
+    Exit;
+
+  FManagers.Add(Manager);
+  if Supports(Manager, IMCPRegistryAware, Aware) then
+    Aware.SetManagerRegistry(Self);
 end;
 
 function TMCPManagerRegistry.GetManagerForMethod(const Method: string): IMCPCapabilityManager;
@@ -55,6 +64,11 @@ begin
       Break;
     end;
   end;
+end;
+
+function TMCPManagerRegistry.GetManagers: TArray<IMCPCapabilityManager>;
+begin
+  Result := FManagers.ToArray;
 end;
 
 end.

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -22,8 +22,15 @@ type
     FSSLCertFile: string;
     FSSLKeyFile: string;
     FSSLRootCertFile: string;
+    FServerTitle: string;
+    FServerDescription: string;
+    FServerWebsiteUrl: string;
+    FInstructions: string;
+    FLenientModernPing: Boolean;
+    FDiscoverListsLegacyVersions: Boolean;
+    FDiscoverTtlMs: Integer;
     function GetProtocol: string;
-    
+
     procedure LoadDefaults;
     procedure CreateDefaultSettingsFile;
   public
@@ -46,6 +53,22 @@ type
     property SSLCertFile: string read FSSLCertFile write FSSLCertFile;
     property SSLKeyFile: string read FSSLKeyFile write FSSLKeyFile;
     property SSLRootCertFile: string read FSSLRootCertFile write FSSLRootCertFile;
+
+    // Optional server identity ([Server] Title, Description, WebsiteUrl,
+    // Instructions); reported in initialize and server/discover when set.
+    property ServerTitle: string read FServerTitle write FServerTitle;
+    property ServerDescription: string read FServerDescription write FServerDescription;
+    property ServerWebsiteUrl: string read FServerWebsiteUrl write FServerWebsiteUrl;
+    property Instructions: string read FInstructions write FInstructions;
+
+    /// [Protocol] LenientModernPing: answer ping for 2026-07-28 requests
+    /// although the revision removed it. Default off.
+    property LenientModernPing: Boolean read FLenientModernPing write FLenientModernPing;
+    /// [Protocol] DiscoverListsLegacyVersions: also list the initialize-based
+    /// revisions in server/discover and in unsupported-version errors. Default off.
+    property DiscoverListsLegacyVersions: Boolean read FDiscoverListsLegacyVersions write FDiscoverListsLegacyVersions;
+    /// [Protocol] DiscoverTtlMs: cache hint on server/discover. Default 0.
+    property DiscoverTtlMs: Integer read FDiscoverTtlMs write FDiscoverTtlMs;
   end;
 
 implementation
@@ -93,6 +116,13 @@ begin
   FSSLCertFile := '';
   FSSLKeyFile := '';
   FSSLRootCertFile := '';
+  FServerTitle := '';
+  FServerDescription := '';
+  FServerWebsiteUrl := '';
+  FInstructions := '';
+  FLenientModernPing := False;
+  FDiscoverListsLegacyVersions := False;
+  FDiscoverTtlMs := 0;
 end;
 
 function TMCPSettings.GetProtocol: string;
@@ -115,7 +145,17 @@ begin
     IniFile.WriteString('Server', 'Name', FServerName);
     IniFile.WriteString('Server', 'Version', FServerVersion);
     IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    
+    IniFile.WriteString('Server', '; Optional identity reported to clients', '');
+    IniFile.WriteString('Server', 'Title', FServerTitle);
+    IniFile.WriteString('Server', 'Description', FServerDescription);
+    IniFile.WriteString('Server', 'WebsiteUrl', FServerWebsiteUrl);
+    IniFile.WriteString('Server', 'Instructions', FInstructions);
+
+    IniFile.WriteString('Protocol', '; Protocol options (1 = on, 0 = off)', '');
+    IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
+    IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    IniFile.WriteInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+
     IniFile.WriteString('CORS', '; Cross-Origin Resource Sharing configuration', '');
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', '; Comma-separated list of allowed origins', '');
@@ -145,7 +185,15 @@ begin
     FServerName := IniFile.ReadString('Server', 'Name', FServerName);
     FServerVersion := IniFile.ReadString('Server', 'Version', FServerVersion);
     FEndpoint := IniFile.ReadString('Server', 'Endpoint', FEndpoint);
-    
+    FServerTitle := IniFile.ReadString('Server', 'Title', FServerTitle);
+    FServerDescription := IniFile.ReadString('Server', 'Description', FServerDescription);
+    FServerWebsiteUrl := IniFile.ReadString('Server', 'WebsiteUrl', FServerWebsiteUrl);
+    FInstructions := IniFile.ReadString('Server', 'Instructions', FInstructions);
+
+    FLenientModernPing := IniFile.ReadBool('Protocol', 'LenientModernPing', FLenientModernPing);
+    FDiscoverListsLegacyVersions := IniFile.ReadBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    FDiscoverTtlMs := IniFile.ReadInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+
     FCorsEnabled := IniFile.ReadBool('CORS', 'Enabled', FCorsEnabled);
     FCorsAllowedOrigins := IniFile.ReadString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
     
@@ -181,7 +229,15 @@ begin
     IniFile.WriteString('Server', 'Name', FServerName);
     IniFile.WriteString('Server', 'Version', FServerVersion);
     IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    
+    IniFile.WriteString('Server', 'Title', FServerTitle);
+    IniFile.WriteString('Server', 'Description', FServerDescription);
+    IniFile.WriteString('Server', 'WebsiteUrl', FServerWebsiteUrl);
+    IniFile.WriteString('Server', 'Instructions', FInstructions);
+
+    IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
+    IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    IniFile.WriteInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
     

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -12,6 +12,9 @@ uses
   Posix.Signal,
   {$ENDIF}
   MCPServer.Types in 'Protocol\MCPServer.Types.pas',
+  MCPServer.Errors in 'Protocol\MCPServer.Errors.pas',
+  MCPServer.RequestContext in 'Protocol\MCPServer.RequestContext.pas',
+  MCPServer.Capabilities in 'Protocol\MCPServer.Capabilities.pas',
   MCPServer.Serializer in 'Protocol\MCPServer.Serializer.pas',
   MCPServer.Schema.Generator in 'Protocol\MCPServer.Schema.Generator.pas',
   MCPServer.Logger in 'Core\MCPServer.Logger.pas',
@@ -133,6 +136,7 @@ begin
 
   StdioTransport := TMCPStdioTransport.Create(ManagerRegistry, CoreManager);
   try
+    StdioTransport.Settings := Settings;
     StdioTransport.Run;
   finally
     StdioTransport.Free;

--- a/src/MCPServer.dproj
+++ b/src/MCPServer.dproj
@@ -129,6 +129,9 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="Protocol\MCPServer.Types.pas"/>
+        <DCCReference Include="Protocol\MCPServer.Errors.pas"/>
+        <DCCReference Include="Protocol\MCPServer.RequestContext.pas"/>
+        <DCCReference Include="Protocol\MCPServer.Capabilities.pas"/>
         <DCCReference Include="Protocol\MCPServer.Serializer.pas"/>
         <DCCReference Include="Protocol\MCPServer.Schema.Generator.pas"/>
         <DCCReference Include="Core\MCPServer.Logger.pas"/>

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -6,30 +6,50 @@ uses
   System.SysUtils,
   System.JSON,
   System.Rtti,
-  System.DateUtils,
   MCPServer.Types,
   MCPServer.Settings,
   MCPServer.Logger;
 
 type
-  TMCPCoreManager = class(TInterfacedObject, IMCPCapabilityManager)
+  /// Lifecycle methods: server/discover for modern clients, initialize and
+  /// ping for legacy clients. Holds no per-client state.
+  TMCPCoreManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPRegistryAware)
   private
-    FSessionID: string;
     FSettings: TMCPSettings;
+    [Weak] FManagerRegistry: IMCPManagerRegistry;
+    function GetSessionID: string;
+    function BuildServerInfo: TJSONObject;
+    function BuildCapabilities(Era: TMCPProtocolEra): TJSONObject;
+    function SupportedVersions: TJSONArray;
+    procedure LogClientInfo(const ClientInfo: TJSONValue);
+    procedure WarnAboutDeprecatedClientCapabilities(const Capabilities: TJSONValue);
   public
     constructor Create(ASettings: TMCPSettings);
-    
+
     function GetCapabilityName: string;
     function HandlesMethod(const Method: string): Boolean;
     function ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
-    
-    function Initialize(const Params: TJSONObject): TValue;
+    function ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
+      const Context: IMCPRequestContext): TValue;
+    procedure SetManagerRegistry(const Registry: IMCPManagerRegistry);
+
+    function Initialize(const Params: TJSONObject; const Context: IMCPRequestContext): TValue;
+    function Discover(const Context: IMCPRequestContext): TValue;
     function Ping: TValue;
-    
-    property SessionID: string read FSessionID;
+
+    /// Sessions are no longer minted; always empty. Kept for consumers.
+    property SessionID: string read GetSessionID;
+    property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
   end;
 
 implementation
+
+uses
+  MCPServer.Capabilities,
+  MCPServer.RequestContext;
+
+const
+  CACHE_SCOPE_PUBLIC = 'public';
 
 { TMCPCoreManager }
 
@@ -37,7 +57,6 @@ constructor TMCPCoreManager.Create(ASettings: TMCPSettings);
 begin
   inherited Create;
   FSettings := ASettings;
-  FSessionID := '';
 end;
 
 function TMCPCoreManager.GetCapabilityName: string;
@@ -45,17 +64,34 @@ begin
   Result := 'core';
 end;
 
+function TMCPCoreManager.GetSessionID: string;
+begin
+  Result := '';
+end;
+
+procedure TMCPCoreManager.SetManagerRegistry(const Registry: IMCPManagerRegistry);
+begin
+  FManagerRegistry := Registry;
+end;
+
 function TMCPCoreManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'initialize') or 
+  Result := (Method = 'initialize') or
             (Method = 'notifications/initialized') or
-            (Method = 'ping');
+            (Method = 'ping') or
+            (Method = 'server/discover');
 end;
 
 function TMCPCoreManager.ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
 begin
+  Result := ExecuteMethodWithContext(Method, Params, TMCPRequestContext.Current);
+end;
+
+function TMCPCoreManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
+  const Context: IMCPRequestContext): TValue;
+begin
   if Method = 'initialize' then
-    Result := Initialize(Params)
+    Result := Initialize(Params, Context)
   else if Method = 'notifications/initialized' then
   begin
     TLogger.Info('MCP Initialized notification received');
@@ -63,75 +99,127 @@ begin
   end
   else if Method = 'ping' then
     Result := Ping
+  else if Method = 'server/discover' then
+    Result := Discover(Context)
   else
     raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
 end;
 
-function TMCPCoreManager.Initialize(const Params: TJSONObject): TValue;
+function TMCPCoreManager.BuildServerInfo: TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.AddPair('name', FSettings.ServerName);
+  Result.AddPair('version', FSettings.ServerVersion);
+  if FSettings.ServerTitle <> '' then
+    Result.AddPair('title', FSettings.ServerTitle);
+  if FSettings.ServerDescription <> '' then
+    Result.AddPair('description', FSettings.ServerDescription);
+  if FSettings.ServerWebsiteUrl <> '' then
+    Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
+end;
+
+function TMCPCoreManager.BuildCapabilities(Era: TMCPProtocolEra): TJSONObject;
+begin
+  Result := TMCPCapabilityBuilder.Build(FManagerRegistry, Era);
+end;
+
+function TMCPCoreManager.SupportedVersions: TJSONArray;
+begin
+  Result := TJSONArray.Create;
+  for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+    Result.Add(Version);
+  if FSettings.DiscoverListsLegacyVersions then
+    for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+      Result.Add(Version);
+end;
+
+procedure TMCPCoreManager.LogClientInfo(const ClientInfo: TJSONValue);
+begin
+  if not (ClientInfo is TJSONObject) then
+    Exit;
+
+  var ClientName := TJSONObject(ClientInfo).GetValue('name');
+  var ClientVersion := TJSONObject(ClientInfo).GetValue('version');
+  if Assigned(ClientName) and Assigned(ClientVersion) then
+    TLogger.Info(Format('Client: %s v%s', [ClientName.Value, ClientVersion.Value]));
+end;
+
+procedure TMCPCoreManager.WarnAboutDeprecatedClientCapabilities(const Capabilities: TJSONValue);
+begin
+  if not (Capabilities is TJSONObject) then
+    Exit;
+
+  for var Deprecated in ['roots', 'sampling'] do
+    if Assigned(TJSONObject(Capabilities).GetValue(Deprecated)) then
+      TLogger.Warning(Format('Client declares the %s capability; this server does not use it (deprecated in MCP 2026-07-28)', [Deprecated]));
+end;
+
+function TMCPCoreManager.Initialize(const Params: TJSONObject; const Context: IMCPRequestContext): TValue;
 var
-  Capabilities: TJSONObject;
-  ClientInfo: TJSONObject;
-  ClientName: TJSONValue;
-  ClientVersion: TJSONValue;
-  ResourcesCap: TJSONObject;
-  ResultJSON: TJSONObject;
-  ServerInfo: TJSONObject;
-  ToolsCap: TJSONObject;
+  Negotiated: string;
 begin
   TLogger.Info('MCP Initialize called');
-  
+
+  if Assigned(Context) then
+    Negotiated := Context.ProtocolVersion
+  else
+  begin
+    // Called outside the processor: negotiate from the params directly.
+    var Requested := '';
+    if Assigned(Params) then
+    begin
+      var RequestedValue := Params.GetValue('protocolVersion');
+      if RequestedValue is TJSONString then
+        Requested := TJSONString(RequestedValue).Value;
+    end;
+    Negotiated := NegotiateLegacyProtocolVersion(Requested);
+  end;
+
   if Assigned(Params) then
   begin
-    ClientInfo := Params.GetValue('clientInfo') as TJSONObject;
-
-    if Assigned(ClientInfo) then
-    begin
-      ClientName := ClientInfo.GetValue('name');
-      ClientVersion := ClientInfo.GetValue('version');
-
-      if Assigned(ClientName) and Assigned(ClientVersion) then
-        TLogger.Info(Format('Client: %s v%s', [ClientName.Value, ClientVersion.Value]));
-    end;
+    LogClientInfo(Params.GetValue('clientInfo'));
+    WarnAboutDeprecatedClientCapabilities(Params.GetValue('capabilities'));
   end;
-  
-  FSessionID := TGuid.NewGuid.ToString;
-  
-  ResultJSON := TJSONObject.Create;
+
+  var ResultJSON := TJSONObject.Create;
   try
-    ResultJSON.AddPair('protocolVersion', MCP_PROTOCOL_VERSION);
-    
-    Capabilities := TJSONObject.Create;
-    ResultJSON.AddPair('capabilities', Capabilities);
-    
-    ToolsCap := TJSONObject.Create;
-    Capabilities.AddPair('tools', ToolsCap);
-{$IF COMPILERVERSION <= 29}
-    ToolsCap.AddPair('supportsProgress', TJSONFalse.Create);
-    ToolsCap.AddPair('supportsCancellation', TJSONFalse.Create);
-{$ELSE}
-    ToolsCap.AddPair('supportsProgress', TJSONBool.Create(False));
-    ToolsCap.AddPair('supportsCancellation', TJSONBool.Create(False));
-{$ENDIF}
-    
-    ResourcesCap := TJSONObject.Create;
-    Capabilities.AddPair('resources', ResourcesCap);
-{$IF COMPILERVERSION <= 29}
-    ResourcesCap.AddPair('subscribe', TJSONFalse.Create);
-    ResourcesCap.AddPair('listChanged', TJSONFalse.Create);
-{$ELSE}
-    ResourcesCap.AddPair('subscribe', TJSONBool.Create(False));
-    ResourcesCap.AddPair('listChanged', TJSONBool.Create(False));
-{$ENDIF}
-    
-    ResultJSON.AddPair('sessionId', FSessionID);
-    
-    ServerInfo := TJSONObject.Create;
-    ResultJSON.AddPair('serverInfo', ServerInfo);
-    ServerInfo.AddPair('name', FSettings.ServerName);
-    ServerInfo.AddPair('version', FSettings.ServerVersion);
-    
-    TLogger.Info('Created new MCP session: ' + FSessionID);
-    
+    ResultJSON.AddPair('protocolVersion', Negotiated);
+    ResultJSON.AddPair('capabilities', BuildCapabilities(TMCPProtocolEra.Legacy));
+    ResultJSON.AddPair('serverInfo', BuildServerInfo);
+    if FSettings.Instructions <> '' then
+      ResultJSON.AddPair('instructions', FSettings.Instructions);
+
+    // stdio remembers the negotiated revision for later legacy requests.
+    if Assigned(Context) and Assigned(Context.LegacySession) then
+      Context.LegacySession.ProtocolVersion := Negotiated;
+
+    TLogger.Info('Negotiated protocol version ' + Negotiated);
+    Result := TValue.From<TJSONObject>(ResultJSON);
+  except
+    ResultJSON.Free;
+    raise;
+  end;
+end;
+
+function TMCPCoreManager.Discover(const Context: IMCPRequestContext): TValue;
+begin
+  TLogger.Info('MCP Discover called');
+
+  var ResultJSON := TJSONObject.Create;
+  try
+    ResultJSON.AddPair('resultType', 'complete');
+    ResultJSON.AddPair('supportedVersions', SupportedVersions);
+    ResultJSON.AddPair('capabilities', BuildCapabilities(TMCPProtocolEra.Modern));
+
+    var Meta := TJSONObject.Create;
+    ResultJSON.AddPair('_meta', Meta);
+    Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
+
+    if FSettings.Instructions <> '' then
+      ResultJSON.AddPair('instructions', FSettings.Instructions);
+    ResultJSON.AddPair('ttlMs', TJSONNumber.Create(FSettings.DiscoverTtlMs));
+    ResultJSON.AddPair('cacheScope', CACHE_SCOPE_PUBLIC);
+
     Result := TValue.From<TJSONObject>(ResultJSON);
   except
     ResultJSON.Free;
@@ -140,18 +228,9 @@ begin
 end;
 
 function TMCPCoreManager.Ping: TValue;
-var
-  ResultJSON: TJSONObject;
 begin
   TLogger.Info('MCP Ping called');
-  
-  ResultJSON := TJSONObject.Create;
-  try
-    Result := TValue.From<TJSONObject>(ResultJSON);
-  except
-    ResultJSON.Free;
-    raise;
-  end;
+  Result := TValue.From<TJSONObject>(TJSONObject.Create);
 end;
 
 end.

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -13,7 +13,7 @@ uses
   MCPServer.Resource.Base;
 
 type
-  TMCPResourcesManager = class(TInterfacedObject, IMCPCapabilityManager)
+  TMCPResourcesManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityProvider)
   private
     FResources: TDictionary<string, IMCPResource>;
     procedure RegisterResource(const Resource: IMCPResource);
@@ -25,7 +25,8 @@ type
     function GetCapabilityName: string;
     function HandlesMethod(const Method: string): Boolean;
     function ExecuteMethod(const Method: string; const Params: System.JSON.TJSONObject): TValue;
-    
+    procedure DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
+
     function ListResources: TValue;
     function ReadResource(const Params: System.JSON.TJSONObject): TValue;
     function ListResourceTemplates: TValue;
@@ -58,9 +59,17 @@ end;
 
 function TMCPResourcesManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'resources/list') or 
-            (Method = 'resources/read') or 
+  Result := (Method = 'resources/list') or
+            (Method = 'resources/read') or
             (Method = 'resources/templates/list');
+end;
+
+procedure TMCPResourcesManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
+begin
+  var Resources := TJSONObject.Create;
+  Resources.AddPair('subscribe', TJSONBool.Create(False));
+  Resources.AddPair('listChanged', TJSONBool.Create(False));
+  Capabilities.AddPair('resources', Resources);
 end;
 
 function TMCPResourcesManager.ExecuteMethod(const Method: string; const Params: System.JSON.TJSONObject): TValue;

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -13,7 +13,7 @@ uses
   MCPServer.Tool.Base;
 
 type
-  TMCPToolsManager = class(TInterfacedObject, IMCPCapabilityManager)
+  TMCPToolsManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityProvider)
   strict private
     function ExtractToolNameAndArguments(const Params: System.JSON.TJSONObject; out ToolName: string; out Arguments: TJSONObject): Boolean;
     function ExecuteTool(const Tool: IMCPTool; const Arguments: TJSONObject): TValue;
@@ -31,7 +31,8 @@ type
     function GetCapabilityName: string;
     function HandlesMethod(const Method: string): Boolean;
     function ExecuteMethod(const Method: string; const Params: System.JSON.TJSONObject): TValue;
-    
+    procedure DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
+
     function ListTools: TValue;
     function CallTool(const Params: System.JSON.TJSONObject): TValue;
   end;
@@ -64,6 +65,13 @@ end;
 function TMCPToolsManager.HandlesMethod(const Method: string): Boolean;
 begin
   Result := (Method = 'tools/list') or (Method = 'tools/call');
+end;
+
+procedure TMCPToolsManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
+begin
+  var Tools := TJSONObject.Create;
+  Tools.AddPair('listChanged', TJSONBool.Create(False));
+  Capabilities.AddPair('tools', Tools);
 end;
 
 function TMCPToolsManager.ExecuteMethod(const Method: string; const Params: System.JSON.TJSONObject): TValue;

--- a/src/Protocol/MCPServer.Capabilities.pas
+++ b/src/Protocol/MCPServer.Capabilities.pas
@@ -1,0 +1,62 @@
+unit MCPServer.Capabilities;
+
+interface
+
+uses
+  System.JSON,
+  MCPServer.Types;
+
+type
+  /// Derives the server capabilities from the registered managers.
+  ///
+  /// Every manager that implements IMCPCapabilityProvider adds its own entry.
+  /// A registry that cannot enumerate its managers yields the built-in
+  /// defaults (tools and resources). The logging capability is never emitted.
+  TMCPCapabilityBuilder = class
+  public
+    class function Build(const Registry: IMCPManagerRegistry; Era: TMCPProtocolEra): TJSONObject;
+    class procedure AddDefaultCapabilities(const Capabilities: TJSONObject);
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+{ TMCPCapabilityBuilder }
+
+class procedure TMCPCapabilityBuilder.AddDefaultCapabilities(const Capabilities: TJSONObject);
+begin
+  var Tools := TJSONObject.Create;
+  Tools.AddPair('listChanged', TJSONBool.Create(False));
+  Capabilities.AddPair('tools', Tools);
+
+  var Resources := TJSONObject.Create;
+  Resources.AddPair('subscribe', TJSONBool.Create(False));
+  Resources.AddPair('listChanged', TJSONBool.Create(False));
+  Capabilities.AddPair('resources', Resources);
+end;
+
+class function TMCPCapabilityBuilder.Build(const Registry: IMCPManagerRegistry; Era: TMCPProtocolEra): TJSONObject;
+var
+  Enumerator: IMCPManagerEnumerator;
+  Provider: IMCPCapabilityProvider;
+begin
+  Result := TJSONObject.Create;
+  try
+    if not Supports(Registry, IMCPManagerEnumerator, Enumerator) then
+    begin
+      AddDefaultCapabilities(Result);
+      Exit;
+    end;
+
+    for var Manager in Enumerator.GetManagers do
+      if Supports(Manager, IMCPCapabilityProvider, Provider) then
+        Provider.DescribeCapabilities(Result, Era);
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+end.

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -1,0 +1,131 @@
+unit MCPServer.Errors;
+
+interface
+
+uses
+  System.SysUtils,
+  System.JSON;
+
+type
+  /// A JSON-RPC error a handler or the processor wants to send back.
+  ///
+  /// Code and Message become the error object; Data (owned, optional) becomes
+  /// error.data. HttpStatus is the status a modern HTTP response must carry;
+  /// 0 leaves the decision to the processor's status policy.
+  EMCPError = class(Exception)
+  private
+    FCode: Integer;
+    FData: TJSONValue;
+    FHttpStatus: Integer;
+  public
+    constructor Create(ACode: Integer; const AMessage: string; AData: TJSONValue = nil;
+      AHttpStatus: Integer = 0); reintroduce;
+    destructor Destroy; override;
+
+    /// Hands the data object to the caller; the exception no longer owns it.
+    function DetachData: TJSONValue;
+
+    class function ParseError(const AMessage: string): EMCPError;
+    class function InvalidRequest(const AMessage: string): EMCPError;
+    class function MethodNotFound(const Method: string): EMCPError;
+    class function InvalidParams(const AMessage: string; AData: TJSONValue = nil): EMCPError;
+    class function InternalError(const AMessage: string): EMCPError;
+    /// -32020 (HTTP 400): headers missing or different from the body.
+    class function HeaderMismatch(const AMessage: string): EMCPError;
+    /// -32021 (HTTP 400): the client did not declare a capability the request needs.
+    class function MissingRequiredClientCapability(const RequiredCapabilities: TJSONObject): EMCPError;
+    /// -32022 (HTTP 400): the requested revision is not served.
+    class function UnsupportedProtocolVersion(const Requested: string; const Supported: TArray<string>): EMCPError;
+
+    property Code: Integer read FCode;
+    property Data: TJSONValue read FData;
+    property HttpStatus: Integer read FHttpStatus write FHttpStatus;
+  end;
+
+const
+  HTTP_STATUS_OK = 200;
+  HTTP_STATUS_ACCEPTED = 202;
+  HTTP_STATUS_BAD_REQUEST = 400;
+  HTTP_STATUS_NOT_FOUND = 404;
+
+implementation
+
+uses
+  MCPServer.Types;
+
+{ EMCPError }
+
+constructor EMCPError.Create(ACode: Integer; const AMessage: string; AData: TJSONValue; AHttpStatus: Integer);
+begin
+  inherited Create(AMessage);
+  FCode := ACode;
+  FData := AData;
+  FHttpStatus := AHttpStatus;
+end;
+
+destructor EMCPError.Destroy;
+begin
+  FData.Free;
+  inherited;
+end;
+
+function EMCPError.DetachData: TJSONValue;
+begin
+  Result := FData;
+  FData := nil;
+end;
+
+class function EMCPError.ParseError(const AMessage: string): EMCPError;
+begin
+  Result := EMCPError.Create(JSONRPC_PARSE_ERROR, AMessage);
+end;
+
+class function EMCPError.InvalidRequest(const AMessage: string): EMCPError;
+begin
+  Result := EMCPError.Create(JSONRPC_INVALID_REQUEST, AMessage);
+end;
+
+class function EMCPError.MethodNotFound(const Method: string): EMCPError;
+begin
+  Result := EMCPError.Create(JSONRPC_METHOD_NOT_FOUND,
+    Format('Method [%s] not found. The method does not exist or is not available.', [Method]));
+end;
+
+class function EMCPError.InvalidParams(const AMessage: string; AData: TJSONValue): EMCPError;
+begin
+  Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, AMessage, AData);
+end;
+
+class function EMCPError.InternalError(const AMessage: string): EMCPError;
+begin
+  Result := EMCPError.Create(JSONRPC_INTERNAL_ERROR, AMessage);
+end;
+
+class function EMCPError.HeaderMismatch(const AMessage: string): EMCPError;
+begin
+  Result := EMCPError.Create(MCP_ERROR_HEADER_MISMATCH, AMessage, nil, HTTP_STATUS_BAD_REQUEST);
+end;
+
+class function EMCPError.MissingRequiredClientCapability(const RequiredCapabilities: TJSONObject): EMCPError;
+begin
+  var Data := TJSONObject.Create;
+  Data.AddPair('requiredCapabilities', RequiredCapabilities);
+  Result := EMCPError.Create(MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY,
+    'Missing required client capability', Data, HTTP_STATUS_BAD_REQUEST);
+end;
+
+class function EMCPError.UnsupportedProtocolVersion(const Requested: string; const Supported: TArray<string>): EMCPError;
+begin
+  var SupportedArray := TJSONArray.Create;
+  for var Version in Supported do
+    SupportedArray.Add(Version);
+
+  var Data := TJSONObject.Create;
+  Data.AddPair('supported', SupportedArray);
+  Data.AddPair('requested', Requested);
+
+  Result := EMCPError.Create(MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION,
+    'Unsupported protocol version', Data, HTTP_STATUS_BAD_REQUEST);
+end;
+
+end.

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -7,21 +7,70 @@ uses
   System.JSON,
   System.Rtti,
   MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.RequestContext,
+  MCPServer.Errors,
   MCPServer.Logger;
 
 type
+  /// Outcome of one JSON-RPC message. Body is empty when nothing must be
+  /// sent back (notifications, client responses). HttpStatus is the status
+  /// a Streamable HTTP transport should answer with.
+  TMCPProcessResult = record
+    Body: string;
+    HttpStatus: Integer;
+    Era: TMCPProtocolEra;
+    IsNotification: Boolean;
+  end;
+
+  /// Transport-independent JSON-RPC pipeline: parse, validate the message
+  /// shape, detect the protocol era, dispatch to the owning manager, shape
+  /// the result for the era and decide the HTTP status.
   TMCPJsonRpcProcessor = class
   private
     FManagerRegistry: IMCPManagerRegistry;
-    class function ParseJSONRequest(const RequestBody: string): TJSONObject;
-    class function ExtractRequestID(JSONRequest: TJSONObject): TValue;
-    class function CreateJSONResponse(const RequestID: TValue): TJSONObject;
-    class procedure AddRequestIDToResponse(Response: TJSONObject; const RequestID: TValue);
-    class function ExecuteMethodCall(ManagerRegistry: IMCPManagerRegistry; const MethodName: string; Params: TJSONObject): TValue;
-    class function CreateErrorResponse(const RequestID: TValue; ErrorCode: Integer; const ErrorMessage: string): string;
+    FSettings: TMCPSettings;
+    FOwnsSettings: Boolean;
+    procedure SetSettings(const Value: TMCPSettings);
+    function SupportedModernVersions: TArray<string>;
+    function BuildServerInfo: TJSONObject;
+    function IsLegacyOnlyMethod(const Method: string): Boolean;
+    function IsModernOnlyMethod(const Method: string): Boolean;
+    function IsCacheableMethod(const Method: string): Boolean;
+    function EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
+    function EraFromMessage(const Method: string; const Params: TJSONObject;
+      const Hints: TMCPTransportHints): TMCPProtocolEra;
+    function ExtractMeta(const Params: TJSONObject): TJSONObject;
+    procedure ValidateModernMeta(const Meta: TJSONObject);
+    function ProcessNotification(const Method: string; const Params: TJSONObject;
+      const Hints: TMCPTransportHints): TMCPProcessResult;
+    function DispatchRequest(const Context: IMCPRequestContext; const Params: TJSONObject): TValue;
+    function ResultToJson(const Value: TValue; const Context: IMCPRequestContext): TJSONValue;
+    procedure ApplyModernEnvelope(const ResultObject: TJSONObject; const Method: string);
+    function StatusForError(Era: TMCPProtocolEra; const Error: EMCPError): Integer;
+    function ErrorResult(Era: TMCPProtocolEra; const RequestId: TMCPRequestId; const Error: EMCPError): TMCPProcessResult;
+    function ExceptionToError(Era: TMCPProtocolEra; const E: Exception): EMCPError;
   public
-    constructor Create(ManagerRegistry: IMCPManagerRegistry);
+    constructor Create(ManagerRegistry: IMCPManagerRegistry); overload;
+    constructor Create(ManagerRegistry: IMCPManagerRegistry; Settings: TMCPSettings); overload;
+    destructor Destroy; override;
+
+    /// Plain JSON-RPC layer without transport hints; returns the response body.
     function ProcessRequest(const RequestBody: string; const SessionID: string): string;
+    function ProcessRequestEx(const RequestBody: string; const Hints: TMCPTransportHints): TMCPProcessResult; overload;
+    /// Message is the already parsed body (nil when parsing failed); the
+    /// caller keeps ownership.
+    function ProcessRequestEx(const Message: TJSONValue; const Hints: TMCPTransportHints): TMCPProcessResult; overload;
+
+    /// Decides the era of a request and validates the modern _meta fields.
+    /// Raises EMCPError with the HTTP status a modern transport must use.
+    function BuildRequestContext(const Method: string; const Params: TJSONObject;
+      const RequestId: TMCPRequestId; const Hints: TMCPTransportHints): IMCPRequestContext;
+
+    property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
+    /// Server identity and protocol options. A processor created without
+    /// settings uses the defaults (settings.ini next to the executable when present).
+    property Settings: TMCPSettings read FSettings write SetSettings;
   end;
 
 const
@@ -36,193 +85,528 @@ const
 
 implementation
 
+const
+  JSONRPC_VERSION = '2.0';
+  RESULT_TYPE_COMPLETE = 'complete';
+  CACHE_SCOPE_PRIVATE = 'private';
+
+  /// Methods that only exist in the initialize-based revisions.
+  LEGACY_ONLY_METHODS: array[0..4] of string = (
+    'ping', 'initialize', 'logging/setLevel', 'resources/subscribe', 'resources/unsubscribe');
+  /// Methods that only exist with per-request _meta.
+  MODERN_ONLY_METHODS: array[0..1] of string = ('server/discover', 'subscriptions/listen');
+  LOG_LEVELS: array[0..7] of string = (
+    'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency');
+
+function InArray(const Value: string; const Values: array of string): Boolean;
+begin
+  for var Item in Values do
+    if Item = Value then
+      Exit(True);
+  Result := False;
+end;
+
 { TMCPJsonRpcProcessor }
 
 constructor TMCPJsonRpcProcessor.Create(ManagerRegistry: IMCPManagerRegistry);
 begin
+  Create(ManagerRegistry, nil);
+end;
+
+constructor TMCPJsonRpcProcessor.Create(ManagerRegistry: IMCPManagerRegistry; Settings: TMCPSettings);
+begin
   inherited Create;
   FManagerRegistry := ManagerRegistry;
+  SetSettings(Settings);
 end;
 
-class function TMCPJsonRpcProcessor.ParseJSONRequest(const RequestBody: string): TJSONObject;
-var
-  ParsedValue: TJSONValue;
+destructor TMCPJsonRpcProcessor.Destroy;
 begin
-  ParsedValue := TJSONObject.ParseJSONValue(RequestBody);
-  if not Assigned(ParsedValue) then
-    raise Exception.Create('Invalid JSON');
-
-  if not (ParsedValue is TJSONObject) then
-  begin
-    ParsedValue.Free;
-    raise Exception.Create('JSON-RPC request must be an object');
-  end;
-
-  Result := ParsedValue as TJSONObject;
+  if FOwnsSettings then
+    FSettings.Free;
+  inherited;
 end;
 
-class function TMCPJsonRpcProcessor.ExtractRequestID(JSONRequest: TJSONObject): TValue;
-var
-  IdValue: TJSONValue;
+procedure TMCPJsonRpcProcessor.SetSettings(const Value: TMCPSettings);
 begin
-  // JSONRequest is nil when the request body failed to parse; there is no id
-  // to extract. Without this guard the nil dereference surfaces as
-  // "Access violation ... Read of address 0000000000000010" for any
-  // syntactically invalid request.
-  if not Assigned(JSONRequest) then
-  begin
-    Result := TValue.Empty;
-    Exit;
-  end;
+  if FOwnsSettings then
+    FreeAndNil(FSettings);
+  FOwnsSettings := False;
 
-  IdValue := JSONRequest.GetValue('id');
-  if not Assigned(IdValue) then
-  begin
-    Result := TValue.Empty;
-    Exit;
-  end;
-
-  if IdValue is TJSONNumber then
-    Result := TValue.From<Int64>((IdValue as TJSONNumber).AsInt64)
-  else if IdValue is TJSONString then
-    Result := TValue.From<string>((IdValue as TJSONString).Value)
+  if Assigned(Value) then
+    FSettings := Value
   else
-    Result := TValue.Empty;
+  begin
+    FSettings := TMCPSettings.Create('', False);
+    FOwnsSettings := True;
+  end;
 end;
 
-class function TMCPJsonRpcProcessor.CreateJSONResponse(const RequestID: TValue): TJSONObject;
+function TMCPJsonRpcProcessor.SupportedModernVersions: TArray<string>;
+begin
+  Result := nil;
+  for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+    Result := Result + [Version];
+  if FSettings.DiscoverListsLegacyVersions then
+    for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+      Result := Result + [Version];
+end;
+
+function TMCPJsonRpcProcessor.BuildServerInfo: TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('jsonrpc', '2.0');
-  AddRequestIDToResponse(Result, RequestID);
+  Result.AddPair('name', FSettings.ServerName);
+  Result.AddPair('version', FSettings.ServerVersion);
+  if FSettings.ServerTitle <> '' then
+    Result.AddPair('title', FSettings.ServerTitle);
+  if FSettings.ServerDescription <> '' then
+    Result.AddPair('description', FSettings.ServerDescription);
+  if FSettings.ServerWebsiteUrl <> '' then
+    Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
 end;
 
-class procedure TMCPJsonRpcProcessor.AddRequestIDToResponse(Response: TJSONObject; const RequestID: TValue);
+function TMCPJsonRpcProcessor.IsLegacyOnlyMethod(const Method: string): Boolean;
 begin
-  if RequestID.IsEmpty then
+  Result := InArray(Method, LEGACY_ONLY_METHODS);
+  if Result and (Method = 'ping') and FSettings.LenientModernPing then
+    Result := False;
+end;
+
+function TMCPJsonRpcProcessor.IsModernOnlyMethod(const Method: string): Boolean;
+begin
+  Result := InArray(Method, MODERN_ONLY_METHODS);
+end;
+
+function TMCPJsonRpcProcessor.IsCacheableMethod(const Method: string): Boolean;
+begin
+  Result := InArray(Method, MCP_CACHEABLE_METHODS);
+end;
+
+function TMCPJsonRpcProcessor.EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
+begin
+  // Before the body is understood only the header can tell the era apart.
+  if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader
+    and IsModernProtocolVersion(Hints.ProtocolVersionHeader) then
+    Result := TMCPProtocolEra.Modern
+  else
+    Result := TMCPProtocolEra.Legacy;
+end;
+
+function TMCPJsonRpcProcessor.EraFromMessage(const Method: string; const Params: TJSONObject;
+  const Hints: TMCPTransportHints): TMCPProtocolEra;
+begin
+  // The era that decides the status of a rejected request: a body that
+  // names a protocol version in _meta is modern even when it fails validation.
+  Result := EraFromHeaders(Hints);
+  if (Result = TMCPProtocolEra.Modern) or (Method = 'initialize') or not Assigned(Params) then
+    Exit;
+
+  var MetaValue := Params.GetValue('_meta');
+  if (MetaValue is TJSONObject) and (TJSONObject(MetaValue).GetValue(MCP_META_PROTOCOL_VERSION) is TJSONString) then
+    Result := TMCPProtocolEra.Modern;
+end;
+
+function TMCPJsonRpcProcessor.ExtractMeta(const Params: TJSONObject): TJSONObject;
+begin
+  Result := nil;
+  if not Assigned(Params) then
+    Exit;
+
+  var MetaValue := Params.GetValue('_meta');
+  if not Assigned(MetaValue) then
+    Exit;
+  if not (MetaValue is TJSONObject) then
+    raise EMCPError.Create(JSONRPC_INVALID_PARAMS, 'params._meta must be an object', nil, HTTP_STATUS_BAD_REQUEST);
+  Result := TJSONObject(MetaValue);
+end;
+
+procedure TMCPJsonRpcProcessor.ValidateModernMeta(const Meta: TJSONObject);
+begin
+  var Capabilities := Meta.GetValue(MCP_META_CLIENT_CAPABILITIES);
+  if not (Capabilities is TJSONObject) then
+    raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
+      'params._meta.' + MCP_META_CLIENT_CAPABILITIES + ' is required and must be an object',
+      nil, HTTP_STATUS_BAD_REQUEST);
+
+  var ClientInfo := Meta.GetValue(MCP_META_CLIENT_INFO);
+  if Assigned(ClientInfo) and not (ClientInfo is TJSONObject) then
+    raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
+      'params._meta.' + MCP_META_CLIENT_INFO + ' must be an object', nil, HTTP_STATUS_BAD_REQUEST);
+
+  var LogLevel := Meta.GetValue(MCP_META_LOG_LEVEL);
+  if Assigned(LogLevel) and (not (LogLevel is TJSONString) or not InArray(TJSONString(LogLevel).Value, LOG_LEVELS)) then
+    raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
+      'params._meta.' + MCP_META_LOG_LEVEL + ' must be one of debug, info, notice, warning, error, critical, alert, emergency',
+      nil, HTTP_STATUS_BAD_REQUEST);
+end;
+
+function TMCPJsonRpcProcessor.BuildRequestContext(const Method: string; const Params: TJSONObject;
+  const RequestId: TMCPRequestId; const Hints: TMCPTransportHints): IMCPRequestContext;
+var
+  Version: string;
+begin
+  var Meta := ExtractMeta(Params);
+
+  // 1. initialize always selects the legacy era, whatever _meta says.
+  if Method = 'initialize' then
   begin
-    Response.AddPair('id', TJSONNull.Create);
+    var Requested := '';
+    if Assigned(Params) then
+    begin
+      var RequestedValue := Params.GetValue('protocolVersion');
+      if RequestedValue is TJSONString then
+        Requested := TJSONString(RequestedValue).Value;
+    end;
+    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Legacy, NegotiateLegacyProtocolVersion(Requested),
+      Method, RequestId, Meta, Hints.LegacySession, FManagerRegistry));
+  end;
+
+  // 2. A protocol version in _meta makes the request modern.
+  var VersionValue: TJSONValue := nil;
+  if Assigned(Meta) then
+    VersionValue := Meta.GetValue(MCP_META_PROTOCOL_VERSION);
+
+  if VersionValue is TJSONString then
+  begin
+    Version := TJSONString(VersionValue).Value;
+
+    if Hints.HasHeaderLayer then
+    begin
+      if not Hints.HasProtocolVersionHeader then
+        raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
+      if Hints.ProtocolVersionHeader <> Version then
+        raise EMCPError.HeaderMismatch(Format(
+          'Header mismatch: MCP-Protocol-Version header value ''%s'' does not match body value ''%s''',
+          [Hints.ProtocolVersionHeader, Version]));
+    end;
+
+    if not IsModernProtocolVersion(Version) then
+      raise EMCPError.UnsupportedProtocolVersion(Version, SupportedModernVersions);
+
+    ValidateModernMeta(Meta);
+
+    if IsLegacyOnlyMethod(Method) then
+    begin
+      var NotFound := EMCPError.MethodNotFound(Method);
+      NotFound.HttpStatus := HTTP_STATUS_NOT_FOUND;
+      raise NotFound;
+    end;
+
+    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta,
+      Hints.LegacySession, FManagerRegistry));
+  end;
+
+  // 3. A modern-only method without _meta is a malformed modern request.
+  if IsModernOnlyMethod(Method) then
+    raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
+      Format('%s requires params._meta.%s', [Method, MCP_META_PROTOCOL_VERSION]), nil, HTTP_STATUS_BAD_REQUEST);
+
+  // 4. On HTTP the header alone can still name the revision.
+  if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader then
+  begin
+    var Header := Hints.ProtocolVersionHeader;
+    if IsModernProtocolVersion(Header) then
+      raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
+        Format('MCP-Protocol-Version %s requires params._meta.%s', [Header, MCP_META_PROTOCOL_VERSION]),
+        nil, HTTP_STATUS_BAD_REQUEST);
+    if not IsLegacyProtocolVersion(Header) and (Header <> MCP_PROTOCOL_VERSION_2025_03_26) then
+      raise EMCPError.Create(JSONRPC_INVALID_REQUEST,
+        'Unsupported MCP-Protocol-Version header: ' + Header, nil, HTTP_STATUS_BAD_REQUEST);
+
+    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Legacy, Header, Method, RequestId, Meta,
+      Hints.LegacySession, FManagerRegistry));
+  end;
+
+  // 5. Legacy, with the version negotiated on this process when known.
+  Version := '';
+  if Assigned(Hints.LegacySession) then
+    Version := Hints.LegacySession.ProtocolVersion;
+  if Version = '' then
+    Version := MCP_LATEST_LEGACY_PROTOCOL_VERSION;
+
+  Result := TMCPRequestContext.Create(TMCPProtocolEra.Legacy, Version, Method, RequestId, Meta,
+    Hints.LegacySession, FManagerRegistry);
+end;
+
+function TMCPJsonRpcProcessor.ProcessNotification(const Method: string; const Params: TJSONObject;
+  const Hints: TMCPTransportHints): TMCPProcessResult;
+begin
+  Result.Body := '';
+  Result.HttpStatus := HTTP_STATUS_ACCEPTED;
+  Result.Era := EraFromHeaders(Hints);
+  Result.IsNotification := True;
+
+  TLogger.Info('Notification received: ' + Method);
+
+  var Manager: IMCPCapabilityManager := nil;
+  if Assigned(FManagerRegistry) then
+    Manager := FManagerRegistry.GetManagerForMethod(Method);
+  if not Assigned(Manager) then
+    Exit;
+
+  try
+    Manager.ExecuteMethod(Method, Params);
+  except
+    on E: Exception do
+      TLogger.Error('Notification ' + Method + ' failed: ' + E.Message);
+  end;
+end;
+
+function TMCPJsonRpcProcessor.DispatchRequest(const Context: IMCPRequestContext; const Params: TJSONObject): TValue;
+var
+  ManagerEx: IMCPCapabilityManagerEx;
+begin
+  if not Assigned(FManagerRegistry) then
+    raise EMCPError.InternalError('Manager registry not initialized');
+
+  var Manager := FManagerRegistry.GetManagerForMethod(Context.Method);
+  if not Assigned(Manager) then
+    raise EMCPError.MethodNotFound(Context.Method);
+
+  TMCPRequestContext.SetCurrent(Context);
+  try
+    if Supports(Manager, IMCPCapabilityManagerEx, ManagerEx) then
+      Result := ManagerEx.ExecuteMethodWithContext(Context.Method, Params, Context)
+    else
+      Result := Manager.ExecuteMethod(Context.Method, Params);
+  finally
+    TMCPRequestContext.SetCurrent(nil);
+  end;
+end;
+
+procedure TMCPJsonRpcProcessor.ApplyModernEnvelope(const ResultObject: TJSONObject; const Method: string);
+begin
+  if not Assigned(ResultObject.GetValue('resultType')) then
+    ResultObject.AddPair('resultType', RESULT_TYPE_COMPLETE);
+
+  var MetaValue := ResultObject.GetValue('_meta');
+  var Meta: TJSONObject := nil;
+  if MetaValue is TJSONObject then
+    Meta := TJSONObject(MetaValue)
+  else if not Assigned(MetaValue) then
+  begin
+    Meta := TJSONObject.Create;
+    ResultObject.AddPair('_meta', Meta);
+  end;
+  if Assigned(Meta) and not Assigned(Meta.GetValue(MCP_META_SERVER_INFO)) then
+    Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
+
+  var ResultType := ResultObject.GetValue('resultType');
+  if IsCacheableMethod(Method) and (ResultType is TJSONString)
+    and (TJSONString(ResultType).Value = RESULT_TYPE_COMPLETE) then
+  begin
+    if not Assigned(ResultObject.GetValue('ttlMs')) then
+      ResultObject.AddPair('ttlMs', TJSONNumber.Create(0));
+    if not Assigned(ResultObject.GetValue('cacheScope')) then
+      ResultObject.AddPair('cacheScope', CACHE_SCOPE_PRIVATE);
+  end;
+end;
+
+function TMCPJsonRpcProcessor.ResultToJson(const Value: TValue; const Context: IMCPRequestContext): TJSONValue;
+begin
+  if Context.Era = TMCPProtocolEra.Legacy then
+  begin
+    // Byte-for-byte what the initialize-based revisions always received.
+    if Value.IsEmpty then
+      Result := nil
+    else if Value.IsType<TJSONObject> then
+      Result := Value.AsType<TJSONObject>
+    else if Value.IsType<string> then
+      Result := TJSONString.Create(Value.AsString)
+    else
+      Result := TJSONString.Create(Value.ToString);
     Exit;
   end;
 
-  if RequestID.Kind in [tkString, tkUString, tkWString, tkLString] then
-    Response.AddPair('id', RequestID.AsString)
-  else if RequestID.Kind in [tkInteger, tkInt64] then
-    Response.AddPair('id', TJSONNumber.Create(RequestID.AsInt64))
+  // Modern results are always objects with a resultType.
+  var ResultObject: TJSONObject;
+  if Value.IsType<TJSONObject> then
+    ResultObject := Value.AsType<TJSONObject>
   else
-    Response.AddPair('id', TJSONNull.Create);
-end;
-
-class function TMCPJsonRpcProcessor.ExecuteMethodCall(ManagerRegistry: IMCPManagerRegistry;
-  const MethodName: string; Params: TJSONObject): TValue;
-var
-  Manager: IMCPCapabilityManager;
-begin
-  if not Assigned(ManagerRegistry) then
-    raise Exception.Create('Manager registry not initialized');
-
-  Manager := ManagerRegistry.GetManagerForMethod(MethodName);
-  if not Assigned(Manager) then
-    raise Exception.CreateFmt('Method [%s] not found. The method does not exist or is not available.', [MethodName]);
-
-  Result := Manager.ExecuteMethod(MethodName, Params);
-end;
-
-class function TMCPJsonRpcProcessor.CreateErrorResponse(const RequestID: TValue;
-  ErrorCode: Integer; const ErrorMessage: string): string;
-var
-  ErrorObj: TJSONObject;
-  JSONResponse: TJSONObject;
-begin
-  JSONResponse := CreateJSONResponse(RequestID);
-  try
-    ErrorObj := TJSONObject.Create;
-    JSONResponse.AddPair('error', ErrorObj);
-    ErrorObj.AddPair('code', TJSONNumber.Create(ErrorCode));
-    ErrorObj.AddPair('message', ErrorMessage);
-    Result := JSONResponse.ToJSON;
-  finally
-    JSONResponse.Free;
+  begin
+    ResultObject := TJSONObject.Create;
+    if not Value.IsEmpty then
+      ResultObject.AddPair('value', Value.ToString);
   end;
+
+  ApplyModernEnvelope(ResultObject, Context.Method);
+  Result := ResultObject;
+end;
+
+function TMCPJsonRpcProcessor.StatusForError(Era: TMCPProtocolEra; const Error: EMCPError): Integer;
+begin
+  // Legacy clients read 404 as "session terminated"; they always get 200.
+  if Era = TMCPProtocolEra.Legacy then
+    Exit(HTTP_STATUS_OK);
+
+  if Error.HttpStatus <> 0 then
+    Exit(Error.HttpStatus);
+
+  case Error.Code of
+    JSONRPC_PARSE_ERROR, JSONRPC_INVALID_REQUEST,
+    MCP_ERROR_HEADER_MISMATCH, MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY,
+    MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION:
+      Result := HTTP_STATUS_BAD_REQUEST;
+    JSONRPC_METHOD_NOT_FOUND:
+      Result := HTTP_STATUS_NOT_FOUND;
+  else
+    Result := HTTP_STATUS_OK;
+  end;
+end;
+
+function TMCPJsonRpcProcessor.ErrorResult(Era: TMCPProtocolEra; const RequestId: TMCPRequestId;
+  const Error: EMCPError): TMCPProcessResult;
+begin
+  TLogger.Error('Error processing request: ' + Error.Message);
+
+  var Response := TJSONObject.Create;
+  try
+    Response.AddPair('jsonrpc', JSONRPC_VERSION);
+    Response.AddPair('id', RequestId.ToJson);
+
+    var ErrorObject := TJSONObject.Create;
+    Response.AddPair('error', ErrorObject);
+    ErrorObject.AddPair('code', TJSONNumber.Create(Error.Code));
+    ErrorObject.AddPair('message', Error.Message);
+    if Assigned(Error.Data) then
+      ErrorObject.AddPair('data', Error.DetachData);
+
+    Result.Body := Response.ToJSON;
+  finally
+    Response.Free;
+  end;
+
+  Result.HttpStatus := StatusForError(Era, Error);
+  Result.Era := Era;
+  Result.IsNotification := False;
+end;
+
+function TMCPJsonRpcProcessor.ExceptionToError(Era: TMCPProtocolEra; const E: Exception): EMCPError;
+begin
+  // The text heuristic predates typed errors; legacy answers keep it.
+  if (Era = TMCPProtocolEra.Legacy) and (Pos('not found', E.Message) > 0) then
+    Result := EMCPError.Create(JSONRPC_METHOD_NOT_FOUND, E.Message)
+  else
+    Result := EMCPError.InternalError(E.Message);
 end;
 
 function TMCPJsonRpcProcessor.ProcessRequest(const RequestBody: string; const SessionID: string): string;
-var
-  ErrorCode: Integer;
-  ExecuteResult: TValue;
-  JSONRequest: TJSONObject;
-  JSONResponse: TJSONObject;
-  MethodName: string;
-  MethodValue: TJSONValue;
-  Params: TJSONObject;
-  ParamsValue: TJSONValue;
-  RequestID: TValue;
 begin
-  Result := '';
-  JSONRequest := nil;
-  JSONResponse := nil;
+  Result := ProcessRequestEx(RequestBody, TMCPTransportHints.None).Body;
+end;
+
+function TMCPJsonRpcProcessor.ProcessRequestEx(const RequestBody: string;
+  const Hints: TMCPTransportHints): TMCPProcessResult;
+begin
+  var Message := TJSONObject.ParseJSONValue(RequestBody);
+  try
+    Result := ProcessRequestEx(Message, Hints);
+  finally
+    Message.Free;
+  end;
+end;
+
+function TMCPJsonRpcProcessor.ProcessRequestEx(const Message: TJSONValue;
+  const Hints: TMCPTransportHints): TMCPProcessResult;
+var
+  RequestId: TMCPRequestId;
+  Era: TMCPProtocolEra;
+  Context: IMCPRequestContext;
+begin
+  RequestId := TMCPRequestId.FromJson(nil);
+  Era := EraFromHeaders(Hints);
+  Context := nil;
 
   try
     try
-      JSONRequest := ParseJSONRequest(RequestBody);
+      if not Assigned(Message) then
+        raise EMCPError.ParseError('Invalid JSON');
+      if Message is TJSONArray then
+        raise EMCPError.InvalidRequest('JSON-RPC batch requests are not supported');
+      if not (Message is TJSONObject) then
+        raise EMCPError.InvalidRequest('JSON-RPC message must be an object');
 
-      RequestID := ExtractRequestID(JSONRequest);
+      var Request := TJSONObject(Message);
 
-      MethodValue := JSONRequest.GetValue('method');
-      MethodName := '';
-      if Assigned(MethodValue) then
-        MethodName := MethodValue.Value;
-
-      // Notifications (requests without id) should not have a response
-      if RequestID.IsEmpty then
+      RequestId := TMCPRequestId.FromJson(Request.GetValue('id'));
+      if RequestId.Kind = TMCPRequestIdKind.Null then
+        raise EMCPError.InvalidRequest('id must not be null');
+      if RequestId.Kind = TMCPRequestIdKind.Invalid then
       begin
-        if MethodName = 'notifications/initialized' then
-          TLogger.Info('MCP Initialized notification received')
-        else
-          TLogger.Info('Notification received: ' + MethodName);
-        Exit;
+        RequestId := TMCPRequestId.FromJson(nil);
+        raise EMCPError.InvalidRequest('id must be a string or an integer');
       end;
 
-      JSONResponse := CreateJSONResponse(RequestID);
+      var JsonRpc := Request.GetValue('jsonrpc');
+      if not (JsonRpc is TJSONString) or (TJSONString(JsonRpc).Value <> JSONRPC_VERSION) then
+        raise EMCPError.InvalidRequest('jsonrpc must be "2.0"');
 
-      ParamsValue := JSONRequest.GetValue('params');
-      Params := nil;
-      if Assigned(ParamsValue) and (ParamsValue is TJSONObject) then
-        Params := ParamsValue as TJSONObject;
-
-      ExecuteResult := ExecuteMethodCall(FManagerRegistry, MethodName, Params);
-
-      if not ExecuteResult.IsEmpty then
+      var MethodValue := Request.GetValue('method');
+      if not (MethodValue is TJSONString) then
       begin
-        if ExecuteResult.IsType<TJSONObject> then
-          JSONResponse.AddPair('result', ExecuteResult.AsType<TJSONObject>)
-        else if ExecuteResult.IsType<string> then
-          JSONResponse.AddPair('result', ExecuteResult.AsString)
-        else
-          JSONResponse.AddPair('result', ExecuteResult.ToString);
+        // A message with result or error is a response sent by the client;
+        // it is never answered.
+        if Assigned(Request.GetValue('result')) or Assigned(Request.GetValue('error')) then
+        begin
+          if Era = TMCPProtocolEra.Modern then
+            raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
+          Result.Body := '';
+          Result.HttpStatus := HTTP_STATUS_ACCEPTED;
+          Result.Era := Era;
+          Result.IsNotification := True;
+          Exit;
+        end;
+        raise EMCPError.InvalidRequest('method must be a string');
+      end;
+      var Method := TJSONString(MethodValue).Value;
+
+      var ParamsValue := Request.GetValue('params');
+      var Params: TJSONObject := nil;
+      if Assigned(ParamsValue) then
+      begin
+        if not (ParamsValue is TJSONObject) then
+          raise EMCPError.InvalidParams('params must be an object');
+        Params := TJSONObject(ParamsValue);
       end;
 
-      Result := JSONResponse.ToJSON;
+      if RequestId.Kind = TMCPRequestIdKind.None then
+        Exit(ProcessNotification(Method, Params, Hints));
 
+      Era := EraFromMessage(Method, Params, Hints);
+      Context := BuildRequestContext(Method, Params, RequestId, Hints);
+      Era := Context.Era;
+
+      var ExecuteResult := DispatchRequest(Context, Params);
+
+      var Response := TJSONObject.Create;
+      try
+        Response.AddPair('jsonrpc', JSONRPC_VERSION);
+        Response.AddPair('id', RequestId.ToJson);
+        var ResultJson := ResultToJson(ExecuteResult, Context);
+        if Assigned(ResultJson) then
+          Response.AddPair('result', ResultJson);
+        Result.Body := Response.ToJSON;
+      finally
+        Response.Free;
+      end;
+      Result.HttpStatus := HTTP_STATUS_OK;
+      Result.Era := Era;
+      Result.IsNotification := False;
     except
+      on E: EMCPError do
+        Result := ErrorResult(Era, RequestId, E);
       on E: Exception do
       begin
-        TLogger.Error('Error processing request: ' + E.Message);
-
-        // If parsing failed, JSONRequest is still nil: report a JSON-RPC parse
-        // error (-32700). ExtractRequestID is nil-safe and yields a null id.
-        ErrorCode := JSONRPC_INTERNAL_ERROR;
-        if not Assigned(JSONRequest) then
-          ErrorCode := JSONRPC_PARSE_ERROR
-        else if Pos('not found', E.Message) > 0 then
-          ErrorCode := JSONRPC_METHOD_NOT_FOUND;
-
-        Result := CreateErrorResponse(ExtractRequestID(JSONRequest), ErrorCode, E.Message);
+        var Error := ExceptionToError(Era, E);
+        try
+          Result := ErrorResult(Era, RequestId, Error);
+        finally
+          Error.Free;
+        end;
       end;
     end;
   finally
-    JSONRequest.Free;
-    JSONResponse.Free;
+    Context := nil;
   end;
 end;
 

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -1,0 +1,262 @@
+unit MCPServer.RequestContext;
+
+interface
+
+uses
+  System.SysUtils,
+  System.JSON,
+  MCPServer.Types;
+
+type
+  /// What the transport knows about a request before the processor sees it.
+  TMCPTransportHints = record
+    /// True when the transport carries HTTP headers (Streamable HTTP).
+    HasHeaderLayer: Boolean;
+    HasProtocolVersionHeader: Boolean;
+    ProtocolVersionHeader: string;
+    HasMethodHeader: Boolean;
+    MethodHeader: string;
+    HasNameHeader: Boolean;
+    NameHeader: string;
+    RemoteAddress: string;
+    /// Per-process legacy state (stdio); nil for stateless transports.
+    LegacySession: TMCPLegacySession;
+
+    /// No headers, no session: the plain JSON-RPC layer.
+    class function None: TMCPTransportHints; static;
+    /// stdio: no headers, one session slot per process.
+    class function ForStdio(const Session: TMCPLegacySession): TMCPTransportHints; static;
+    /// HTTP: the MCP-Protocol-Version header, empty and HasHeader False when absent.
+    class function ForHttp(const HasVersionHeader: Boolean; const VersionHeader: string): TMCPTransportHints; static;
+  end;
+
+  /// Default IMCPRequestContext implementation and the thread-local Current.
+  TMCPRequestContext = class(TInterfacedObject, IMCPRequestContext)
+  private
+    FEra: TMCPProtocolEra;
+    FProtocolVersion: string;
+    FMethod: string;
+    FRequestId: TMCPRequestId;
+    FMeta: TJSONObject;
+    FLegacySession: TMCPLegacySession;
+    FManagerRegistry: IMCPManagerRegistry;
+    function MetaObject(const Key: string): TJSONObject;
+  public
+    /// Meta is cloned; the context owns its copy.
+    constructor Create(AEra: TMCPProtocolEra; const AProtocolVersion, AMethod: string;
+      const ARequestId: TMCPRequestId; const AMeta: TJSONObject;
+      const ALegacySession: TMCPLegacySession; const AManagerRegistry: IMCPManagerRegistry);
+    destructor Destroy; override;
+
+    function GetEra: TMCPProtocolEra;
+    function GetProtocolVersion: string;
+    function GetMethod: string;
+    function GetRequestId: TMCPRequestId;
+    function GetMeta: TJSONObject;
+    function GetClientCapabilities: TJSONObject;
+    function GetClientInfo: TJSONObject;
+    function GetLogLevel: string;
+    function GetProgressToken: TJSONValue;
+    function GetLegacySession: TMCPLegacySession;
+    function GetManagerRegistry: IMCPManagerRegistry;
+    function HasClientCapability(const Path: string): Boolean;
+    procedure RequireClientCapability(const Path: string);
+    function IsCancelled: Boolean;
+    procedure CheckCancelled;
+
+    /// The context of the request the calling thread is serving, or nil.
+    class function Current: IMCPRequestContext;
+    /// Set by the processor around a handler call; nil clears it.
+    class procedure SetCurrent(const Value: IMCPRequestContext);
+  end;
+
+implementation
+
+uses
+  MCPServer.Errors;
+
+threadvar
+  // Raw pointer with manual reference counting: a managed threadvar is not
+  // finalised when a thread ends.
+  CurrentContextPointer: Pointer;
+
+{ TMCPTransportHints }
+
+class function TMCPTransportHints.None: TMCPTransportHints;
+begin
+  Result := Default(TMCPTransportHints);
+end;
+
+class function TMCPTransportHints.ForStdio(const Session: TMCPLegacySession): TMCPTransportHints;
+begin
+  Result := Default(TMCPTransportHints);
+  Result.LegacySession := Session;
+end;
+
+class function TMCPTransportHints.ForHttp(const HasVersionHeader: Boolean; const VersionHeader: string): TMCPTransportHints;
+begin
+  Result := Default(TMCPTransportHints);
+  Result.HasHeaderLayer := True;
+  Result.HasProtocolVersionHeader := HasVersionHeader;
+  Result.ProtocolVersionHeader := VersionHeader;
+end;
+
+{ TMCPRequestContext }
+
+constructor TMCPRequestContext.Create(AEra: TMCPProtocolEra; const AProtocolVersion, AMethod: string;
+  const ARequestId: TMCPRequestId; const AMeta: TJSONObject; const ALegacySession: TMCPLegacySession;
+  const AManagerRegistry: IMCPManagerRegistry);
+begin
+  inherited Create;
+  FEra := AEra;
+  FProtocolVersion := AProtocolVersion;
+  FMethod := AMethod;
+  FRequestId := ARequestId;
+  if Assigned(AMeta) then
+    FMeta := TJSONObject(AMeta.Clone);
+  FLegacySession := ALegacySession;
+  FManagerRegistry := AManagerRegistry;
+end;
+
+destructor TMCPRequestContext.Destroy;
+begin
+  FMeta.Free;
+  inherited;
+end;
+
+function TMCPRequestContext.MetaObject(const Key: string): TJSONObject;
+begin
+  Result := nil;
+  if not Assigned(FMeta) then
+    Exit;
+
+  var Value := FMeta.GetValue(Key);
+  if Value is TJSONObject then
+    Result := TJSONObject(Value);
+end;
+
+function TMCPRequestContext.GetEra: TMCPProtocolEra;
+begin
+  Result := FEra;
+end;
+
+function TMCPRequestContext.GetProtocolVersion: string;
+begin
+  Result := FProtocolVersion;
+end;
+
+function TMCPRequestContext.GetMethod: string;
+begin
+  Result := FMethod;
+end;
+
+function TMCPRequestContext.GetRequestId: TMCPRequestId;
+begin
+  Result := FRequestId;
+end;
+
+function TMCPRequestContext.GetMeta: TJSONObject;
+begin
+  Result := FMeta;
+end;
+
+function TMCPRequestContext.GetClientCapabilities: TJSONObject;
+begin
+  Result := MetaObject(MCP_META_CLIENT_CAPABILITIES);
+end;
+
+function TMCPRequestContext.GetClientInfo: TJSONObject;
+begin
+  Result := MetaObject(MCP_META_CLIENT_INFO);
+end;
+
+function TMCPRequestContext.GetLogLevel: string;
+begin
+  Result := '';
+  if not Assigned(FMeta) then
+    Exit;
+
+  var Value := FMeta.GetValue(MCP_META_LOG_LEVEL);
+  if Value is TJSONString then
+    Result := TJSONString(Value).Value;
+end;
+
+function TMCPRequestContext.GetProgressToken: TJSONValue;
+begin
+  Result := nil;
+  if Assigned(FMeta) then
+    Result := FMeta.GetValue(MCP_META_PROGRESS_TOKEN);
+end;
+
+function TMCPRequestContext.GetLegacySession: TMCPLegacySession;
+begin
+  Result := FLegacySession;
+end;
+
+function TMCPRequestContext.GetManagerRegistry: IMCPManagerRegistry;
+begin
+  Result := FManagerRegistry;
+end;
+
+function TMCPRequestContext.HasClientCapability(const Path: string): Boolean;
+begin
+  Result := False;
+  var Node: TJSONValue := GetClientCapabilities;
+  if not Assigned(Node) then
+    Exit;
+
+  for var Segment in Path.Split(['.']) do
+  begin
+    if not (Node is TJSONObject) then
+      Exit;
+    Node := TJSONObject(Node).GetValue(Segment);
+    if not Assigned(Node) then
+      Exit;
+  end;
+  Result := True;
+end;
+
+procedure TMCPRequestContext.RequireClientCapability(const Path: string);
+begin
+  if HasClientCapability(Path) then
+    Exit;
+
+  // Rebuild the dotted path as nested objects: 'elicitation.form' becomes
+  // {"elicitation": {"form": {}}}.
+  var Required := TJSONObject.Create;
+  var Node := Required;
+  for var Segment in Path.Split(['.']) do
+  begin
+    var Child := TJSONObject.Create;
+    Node.AddPair(Segment, Child);
+    Node := Child;
+  end;
+  raise EMCPError.MissingRequiredClientCapability(Required);
+end;
+
+function TMCPRequestContext.IsCancelled: Boolean;
+begin
+  Result := False;
+end;
+
+procedure TMCPRequestContext.CheckCancelled;
+begin
+  // Cancellation is not wired to a transport yet; nothing to check.
+end;
+
+class function TMCPRequestContext.Current: IMCPRequestContext;
+begin
+  Result := IMCPRequestContext(CurrentContextPointer);
+end;
+
+class procedure TMCPRequestContext.SetCurrent(const Value: IMCPRequestContext);
+begin
+  if Assigned(CurrentContextPointer) then
+    IMCPRequestContext(CurrentContextPointer)._Release;
+
+  CurrentContextPointer := Pointer(Value);
+  if Assigned(Value) then
+    Value._AddRef;
+end;
+
+end.

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -65,6 +65,12 @@ const
     'resources/read'
   );
 
+function IsLegacyProtocolVersion(const Version: string): Boolean;
+function IsModernProtocolVersion(const Version: string): Boolean;
+/// The revision answered to an initialize request: the requested one when it
+/// is served, otherwise the newest legacy revision.
+function NegotiateLegacyProtocolVersion(const Requested: string): string;
+
 type
   OptionalAttribute = class(TCustomAttribute)
   end;
@@ -103,7 +109,111 @@ type
     procedure RegisterManager(const Manager: IMCPCapabilityManager);
     function GetManagerForMethod(const Method: string): IMCPCapabilityManager;
   end;
-  
+
+  /// Optional view on a manager registry that can list its managers, used to
+  /// derive the server capabilities. Probed with Supports().
+  IMCPManagerEnumerator = interface
+    ['{6D1F0B2C-3A4E-4F5B-8C7D-9E0F1A2B3C4D}']
+    function GetManagers: TArray<IMCPCapabilityManager>;
+  end;
+
+  /// Implemented by managers that want a reference to the registry they are
+  /// registered in (TMCPManagerRegistry injects it). Keep the reference weak.
+  IMCPRegistryAware = interface
+    ['{2B7C9D1E-4F6A-4B8C-9D0E-1F2A3B4C5D6E}']
+    procedure SetManagerRegistry(const Registry: IMCPManagerRegistry);
+  end;
+
+  {$SCOPEDENUMS ON}
+  /// Legacy: initialize-based revisions (2025-11-25 and earlier).
+  /// Modern: per-request _meta revisions (2026-07-28 and later).
+  TMCPProtocolEra = (Legacy, Modern);
+
+  TMCPRequestIdKind = (None, Null, Text, Number, Invalid);
+  {$SCOPEDENUMS OFF}
+
+  /// The JSON-RPC id of a message. None means the member is absent
+  /// (notification); Invalid covers booleans, objects, arrays and fractions.
+  TMCPRequestId = record
+    Kind: TMCPRequestIdKind;
+    Text: string;
+    Number: Int64;
+    class function FromJson(const Value: TJSONValue): TMCPRequestId; static;
+    class function FromNumber(const Value: Int64): TMCPRequestId; static;
+    class function FromText(const Value: string): TMCPRequestId; static;
+    /// True for a string or integer id (a request that must be answered).
+    function IsPresent: Boolean;
+    /// JSON value for the response; null when the id is absent or invalid.
+    function ToJson: TJSONValue;
+    function AsText: string;
+  end;
+
+  /// Per-process legacy state for stdio: the protocol version negotiated by
+  /// the last initialize. Empty until an initialize has been answered.
+  TMCPLegacySession = class
+  private
+    FProtocolVersion: string;
+  public
+    property ProtocolVersion: string read FProtocolVersion write FProtocolVersion;
+  end;
+
+  /// What a handler may know about the request it is serving. Built once
+  /// per request by the JSON-RPC processor and reachable through
+  /// TMCPRequestContext.Current while the handler runs.
+  IMCPRequestContext = interface
+    ['{7E3A9C1B-5D2F-4A6E-8B0C-3D4E5F6A7B8C}']
+    function GetEra: TMCPProtocolEra;
+    function GetProtocolVersion: string;
+    function GetMethod: string;
+    function GetRequestId: TMCPRequestId;
+    function GetMeta: TJSONObject;
+    function GetClientCapabilities: TJSONObject;
+    function GetClientInfo: TJSONObject;
+    function GetLogLevel: string;
+    function GetProgressToken: TJSONValue;
+    function GetLegacySession: TMCPLegacySession;
+    function GetManagerRegistry: IMCPManagerRegistry;
+
+    /// True when the client declared the capability, given as a dotted path
+    /// such as 'elicitation' or 'elicitation.form'. Always False for legacy
+    /// requests (their capabilities are not carried per request).
+    function HasClientCapability(const Path: string): Boolean;
+    /// Raises EMCPError -32021 when the capability was not declared.
+    procedure RequireClientCapability(const Path: string);
+    function IsCancelled: Boolean;
+    procedure CheckCancelled;
+
+    property Era: TMCPProtocolEra read GetEra;
+    property ProtocolVersion: string read GetProtocolVersion;
+    property Method: string read GetMethod;
+    property RequestId: TMCPRequestId read GetRequestId;
+    /// The request's _meta object (nil when absent). Owned by the context.
+    property Meta: TJSONObject read GetMeta;
+    /// io.modelcontextprotocol/clientCapabilities (never nil for modern
+    /// requests, nil for legacy requests).
+    property ClientCapabilities: TJSONObject read GetClientCapabilities;
+    property ClientInfo: TJSONObject read GetClientInfo;
+    property LogLevel: string read GetLogLevel;
+    property ProgressToken: TJSONValue read GetProgressToken;
+    property LegacySession: TMCPLegacySession read GetLegacySession;
+    property ManagerRegistry: IMCPManagerRegistry read GetManagerRegistry;
+  end;
+
+  /// Managers that want the request context receive it through this
+  /// interface; the processor falls back to IMCPCapabilityManager.ExecuteMethod.
+  IMCPCapabilityManagerEx = interface
+    ['{9F4B2D6A-1C3E-4E5F-A7B8-C9D0E1F2A3B4}']
+    function ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
+      const Context: IMCPRequestContext): TValue;
+  end;
+
+  /// Managers that contribute an entry to the server capabilities
+  /// (for example "tools": {"listChanged": false}).
+  IMCPCapabilityProvider = interface
+    ['{C5D7E9F1-2A4B-4C6D-8E0F-1A2B3C4D5E6F}']
+    procedure DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
+  end;
+
   TMCPCapabilities = class
   private
     FTools: TMCPToolsCapability;
@@ -166,6 +276,105 @@ type
   end;
 
 implementation
+
+function IsLegacyProtocolVersion(const Version: string): Boolean;
+begin
+  for var Known in MCP_LEGACY_PROTOCOL_VERSIONS do
+    if Known = Version then
+      Exit(True);
+  Result := False;
+end;
+
+function IsModernProtocolVersion(const Version: string): Boolean;
+begin
+  for var Known in MCP_MODERN_PROTOCOL_VERSIONS do
+    if Known = Version then
+      Exit(True);
+  Result := False;
+end;
+
+function NegotiateLegacyProtocolVersion(const Requested: string): string;
+begin
+  if IsLegacyProtocolVersion(Requested) then
+    Result := Requested
+  else
+    Result := MCP_LATEST_LEGACY_PROTOCOL_VERSION;
+end;
+
+{ TMCPRequestId }
+
+class function TMCPRequestId.FromJson(const Value: TJSONValue): TMCPRequestId;
+begin
+  Result.Text := '';
+  Result.Number := 0;
+
+  if not Assigned(Value) then
+    Result.Kind := TMCPRequestIdKind.None
+  else if Value is TJSONNull then
+    Result.Kind := TMCPRequestIdKind.Null
+  else if Value is TJSONNumber then
+  begin
+    // Only integers are valid ids; a fraction is not.
+    var Number := TJSONNumber(Value);
+    if Frac(Number.AsDouble) = 0 then
+    begin
+      Result.Kind := TMCPRequestIdKind.Number;
+      Result.Number := Number.AsInt64;
+    end
+    else
+      Result.Kind := TMCPRequestIdKind.Invalid;
+  end
+  else if Value is TJSONString then
+  begin
+    Result.Kind := TMCPRequestIdKind.Text;
+    Result.Text := TJSONString(Value).Value;
+  end
+  else
+    Result.Kind := TMCPRequestIdKind.Invalid;
+end;
+
+class function TMCPRequestId.FromNumber(const Value: Int64): TMCPRequestId;
+begin
+  Result.Kind := TMCPRequestIdKind.Number;
+  Result.Number := Value;
+  Result.Text := '';
+end;
+
+class function TMCPRequestId.FromText(const Value: string): TMCPRequestId;
+begin
+  Result.Kind := TMCPRequestIdKind.Text;
+  Result.Number := 0;
+  Result.Text := Value;
+end;
+
+function TMCPRequestId.IsPresent: Boolean;
+begin
+  Result := Kind in [TMCPRequestIdKind.Text, TMCPRequestIdKind.Number];
+end;
+
+function TMCPRequestId.ToJson: TJSONValue;
+begin
+  case Kind of
+    TMCPRequestIdKind.Text:
+      Result := TJSONString.Create(Text);
+    TMCPRequestIdKind.Number:
+      Result := TJSONNumber.Create(Number);
+  else
+    Result := TJSONNull.Create;
+  end;
+end;
+
+function TMCPRequestId.AsText: string;
+begin
+  case Kind of
+    TMCPRequestIdKind.Text:
+      Result := Text;
+    TMCPRequestIdKind.Number:
+      Result := Number.ToString;
+  else
+    Result := '';
+  end;
+end;
 
 { SchemaDescriptionAttribute }
 

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -26,6 +26,7 @@ uses
   IdServerIOHandler,
   MCPServer.Types,
   MCPServer.Settings,
+  MCPServer.RequestContext,
   MCPServer.JsonRpcProcessor;
 
 type
@@ -54,6 +55,7 @@ type
     procedure HandlePostRequestSSE(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo; const RequestBody: string; const SessionID: string);
     procedure HandlePostRequestJSON(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo; const RequestBody: string; const SessionID: string);
     function GetNextEventID: string;
+    function BuildTransportHints(RequestInfo: TIdHTTPRequestInfo): TMCPTransportHints;
     function AcceptsSSE(const AcceptHeader: string): Boolean;
     function IsRequestOnlyNotificationsOrResponses(JSONRequest: TJSONValue): Boolean;
   public
@@ -134,7 +136,7 @@ begin
   if not Assigned(FManagerRegistry) then
     raise Exception.Create('Manager registry not assigned');
 
-  FJsonRpcProcessor := TMCPJsonRpcProcessor.Create(FManagerRegistry);
+  FJsonRpcProcessor := TMCPJsonRpcProcessor.Create(FManagerRegistry, FSettings);
 
   if Assigned(FSettings) then
   begin
@@ -412,6 +414,16 @@ begin
   Result := IntToStr(AtomicIncrement(FEventIDCounter));
 end;
 
+function TMCPIdHTTPServer.BuildTransportHints(RequestInfo: TIdHTTPRequestInfo): TMCPTransportHints;
+const
+  PROTOCOL_VERSION_HEADER = 'MCP-Protocol-Version';
+begin
+  // Header names are matched case-insensitively by TIdHeaderList.
+  var HasHeader := RequestInfo.RawHeaders.IndexOfName(PROTOCOL_VERSION_HEADER) >= 0;
+  Result := TMCPTransportHints.ForHttp(HasHeader, Trim(RequestInfo.RawHeaders.Values[PROTOCOL_VERSION_HEADER]));
+  Result.RemoteAddress := RequestInfo.RemoteIP;
+end;
+
 function TMCPIdHTTPServer.AcceptsSSE(const AcceptHeader: string): Boolean;
 begin
   Result := Pos('text/event-stream', AcceptHeader) > 0;
@@ -478,7 +490,7 @@ begin
   if SessionID <> '' then
     ResponseInfo.CustomHeaders.Values['Mcp-Session-Id'] := SessionID;
 
-  JSONResponse := FJsonRpcProcessor.ProcessRequest(RequestBody, SessionID);
+  JSONResponse := FJsonRpcProcessor.ProcessRequestEx(RequestBody, BuildTransportHints(RequestInfo)).Body;
 
   if JSONResponse <> '' then
   begin
@@ -506,13 +518,10 @@ procedure TMCPIdHTTPServer.HandlePostRequestJSON(RequestInfo: TIdHTTPRequestInfo
   ResponseInfo: TIdHTTPResponseInfo; const RequestBody: string; const SessionID: string);
 var
   ResponseBody: string;
-  ResponseJSON: TJSONObject;
-  ResultObj: TJSONObject;
-  SessionValue: TJSONValue;
 begin
   TLogger.Info('Handling POST request with JSON response');
 
-  ResponseBody := FJsonRpcProcessor.ProcessRequest(RequestBody, SessionID);
+  ResponseBody := FJsonRpcProcessor.ProcessRequestEx(RequestBody, BuildTransportHints(RequestInfo)).Body;
 
   if ResponseBody = '' then
   begin
@@ -523,22 +532,8 @@ begin
   ResponseInfo.ContentType := 'application/json';
   ResponseInfo.CustomHeaders.Values['Connection'] := 'keep-alive';
 
-  if (SessionID = '') and (Pos('"sessionId"', ResponseBody) > 0) then
-  begin
-    ResponseJSON := TJSONObject.ParseJSONValue(ResponseBody) as TJSONObject;
-    try
-      ResultObj := ResponseJSON.GetValue('result') as TJSONObject;
-      if Assigned(ResultObj) then
-      begin
-        SessionValue := ResultObj.GetValue('sessionId');
-        if Assigned(SessionValue) then
-          ResponseInfo.CustomHeaders.Values['Mcp-Session-Id'] := SessionValue.Value;
-      end;
-    finally
-      ResponseJSON.Free;
-    end;
-  end
-  else if SessionID <> '' then
+  // Sessions are never minted; an incoming id is echoed back unchanged.
+  if SessionID <> '' then
     ResponseInfo.CustomHeaders.Values['Mcp-Session-Id'] := SessionID;
 
   ResponseInfo.ContentStream := TStringStream.Create(ResponseBody, TEncoding.UTF8);

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -7,6 +7,8 @@ uses
   System.Classes,
   System.JSON,
   MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.RequestContext,
   MCPServer.JsonRpcProcessor,
   MCPServer.Logger;
 
@@ -16,10 +18,16 @@ type
     FManagerRegistry: IMCPManagerRegistry;
     FCoreManager: IMCPCapabilityManager;
     FJsonRpcProcessor: TMCPJsonRpcProcessor;
+    FLegacySession: TMCPLegacySession;
+    function GetSettings: TMCPSettings;
+    procedure SetSettings(const Value: TMCPSettings);
   public
     constructor Create(ManagerRegistry: IMCPManagerRegistry; CoreManager: IMCPCapabilityManager);
     destructor Destroy; override;
     procedure Run;
+    /// Server identity and protocol options; assign before Run. Without it the
+    /// processor uses the defaults (settings.ini next to the executable).
+    property Settings: TMCPSettings read GetSettings write SetSettings;
   end;
 
 implementation
@@ -32,6 +40,7 @@ begin
   FManagerRegistry := ManagerRegistry;
   FCoreManager := CoreManager;
   FJsonRpcProcessor := TMCPJsonRpcProcessor.Create(ManagerRegistry);
+  FLegacySession := TMCPLegacySession.Create;
 
   // stdout carries MCP messages only; every log line must go to stderr,
   // also for library consumers that never set UseStdErr themselves.
@@ -42,7 +51,18 @@ end;
 destructor TMCPStdioTransport.Destroy;
 begin
   FJsonRpcProcessor.Free;
+  FLegacySession.Free;
   inherited;
+end;
+
+function TMCPStdioTransport.GetSettings: TMCPSettings;
+begin
+  Result := FJsonRpcProcessor.Settings;
+end;
+
+procedure TMCPStdioTransport.SetSettings(const Value: TMCPSettings);
+begin
+  FJsonRpcProcessor.Settings := Value;
 end;
 
 procedure TMCPStdioTransport.Run;
@@ -66,7 +86,7 @@ begin
 
       TLogger.Info('Received: ' + InputLine);
 
-      Response := FJsonRpcProcessor.ProcessRequest(InputLine, '');
+      Response := FJsonRpcProcessor.ProcessRequestEx(InputLine, TMCPTransportHints.ForStdio(FLegacySession)).Body;
 
       if Response <> '' then
       begin

--- a/tests/MCPServer.Tests.Capabilities.pas
+++ b/tests/MCPServer.Tests.Capabilities.pas
@@ -1,0 +1,100 @@
+unit MCPServer.Tests.Capabilities;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TCapabilityBuilderTests = class
+  public
+    [Test] procedure Registry_YieldsToolsAndResourcesInRegistrationOrder;
+    [Test] procedure Registry_NeverEmitsLogging;
+    [Test] procedure RegistryWithoutEnumeration_YieldsDefaults;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Generics.Collections,
+  System.JSON,
+  MCPServer.Types,
+  MCPServer.Capabilities,
+  MCPServer.Tests.Harness;
+
+type
+  /// A registry that cannot list its managers (a consumer's own implementation).
+  TOpaqueRegistry = class(TInterfacedObject, IMCPManagerRegistry)
+  public
+    procedure RegisterManager(const Manager: IMCPCapabilityManager);
+    function GetManagerForMethod(const Method: string): IMCPCapabilityManager;
+  end;
+
+procedure TOpaqueRegistry.RegisterManager(const Manager: IMCPCapabilityManager);
+begin
+end;
+
+function TOpaqueRegistry.GetManagerForMethod(const Method: string): IMCPCapabilityManager;
+begin
+  Result := nil;
+end;
+
+{ TCapabilityBuilderTests }
+
+procedure TCapabilityBuilderTests.Registry_YieldsToolsAndResourcesInRegistrationOrder;
+begin
+  var Harness := TMCPTestHarness.Create;
+  try
+    var Capabilities := TMCPCapabilityBuilder.Build(Harness.ManagerRegistry, TMCPProtocolEra.Modern);
+    try
+      Assert.AreEqual(2, Capabilities.Count);
+      Assert.AreEqual('tools', Capabilities.Pairs[0].JsonString.Value);
+      Assert.AreEqual('resources', Capabilities.Pairs[1].JsonString.Value);
+      Assert.IsFalse(Capabilities.GetValue<Boolean>('tools.listChanged'));
+      Assert.IsFalse(Capabilities.GetValue<Boolean>('resources.subscribe'));
+      Assert.IsFalse(Capabilities.GetValue<Boolean>('resources.listChanged'));
+    finally
+      Capabilities.Free;
+    end;
+  finally
+    Harness.Free;
+  end;
+end;
+
+procedure TCapabilityBuilderTests.Registry_NeverEmitsLogging;
+begin
+  var Harness := TMCPTestHarness.Create;
+  try
+    for var Era in [TMCPProtocolEra.Legacy, TMCPProtocolEra.Modern] do
+    begin
+      var Capabilities := TMCPCapabilityBuilder.Build(Harness.ManagerRegistry, Era);
+      try
+        Assert.IsNull(Capabilities.GetValue('logging'));
+        Assert.IsNull(Capabilities.GetValue('extensions'));
+      finally
+        Capabilities.Free;
+      end;
+    end;
+  finally
+    Harness.Free;
+  end;
+end;
+
+procedure TCapabilityBuilderTests.RegistryWithoutEnumeration_YieldsDefaults;
+begin
+  var Registry: IMCPManagerRegistry := TOpaqueRegistry.Create;
+  var Capabilities := TMCPCapabilityBuilder.Build(Registry, TMCPProtocolEra.Legacy);
+  try
+    Assert.IsNotNull(Capabilities.GetValue('tools'));
+    Assert.IsNotNull(Capabilities.GetValue('resources'));
+  finally
+    Capabilities.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TCapabilityBuilderTests);
+
+end.

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -91,29 +91,11 @@ end;
 
 procedure TLegacyGoldenTests.CheckGolden(const CaseName: string);
 begin
-  var GoldenCase := TGoldenCase.Create(TGoldenFiles.CaseFile(TGoldenFiles.LEGACY_SUITE, CaseName));
-  try
-    var Response: string;
-    var SavedDirectory := GetCurrentDir;
-    if GoldenCase.WorkingDirectory <> '' then
-      SetCurrentDir(GoldenCase.WorkingDirectory);
-    try
-      Response := FHarness.Process(GoldenCase.RequestBody);
-    finally
-      SetCurrentDir(SavedDirectory);
-    end;
-
-    if TGoldenFiles.RecordMode then
+  TGoldenRunner.Check(TGoldenFiles.LEGACY_SUITE, CaseName,
+    function(const RequestBody: string): string
     begin
-      GoldenCase.RecordExpected(Response);
-      Exit;
-    end;
-
-    Assert.AreEqual(GoldenCase.ExpectedText, GoldenCase.NormalizeResponse(Response),
-      'Golden mismatch for ' + CaseName);
-  finally
-    GoldenCase.Free;
-  end;
+      Result := FHarness.Process(RequestBody);
+    end);
 end;
 
 procedure TLegacyGoldenTests.Initialize_2025_06_18;

--- a/tests/MCPServer.Tests.Golden.Modern.pas
+++ b/tests/MCPServer.Tests.Golden.Modern.pas
@@ -1,0 +1,163 @@
+unit MCPServer.Tests.Golden.Modern;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  MCPServer.Tests.Harness,
+  MCPServer.Tests.Golden;
+
+type
+  /// Pins the wire behaviour for requests that carry per-request _meta
+  /// (MCP 2026-07-28), replayed through the plain JSON-RPC layer.
+  [TestFixture]
+  TModernGoldenTests = class
+  private
+    FHarness: TMCPTestHarness;
+    procedure CheckGolden(const CaseName: string);
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test] procedure Server_Discover;
+    [Test] procedure Server_Discover_AfterInitialize;
+    [Test] procedure Server_Discover_WithoutMeta;
+    [Test] procedure Tools_List;
+    [Test] procedure Tools_Call_Echo;
+    [Test] procedure Tools_Call_UnknownTool;
+    [Test] procedure Resources_List;
+    [Test] procedure Resources_Read_ProjectInfo;
+    [Test] procedure Resources_Templates_List;
+    [Test] procedure Ping_IsNotFound;
+    [Test] procedure UnknownMethod;
+    [Test] procedure UnknownProtocolVersion;
+    [Test] procedure MissingClientCapabilities;
+    [Test] procedure InvalidLogLevel;
+    [Test] procedure Initialize_WithModernMeta_IsLegacy;
+    [Test] procedure Id_Null;
+    [Test] procedure MissingJsonRpcField;
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+const
+  INITIALIZE_REQUEST = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18",'
+    + '"capabilities":{},"clientInfo":{"name":"golden-client","version":"1.0.0"}}}';
+
+{ TModernGoldenTests }
+
+procedure TModernGoldenTests.Setup;
+begin
+  FHarness := TMCPTestHarness.Create;
+end;
+
+procedure TModernGoldenTests.TearDown;
+begin
+  FreeAndNil(FHarness);
+end;
+
+procedure TModernGoldenTests.CheckGolden(const CaseName: string);
+begin
+  TGoldenRunner.Check(TGoldenFiles.MODERN_SUITE, CaseName,
+    function(const RequestBody: string): string
+    begin
+      Result := FHarness.Process(RequestBody);
+    end);
+end;
+
+procedure TModernGoldenTests.Server_Discover;
+begin
+  CheckGolden('server-discover');
+end;
+
+procedure TModernGoldenTests.Server_Discover_AfterInitialize;
+begin
+  // A legacy handshake on the same process must not latch the server.
+  FHarness.Process(INITIALIZE_REQUEST);
+  CheckGolden('server-discover');
+end;
+
+procedure TModernGoldenTests.Server_Discover_WithoutMeta;
+begin
+  CheckGolden('server-discover-without-meta');
+end;
+
+procedure TModernGoldenTests.Tools_List;
+begin
+  CheckGolden('tools-list');
+end;
+
+procedure TModernGoldenTests.Tools_Call_Echo;
+begin
+  CheckGolden('tools-call-echo');
+end;
+
+procedure TModernGoldenTests.Tools_Call_UnknownTool;
+begin
+  CheckGolden('tools-call-unknown-tool');
+end;
+
+procedure TModernGoldenTests.Resources_List;
+begin
+  CheckGolden('resources-list');
+end;
+
+procedure TModernGoldenTests.Resources_Read_ProjectInfo;
+begin
+  CheckGolden('resources-read-project-info');
+end;
+
+procedure TModernGoldenTests.Resources_Templates_List;
+begin
+  CheckGolden('resources-templates-list');
+end;
+
+procedure TModernGoldenTests.Ping_IsNotFound;
+begin
+  CheckGolden('ping');
+end;
+
+procedure TModernGoldenTests.UnknownMethod;
+begin
+  CheckGolden('unknown-method');
+end;
+
+procedure TModernGoldenTests.UnknownProtocolVersion;
+begin
+  CheckGolden('unknown-protocol-version');
+end;
+
+procedure TModernGoldenTests.MissingClientCapabilities;
+begin
+  CheckGolden('missing-client-capabilities');
+end;
+
+procedure TModernGoldenTests.InvalidLogLevel;
+begin
+  CheckGolden('invalid-log-level');
+end;
+
+procedure TModernGoldenTests.Initialize_WithModernMeta_IsLegacy;
+begin
+  CheckGolden('initialize-with-modern-meta');
+end;
+
+procedure TModernGoldenTests.Id_Null;
+begin
+  CheckGolden('id-null');
+end;
+
+procedure TModernGoldenTests.MissingJsonRpcField;
+begin
+  CheckGolden('missing-jsonrpc-field');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TModernGoldenTests);
+
+end.

--- a/tests/MCPServer.Tests.Golden.pas
+++ b/tests/MCPServer.Tests.Golden.pas
@@ -23,6 +23,7 @@ type
     const GOLDEN_DIR_ENVIRONMENT_VARIABLE = 'MCP_GOLDEN_DIR';
     const GOLDEN_DIRECTORY_NAME = 'golden';
     const LEGACY_SUITE = 'legacy';
+    const MODERN_SUITE = 'modern';
 
     class function GoldenRoot: string;
     class function TestsRoot: string;
@@ -95,6 +96,15 @@ type
     property RequestBody: string read GetRequestBody;
     property WorkingDirectory: string read GetWorkingDirectory;
     property HasExpected: Boolean read GetHasExpected;
+  end;
+
+  TGoldenProcessFunc = reference to function(const RequestBody: string): string;
+
+  /// Replays one golden case through the given processing function and
+  /// compares (or records) the response.
+  TGoldenRunner = class
+  public
+    class procedure Check(const Suite, CaseName: string; const Process: TGoldenProcessFunc);
   end;
 
 implementation
@@ -401,6 +411,38 @@ procedure TGoldenCase.Save;
 begin
   var Text := FDocument.Format(INDENTATION) + sLineBreak;
   TFile.WriteAllBytes(FFileName, TEncoding.UTF8.GetBytes(Text));
+end;
+
+{ TGoldenRunner }
+
+class procedure TGoldenRunner.Check(const Suite, CaseName: string; const Process: TGoldenProcessFunc);
+begin
+  var GoldenCase := TGoldenCase.Create(TGoldenFiles.CaseFile(Suite, CaseName));
+  try
+    var Response: string;
+    var SavedDirectory := GetCurrentDir;
+    if GoldenCase.WorkingDirectory <> '' then
+      SetCurrentDir(GoldenCase.WorkingDirectory);
+    try
+      Response := Process(GoldenCase.RequestBody);
+    finally
+      SetCurrentDir(SavedDirectory);
+    end;
+
+    if TGoldenFiles.RecordMode then
+    begin
+      GoldenCase.RecordExpected(Response);
+      Exit;
+    end;
+
+    var Expected := GoldenCase.ExpectedText;
+    var Actual := GoldenCase.NormalizeResponse(Response);
+    if Expected <> Actual then
+      raise EGoldenError.CreateFmt('Golden mismatch for %s/%s'#13#10'--- expected ---'#13#10'%s'#13#10'--- actual ---'#13#10'%s',
+        [Suite, CaseName, Expected, Actual]);
+  finally
+    GoldenCase.Free;
+  end;
 end;
 
 end.

--- a/tests/MCPServer.Tests.Processor.pas
+++ b/tests/MCPServer.Tests.Processor.pas
@@ -1,0 +1,369 @@
+unit MCPServer.Tests.Processor;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Generics.Collections,
+  System.JSON,
+  System.Rtti,
+  MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.RequestContext,
+  MCPServer.JsonRpcProcessor,
+  MCPServer.Tests.Harness;
+
+type
+  /// A manager that records the context it was called with.
+  TProbeManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx)
+  public
+    SeenContext: IMCPRequestContext;
+    SeenCurrent: IMCPRequestContext;
+    function GetCapabilityName: string;
+    function HandlesMethod(const Method: string): Boolean;
+    function ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
+    function ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
+      const Context: IMCPRequestContext): TValue;
+  end;
+
+  /// Status policy, result envelope and dispatch through ProcessRequestEx.
+  [TestFixture]
+  TProcessorTests = class
+  private
+    FHarness: TMCPTestHarness;
+    FSettings: TMCPSettings;
+    FProcessor: TMCPJsonRpcProcessor;
+    function Run(const RequestJson: string; const Hints: TMCPTransportHints): TMCPProcessResult;
+    function Parse(const Body: string): TJSONObject;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test] procedure Modern_UnknownMethod_Is404;
+    [Test] procedure Legacy_UnknownMethod_Is200;
+    [Test] procedure ParseError_ModernHeader_Is400_LegacyIs200;
+    [Test] procedure Modern_MetaValidationError_Is400;
+    [Test] procedure Modern_ApplicationInvalidParams_Is200;
+    [Test] procedure Modern_ToolsList_HasEnvelopeAndCacheHints;
+    [Test] procedure Modern_ToolsCall_HasResultTypeButNoCacheHints;
+    [Test] procedure Modern_Discover_ListsModernVersionsAndCapabilities;
+    [Test] procedure Modern_Discover_ListsLegacyVersions_WhenConfigured;
+    [Test] procedure Modern_ServerInfo_UsesSettings;
+    [Test] procedure Legacy_Initialize_NegotiatesAndDeclaresCapabilities;
+    [Test] procedure Legacy_Result_IsUntouched;
+    [Test] procedure Notification_Returns202WithoutBody;
+    [Test] procedure ClientResponse_Legacy_IsIgnored_Modern_IsRejected;
+    [Test] procedure ErrorData_IsEmitted;
+    [Test] procedure Current_IsSetDuringDispatch_AndClearedAfter;
+    [Test] procedure Concurrent_Initialize_AllSucceed;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.Threading,
+  MCPServer.ManagerRegistry,
+  MCPServer.Errors;
+
+const
+  META = '"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}';
+
+{ TProbeManager }
+
+function TProbeManager.GetCapabilityName: string;
+begin
+  Result := 'probe';
+end;
+
+function TProbeManager.HandlesMethod(const Method: string): Boolean;
+begin
+  Result := Method = 'probe/run';
+end;
+
+function TProbeManager.ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
+begin
+  Result := ExecuteMethodWithContext(Method, Params, nil);
+end;
+
+function TProbeManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
+  const Context: IMCPRequestContext): TValue;
+begin
+  SeenContext := Context;
+  SeenCurrent := TMCPRequestContext.Current;
+  Result := TValue.From<TJSONObject>(TJSONObject.Create);
+end;
+
+{ TProcessorTests }
+
+procedure TProcessorTests.Setup;
+begin
+  FHarness := TMCPTestHarness.Create;
+  // One settings instance for the managers and the processor.
+  FSettings := FHarness.Settings;
+  FProcessor := TMCPJsonRpcProcessor.Create(FHarness.ManagerRegistry, FSettings);
+end;
+
+procedure TProcessorTests.TearDown;
+begin
+  FProcessor.Free;
+  FHarness.Free;
+end;
+
+function TProcessorTests.Run(const RequestJson: string; const Hints: TMCPTransportHints): TMCPProcessResult;
+begin
+  Result := FProcessor.ProcessRequestEx(RequestJson, Hints);
+end;
+
+function TProcessorTests.Parse(const Body: string): TJSONObject;
+begin
+  Result := TJSONObject.ParseJSONValue(Body) as TJSONObject;
+  Assert.IsNotNull(Result, 'response is not a JSON object: ' + Body);
+end;
+
+procedure TProcessorTests.Modern_UnknownMethod_Is404;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{' + META + '}}', TMCPTransportHints.None);
+  Assert.AreEqual(404, Outcome.HttpStatus);
+  Assert.AreEqual(TMCPProtocolEra.Modern, Outcome.Era);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual(JSONRPC_METHOD_NOT_FOUND, Response.GetValue<Integer>('error.code'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Legacy_UnknownMethod_Is200;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"prompts/list"}', TMCPTransportHints.ForHttp(True, '2025-06-18'));
+  Assert.AreEqual(200, Outcome.HttpStatus);
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Outcome.Era);
+end;
+
+procedure TProcessorTests.ParseError_ModernHeader_Is400_LegacyIs200;
+begin
+  Assert.AreEqual(400, Run('{not json', TMCPTransportHints.ForHttp(True, '2026-07-28')).HttpStatus);
+  Assert.AreEqual(200, Run('{not json', TMCPTransportHints.ForHttp(True, '2025-06-18')).HttpStatus);
+  Assert.AreEqual(200, Run('{not json', TMCPTransportHints.None).HttpStatus);
+end;
+
+procedure TProcessorTests.Modern_MetaValidationError_Is400;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}', TMCPTransportHints.None);
+  Assert.AreEqual(400, Outcome.HttpStatus);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual(JSONRPC_INVALID_PARAMS, Response.GetValue<Integer>('error.code'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_ApplicationInvalidParams_Is200;
+begin
+  // An error a manager raises without an explicit status stays application level.
+  var Probe := TProbeManager.Create;
+  var Registry: IMCPManagerRegistry := TMCPManagerRegistry.Create;
+  Registry.RegisterManager(Probe);
+  var Processor := TMCPJsonRpcProcessor.Create(Registry, FSettings);
+  try
+    Probe.SeenContext := nil;
+    var Outcome := Processor.ProcessRequestEx('{"jsonrpc":"2.0","id":1,"method":"probe/run","params":{' + META + '}}', TMCPTransportHints.None);
+    Assert.AreEqual(200, Outcome.HttpStatus);
+  finally
+    Processor.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_ToolsList_HasEnvelopeAndCacheHints;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{' + META + '}}', TMCPTransportHints.None);
+  Assert.AreEqual(200, Outcome.HttpStatus);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual('complete', Response.GetValue<string>('result.resultType'));
+    Assert.AreEqual('delphi-mcp-server', Response.GetValue<string>('result._meta["io.modelcontextprotocol/serverInfo"].name'));
+    Assert.AreEqual(0, Response.GetValue<Integer>('result.ttlMs'));
+    Assert.AreEqual('private', Response.GetValue<string>('result.cacheScope'));
+    Assert.IsNotNull(Response.FindValue('result.tools'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_ToolsCall_HasResultTypeButNoCacheHints;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"},' + META + '}}', TMCPTransportHints.None);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual('complete', Response.GetValue<string>('result.resultType'));
+    Assert.IsNull(Response.FindValue('result.ttlMs'));
+    Assert.IsNull(Response.FindValue('result.cacheScope'));
+    Assert.AreEqual('Echo: hi', Response.GetValue<string>('result.content[0].text'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_Discover_ListsModernVersionsAndCapabilities;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":"d","method":"server/discover","params":{' + META + '}}', TMCPTransportHints.None);
+  Assert.AreEqual(200, Outcome.HttpStatus);
+  var Response := Parse(Outcome.Body);
+  try
+    var Versions := Response.FindValue('result.supportedVersions') as TJSONArray;
+    Assert.AreEqual(1, Versions.Count);
+    Assert.AreEqual('2026-07-28', Versions.Items[0].Value);
+    Assert.IsFalse(Response.GetValue<Boolean>('result.capabilities.tools.listChanged'));
+    Assert.IsFalse(Response.GetValue<Boolean>('result.capabilities.resources.subscribe'));
+    Assert.IsNull(Response.FindValue('result.capabilities.logging'));
+    Assert.AreEqual('public', Response.GetValue<string>('result.cacheScope'));
+    Assert.AreEqual(0, Response.GetValue<Integer>('result.ttlMs'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_Discover_ListsLegacyVersions_WhenConfigured;
+begin
+  FSettings.DiscoverListsLegacyVersions := True;
+  var Outcome := Run('{"jsonrpc":"2.0","id":"d","method":"server/discover","params":{' + META + '}}', TMCPTransportHints.None);
+  var Response := Parse(Outcome.Body);
+  try
+    var Versions := Response.FindValue('result.supportedVersions') as TJSONArray;
+    Assert.AreEqual(3, Versions.Count);
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Modern_ServerInfo_UsesSettings;
+begin
+  FSettings.ServerTitle := 'Test Server';
+  FSettings.ServerWebsiteUrl := 'https://example.com';
+  FSettings.Instructions := 'Use the echo tool.';
+  var Outcome := Run('{"jsonrpc":"2.0","id":"d","method":"server/discover","params":{' + META + '}}', TMCPTransportHints.None);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual('Test Server', Response.GetValue<string>('result._meta["io.modelcontextprotocol/serverInfo"].title'));
+    Assert.AreEqual('https://example.com', Response.GetValue<string>('result._meta["io.modelcontextprotocol/serverInfo"].websiteUrl'));
+    Assert.AreEqual('Use the echo tool.', Response.GetValue<string>('result.instructions'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Legacy_Initialize_NegotiatesAndDeclaresCapabilities;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{}},"clientInfo":{"name":"c","version":"1"}}}', TMCPTransportHints.None);
+  Assert.AreEqual(200, Outcome.HttpStatus);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual('2025-11-25', Response.GetValue<string>('result.protocolVersion'));
+    Assert.IsFalse(Response.GetValue<Boolean>('result.capabilities.tools.listChanged'));
+    Assert.IsNull(Response.FindValue('result.sessionId'));
+    Assert.IsNull(Response.FindValue('result.capabilities.tools.supportsProgress'));
+    Assert.IsNull(Response.FindValue('result.resultType'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Legacy_Result_IsUntouched;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":1,"method":"tools/list"}', TMCPTransportHints.None);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.IsNull(Response.FindValue('result.resultType'));
+    Assert.IsNull(Response.FindValue('result._meta'));
+    Assert.IsNull(Response.FindValue('result.ttlMs'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Notification_Returns202WithoutBody;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","method":"notifications/initialized"}', TMCPTransportHints.None);
+  Assert.AreEqual('', Outcome.Body);
+  Assert.AreEqual(202, Outcome.HttpStatus);
+  Assert.IsTrue(Outcome.IsNotification);
+end;
+
+procedure TProcessorTests.ClientResponse_Legacy_IsIgnored_Modern_IsRejected;
+begin
+  var Legacy := Run('{"jsonrpc":"2.0","id":1,"result":{}}', TMCPTransportHints.None);
+  Assert.AreEqual('', Legacy.Body);
+  Assert.AreEqual(202, Legacy.HttpStatus);
+
+  var Modern := Run('{"jsonrpc":"2.0","id":1,"result":{}}', TMCPTransportHints.ForHttp(True, '2026-07-28'));
+  Assert.AreEqual(400, Modern.HttpStatus);
+  Assert.IsTrue(Modern.Body.Contains('-32600'));
+end;
+
+procedure TProcessorTests.ErrorData_IsEmitted;
+begin
+  var Outcome := Run('{"jsonrpc":"2.0","id":7,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2030-01-01","io.modelcontextprotocol/clientCapabilities":{}}}}', TMCPTransportHints.None);
+  Assert.AreEqual(400, Outcome.HttpStatus);
+  var Response := Parse(Outcome.Body);
+  try
+    Assert.AreEqual(7, Response.GetValue<Integer>('id'));
+    Assert.AreEqual(MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION, Response.GetValue<Integer>('error.code'));
+    Assert.AreEqual('2030-01-01', Response.GetValue<string>('error.data.requested'));
+    Assert.AreEqual('2026-07-28', Response.GetValue<string>('error.data.supported[0]'));
+  finally
+    Response.Free;
+  end;
+end;
+
+procedure TProcessorTests.Current_IsSetDuringDispatch_AndClearedAfter;
+begin
+  var Probe := TProbeManager.Create;
+  var Registry: IMCPManagerRegistry := TMCPManagerRegistry.Create;
+  Registry.RegisterManager(Probe);
+  var Processor := TMCPJsonRpcProcessor.Create(Registry, FSettings);
+  try
+    Processor.ProcessRequestEx('{"jsonrpc":"2.0","id":"x","method":"probe/run","params":{' + META + '}}', TMCPTransportHints.None);
+
+    Assert.IsNotNull(Probe.SeenContext);
+    Assert.AreSame(Probe.SeenContext, Probe.SeenCurrent);
+    Assert.AreEqual('x', Probe.SeenContext.RequestId.AsText);
+    Assert.AreEqual(TMCPProtocolEra.Modern, Probe.SeenContext.Era);
+    Assert.IsNull(TMCPRequestContext.Current);
+  finally
+    Probe.SeenContext := nil;
+    Probe.SeenCurrent := nil;
+    Processor.Free;
+  end;
+end;
+
+procedure TProcessorTests.Concurrent_Initialize_AllSucceed;
+const
+  REQUESTS = 50;
+begin
+  var Failures := 0;
+  var Tasks: TArray<ITask>;
+  SetLength(Tasks, REQUESTS);
+  for var I := 0 to High(Tasks) do
+    Tasks[I] := TTask.Run(
+      procedure
+      begin
+        var Outcome := FProcessor.ProcessRequestEx(
+          '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}',
+          TMCPTransportHints.None);
+        if not Outcome.Body.Contains('"protocolVersion":"2025-06-18"') or Outcome.Body.Contains('"error"') then
+          AtomicIncrement(Failures);
+      end);
+  TTask.WaitForAll(Tasks);
+
+  Assert.AreEqual(0, Failures);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TProcessorTests);
+
+end.

--- a/tests/MCPServer.Tests.RequestContext.pas
+++ b/tests/MCPServer.Tests.RequestContext.pas
@@ -1,0 +1,332 @@
+unit MCPServer.Tests.RequestContext;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Generics.Collections,
+  System.JSON,
+  MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.RequestContext,
+  MCPServer.JsonRpcProcessor,
+  MCPServer.Tests.Harness;
+
+type
+  /// Era detection, one branch per test, straight against BuildRequestContext.
+  [TestFixture]
+  TRequestContextTests = class
+  private
+    FHarness: TMCPTestHarness;
+    FSettings: TMCPSettings;
+    FProcessor: TMCPJsonRpcProcessor;
+    FSession: TMCPLegacySession;
+    function Build(const RequestJson: string; const Hints: TMCPTransportHints): IMCPRequestContext;
+    procedure ExpectError(const RequestJson: string; const Hints: TMCPTransportHints;
+      ExpectedCode, ExpectedStatus: Integer; const Because: string);
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test] procedure Initialize_IsLegacy_EvenWithModernMeta;
+    [Test] procedure Initialize_EchoesServedRevision;
+    [Test] procedure Initialize_UnknownRevision_AnswersLatestLegacy;
+    [Test] procedure ModernMeta_IsModern;
+    [Test] procedure ModernMeta_Http_HeaderMissing_IsHeaderMismatch;
+    [Test] procedure ModernMeta_Http_HeaderDiffers_IsHeaderMismatch;
+    [Test] procedure ModernMeta_Http_HeaderMatches_IsModern;
+    [Test] procedure ModernMeta_UnknownVersion_ListsSupported;
+    [Test] procedure ModernMeta_MissingClientCapabilities_IsInvalidParams;
+    [Test] procedure ModernMeta_ClientInfoNotObject_IsInvalidParams;
+    [Test] procedure ModernMeta_InvalidLogLevel_IsInvalidParams;
+    [Test] procedure ModernMeta_Ping_IsMethodNotFound;
+    [Test] procedure ModernMeta_Ping_LenientSetting_Allows;
+    [Test] procedure ModernMeta_LegacyOnlyMethods_AreNotFound;
+    [Test] procedure ModernOnlyMethod_WithoutMeta_IsInvalidParams;
+    [Test] procedure Http_ModernHeader_WithoutMeta_IsInvalidParams;
+    [Test] procedure Http_UnknownHeaderVersion_IsInvalidRequest;
+    [Test] procedure Http_LegacyHeader_IsLegacyWithHeaderVersion;
+    [Test] procedure Http_NoHeader_NoMeta_IsLegacy;
+    [Test] procedure Stdio_SessionVersion_IsUsedForLegacyRequests;
+    [Test] procedure Stdio_NoSessionVersion_IsLatestLegacy;
+    [Test] procedure LegacyMeta_WithProgressTokenOnly_IsLegacy;
+    [Test] procedure Meta_NotAnObject_IsInvalidParams;
+    [Test] procedure ClientCapabilities_AreReadable;
+    [Test] procedure RequireClientCapability_RaisesMissingCapability;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Errors;
+
+const
+  META_MODERN = '"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",'
+    + '"io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":{}}},'
+    + '"io.modelcontextprotocol/clientInfo":{"name":"ctx-client","version":"2.0"},'
+    + '"io.modelcontextprotocol/logLevel":"info"}';
+
+function Request(const Method: string; const ParamsJson: string = ''): string;
+begin
+  if ParamsJson = '' then
+    Result := Format('{"jsonrpc":"2.0","id":1,"method":"%s"}', [Method])
+  else
+    Result := Format('{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}', [Method, ParamsJson]);
+end;
+
+{ TRequestContextTests }
+
+procedure TRequestContextTests.Setup;
+begin
+  FHarness := TMCPTestHarness.Create;
+  FSettings := FHarness.Settings;
+  FProcessor := TMCPJsonRpcProcessor.Create(FHarness.ManagerRegistry, FSettings);
+  FSession := TMCPLegacySession.Create;
+end;
+
+procedure TRequestContextTests.TearDown;
+begin
+  FSession.Free;
+  FProcessor.Free;
+  FHarness.Free;
+end;
+
+function TRequestContextTests.Build(const RequestJson: string; const Hints: TMCPTransportHints): IMCPRequestContext;
+begin
+  var Message := TJSONObject.ParseJSONValue(RequestJson) as TJSONObject;
+  try
+    var Method := Message.GetValue('method').Value;
+    var Params := Message.GetValue('params') as TJSONObject;
+    var RequestId := TMCPRequestId.FromJson(Message.GetValue('id'));
+    Result := FProcessor.BuildRequestContext(Method, Params, RequestId, Hints);
+  finally
+    Message.Free;
+  end;
+end;
+
+procedure TRequestContextTests.ExpectError(const RequestJson: string; const Hints: TMCPTransportHints;
+  ExpectedCode, ExpectedStatus: Integer; const Because: string);
+begin
+  try
+    Build(RequestJson, Hints);
+    Assert.Fail('expected EMCPError ' + ExpectedCode.ToString + ': ' + Because);
+  except
+    on E: EMCPError do
+    begin
+      Assert.AreEqual(ExpectedCode, E.Code, Because + ' (code)');
+      Assert.AreEqual(ExpectedStatus, E.HttpStatus, Because + ' (http status)');
+    end;
+  end;
+end;
+
+procedure TRequestContextTests.Initialize_IsLegacy_EvenWithModernMeta;
+begin
+  var Context := Build(Request('initialize', '{"protocolVersion":"2025-11-25",' + META_MODERN + '}'), TMCPTransportHints.None);
+
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+  Assert.AreEqual('2025-11-25', Context.ProtocolVersion);
+end;
+
+procedure TRequestContextTests.Initialize_EchoesServedRevision;
+begin
+  Assert.AreEqual('2025-06-18', Build(Request('initialize', '{"protocolVersion":"2025-06-18"}'), TMCPTransportHints.None).ProtocolVersion);
+  Assert.AreEqual('2025-11-25', Build(Request('initialize', '{"protocolVersion":"2025-11-25"}'), TMCPTransportHints.None).ProtocolVersion);
+end;
+
+procedure TRequestContextTests.Initialize_UnknownRevision_AnswersLatestLegacy;
+begin
+  Assert.AreEqual('2025-11-25', Build(Request('initialize', '{"protocolVersion":"2025-03-26"}'), TMCPTransportHints.None).ProtocolVersion);
+  Assert.AreEqual('2025-11-25', Build(Request('initialize', '{"protocolVersion":"1900-01-01"}'), TMCPTransportHints.None).ProtocolVersion);
+  Assert.AreEqual('2025-11-25', Build(Request('initialize'), TMCPTransportHints.None).ProtocolVersion);
+end;
+
+procedure TRequestContextTests.ModernMeta_IsModern;
+begin
+  var Context := Build(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.None);
+
+  Assert.AreEqual(TMCPProtocolEra.Modern, Context.Era);
+  Assert.AreEqual('2026-07-28', Context.ProtocolVersion);
+  Assert.AreEqual('tools/list', Context.Method);
+  Assert.IsNotNull(Context.ClientCapabilities);
+  Assert.AreEqual('ctx-client', Context.ClientInfo.GetValue('name').Value);
+  Assert.AreEqual('info', Context.LogLevel);
+end;
+
+procedure TRequestContextTests.ModernMeta_Http_HeaderMissing_IsHeaderMismatch;
+begin
+  ExpectError(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.ForHttp(False, ''),
+    MCP_ERROR_HEADER_MISMATCH, 400, 'modern body without MCP-Protocol-Version header');
+end;
+
+procedure TRequestContextTests.ModernMeta_Http_HeaderDiffers_IsHeaderMismatch;
+begin
+  ExpectError(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.ForHttp(True, '2025-11-25'),
+    MCP_ERROR_HEADER_MISMATCH, 400, 'header differs from _meta');
+end;
+
+procedure TRequestContextTests.ModernMeta_Http_HeaderMatches_IsModern;
+begin
+  var Context := Build(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.ForHttp(True, '2026-07-28'));
+  Assert.AreEqual(TMCPProtocolEra.Modern, Context.Era);
+end;
+
+procedure TRequestContextTests.ModernMeta_UnknownVersion_ListsSupported;
+begin
+  var Body := Request('tools/list', '{"_meta":{"io.modelcontextprotocol/protocolVersion":"1900-01-01","io.modelcontextprotocol/clientCapabilities":{}}}');
+  try
+    Build(Body, TMCPTransportHints.None);
+    Assert.Fail('expected unsupported version');
+  except
+    on E: EMCPError do
+    begin
+      Assert.AreEqual(MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION, E.Code);
+      Assert.AreEqual(400, E.HttpStatus);
+      var Data := E.Data as TJSONObject;
+      Assert.AreEqual('1900-01-01', Data.GetValue('requested').Value);
+      var Supported := Data.GetValue('supported') as TJSONArray;
+      Assert.AreEqual(1, Supported.Count);
+      Assert.AreEqual('2026-07-28', Supported.Items[0].Value);
+    end;
+  end;
+end;
+
+procedure TRequestContextTests.ModernMeta_MissingClientCapabilities_IsInvalidParams;
+begin
+  ExpectError(Request('tools/list', '{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}'),
+    TMCPTransportHints.None, JSONRPC_INVALID_PARAMS, 400, 'clientCapabilities is required');
+  ExpectError(Request('tools/list', '{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":"yes"}}'),
+    TMCPTransportHints.None, JSONRPC_INVALID_PARAMS, 400, 'clientCapabilities must be an object');
+end;
+
+procedure TRequestContextTests.ModernMeta_ClientInfoNotObject_IsInvalidParams;
+begin
+  ExpectError(Request('tools/list', '{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":"me"}}'),
+    TMCPTransportHints.None, JSONRPC_INVALID_PARAMS, 400, 'clientInfo must be an object');
+end;
+
+procedure TRequestContextTests.ModernMeta_InvalidLogLevel_IsInvalidParams;
+begin
+  ExpectError(Request('tools/list', '{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/logLevel":"loud"}}'),
+    TMCPTransportHints.None, JSONRPC_INVALID_PARAMS, 400, 'logLevel outside the LoggingLevel set');
+end;
+
+procedure TRequestContextTests.ModernMeta_Ping_IsMethodNotFound;
+begin
+  ExpectError(Request('ping', '{' + META_MODERN + '}'), TMCPTransportHints.None,
+    JSONRPC_METHOD_NOT_FOUND, 404, 'ping was removed in 2026-07-28');
+end;
+
+procedure TRequestContextTests.ModernMeta_Ping_LenientSetting_Allows;
+begin
+  FSettings.LenientModernPing := True;
+  var Context := Build(Request('ping', '{' + META_MODERN + '}'), TMCPTransportHints.None);
+  Assert.AreEqual(TMCPProtocolEra.Modern, Context.Era);
+end;
+
+procedure TRequestContextTests.ModernMeta_LegacyOnlyMethods_AreNotFound;
+begin
+  for var Method in ['logging/setLevel', 'resources/subscribe', 'resources/unsubscribe'] do
+    ExpectError(Request(Method, '{' + META_MODERN + '}'), TMCPTransportHints.None,
+      JSONRPC_METHOD_NOT_FOUND, 404, Method + ' is legacy-only');
+end;
+
+procedure TRequestContextTests.ModernOnlyMethod_WithoutMeta_IsInvalidParams;
+begin
+  ExpectError(Request('server/discover'), TMCPTransportHints.None,
+    JSONRPC_INVALID_PARAMS, 400, 'server/discover needs _meta');
+  ExpectError(Request('subscriptions/listen', '{"subscriptions":[]}'), TMCPTransportHints.None,
+    JSONRPC_INVALID_PARAMS, 400, 'subscriptions/listen needs _meta');
+end;
+
+procedure TRequestContextTests.Http_ModernHeader_WithoutMeta_IsInvalidParams;
+begin
+  ExpectError(Request('tools/list'), TMCPTransportHints.ForHttp(True, '2026-07-28'),
+    JSONRPC_INVALID_PARAMS, 400, 'modern header names a revision the body does not carry');
+end;
+
+procedure TRequestContextTests.Http_UnknownHeaderVersion_IsInvalidRequest;
+begin
+  ExpectError(Request('tools/list'), TMCPTransportHints.ForHttp(True, '1900-01-01'),
+    JSONRPC_INVALID_REQUEST, 400, 'header version in neither set');
+end;
+
+procedure TRequestContextTests.Http_LegacyHeader_IsLegacyWithHeaderVersion;
+begin
+  var Context := Build(Request('tools/list'), TMCPTransportHints.ForHttp(True, '2025-06-18'));
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+  Assert.AreEqual('2025-06-18', Context.ProtocolVersion);
+
+  Context := Build(Request('tools/list'), TMCPTransportHints.ForHttp(True, '2025-03-26'));
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+end;
+
+procedure TRequestContextTests.Http_NoHeader_NoMeta_IsLegacy;
+begin
+  var Context := Build(Request('tools/list'), TMCPTransportHints.ForHttp(False, ''));
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+  Assert.AreEqual('2025-11-25', Context.ProtocolVersion);
+end;
+
+procedure TRequestContextTests.Stdio_SessionVersion_IsUsedForLegacyRequests;
+begin
+  FSession.ProtocolVersion := '2025-06-18';
+  var Context := Build(Request('tools/list'), TMCPTransportHints.ForStdio(FSession));
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+  Assert.AreEqual('2025-06-18', Context.ProtocolVersion);
+  Assert.AreSame(FSession, Context.LegacySession);
+end;
+
+procedure TRequestContextTests.Stdio_NoSessionVersion_IsLatestLegacy;
+begin
+  var Context := Build(Request('tools/list'), TMCPTransportHints.ForStdio(FSession));
+  Assert.AreEqual('2025-11-25', Context.ProtocolVersion);
+end;
+
+procedure TRequestContextTests.LegacyMeta_WithProgressTokenOnly_IsLegacy;
+begin
+  var Context := Build(Request('tools/call', '{"name":"echo","arguments":{},"_meta":{"progressToken":"p1"}}'), TMCPTransportHints.None);
+  Assert.AreEqual(TMCPProtocolEra.Legacy, Context.Era);
+  Assert.AreEqual('p1', Context.ProgressToken.Value);
+  Assert.IsNull(Context.ClientCapabilities);
+end;
+
+procedure TRequestContextTests.Meta_NotAnObject_IsInvalidParams;
+begin
+  ExpectError(Request('tools/list', '{"_meta":5}'), TMCPTransportHints.None,
+    JSONRPC_INVALID_PARAMS, 400, '_meta must be an object');
+end;
+
+procedure TRequestContextTests.ClientCapabilities_AreReadable;
+begin
+  var Context := Build(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.None);
+
+  Assert.IsTrue(Context.HasClientCapability('elicitation'));
+  Assert.IsTrue(Context.HasClientCapability('elicitation.form'));
+  Assert.IsFalse(Context.HasClientCapability('elicitation.url'));
+  Assert.IsFalse(Context.HasClientCapability('sampling'));
+end;
+
+procedure TRequestContextTests.RequireClientCapability_RaisesMissingCapability;
+begin
+  var Context := Build(Request('tools/list', '{' + META_MODERN + '}'), TMCPTransportHints.None);
+  try
+    Context.RequireClientCapability('sampling.tools');
+    Assert.Fail('expected -32021');
+  except
+    on E: EMCPError do
+    begin
+      Assert.AreEqual(MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY, E.Code);
+      Assert.AreEqual(400, E.HttpStatus);
+      var Required := (E.Data as TJSONObject).GetValue('requiredCapabilities') as TJSONObject;
+      Assert.IsNotNull((Required.GetValue('sampling') as TJSONObject).GetValue('tools'));
+    end;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TRequestContextTests);
+
+end.

--- a/tests/MCPServer.Tests.dpr
+++ b/tests/MCPServer.Tests.dpr
@@ -9,6 +9,9 @@ uses
   DUnitX.Loggers.Xml.NUnit,
   DUnitX.TestFramework,
   MCPServer.Types in '..\src\Protocol\MCPServer.Types.pas',
+  MCPServer.Errors in '..\src\Protocol\MCPServer.Errors.pas',
+  MCPServer.RequestContext in '..\src\Protocol\MCPServer.RequestContext.pas',
+  MCPServer.Capabilities in '..\src\Protocol\MCPServer.Capabilities.pas',
   MCPServer.Serializer in '..\src\Protocol\MCPServer.Serializer.pas',
   MCPServer.Schema.Generator in '..\src\Protocol\MCPServer.Schema.Generator.pas',
   MCPServer.Logger in '..\src\Core\MCPServer.Logger.pas',
@@ -38,7 +41,11 @@ uses
   MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas',
   MCPServer.Tests.ServerStatus in 'MCPServer.Tests.ServerStatus.pas',
   MCPServer.Tests.Registration in 'MCPServer.Tests.Registration.pas',
-  MCPServer.Tests.Logger in 'MCPServer.Tests.Logger.pas';
+  MCPServer.Tests.Logger in 'MCPServer.Tests.Logger.pas',
+  MCPServer.Tests.RequestContext in 'MCPServer.Tests.RequestContext.pas',
+  MCPServer.Tests.Processor in 'MCPServer.Tests.Processor.pas',
+  MCPServer.Tests.Capabilities in 'MCPServer.Tests.Capabilities.pas',
+  MCPServer.Tests.Golden.Modern in 'MCPServer.Tests.Golden.Modern.pas';
 
 procedure RunTests;
 begin

--- a/tests/MCPServer.Tests.dproj
+++ b/tests/MCPServer.Tests.dproj
@@ -73,6 +73,9 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="..\src\Protocol\MCPServer.Types.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.Errors.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.RequestContext.pas"/>
+        <DCCReference Include="..\src\Protocol\MCPServer.Capabilities.pas"/>
         <DCCReference Include="..\src\Protocol\MCPServer.Serializer.pas"/>
         <DCCReference Include="..\src\Protocol\MCPServer.Schema.Generator.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.Logger.pas"/>
@@ -100,6 +103,10 @@
         <DCCReference Include="MCPServer.Tests.ServerStatus.pas"/>
         <DCCReference Include="MCPServer.Tests.Registration.pas"/>
         <DCCReference Include="MCPServer.Tests.Logger.pas"/>
+        <DCCReference Include="MCPServer.Tests.RequestContext.pas"/>
+        <DCCReference Include="MCPServer.Tests.Processor.pas"/>
+        <DCCReference Include="MCPServer.Tests.Capabilities.pas"/>
+        <DCCReference Include="MCPServer.Tests.Golden.Modern.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -9,6 +9,7 @@ CHANGELOG; an unintended change is a regression.
 | Directory | Layer | Recorded by | Verified by |
 |---|---|---|---|
 | `legacy/` | JSON-RPC processor (`TMCPJsonRpcProcessor.ProcessRequest`) with the same registry as `MCPServer.dpr`, initialize-based protocol revisions | `scripts\run-tests.ps1 -Record` | `scripts\run-tests.ps1` (DUnitX fixture `TLegacyGoldenTests`) |
+| `modern/` | The same layer for requests that carry per-request `_meta` (MCP 2026-07-28), including the rejected shapes | `scripts\run-tests.ps1 -Record` | `scripts\run-tests.ps1` (DUnitX fixture `TModernGoldenTests`) |
 | `http/` | Streamable HTTP transport (`TMCPIdHTTPServer`) of the built executable, captured with curl | `scripts\capture-http-goldens.ps1 -Record` | `scripts\capture-http-goldens.ps1` |
 
 ## Legacy case files

--- a/tests/golden/http/modern-discover.txt
+++ b/tests/golden/http/modern-discover.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 105
+Content-Length: 322
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"JSON-RPC batch requests are not supported"}}
+{"jsonrpc":"2.0","id":"d1","result":{"resultType":"complete","supportedVersions":["2026-07-28"],"capabilities":{"tools":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false}},"_meta":{"io.modelcontextprotocol/serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}},"ttlMs":0,"cacheScope":"public"}}

--- a/tests/golden/http/modern-missing-client-capabilities.txt
+++ b/tests/golden/http/modern-missing-client-capabilities.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 105
+Content-Length: 151
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"JSON-RPC batch requests are not supported"}}
+{"jsonrpc":"2.0","id":24,"error":{"code":-32602,"message":"params._meta.io.modelcontextprotocol/clientCapabilities is required and must be an object"}}

--- a/tests/golden/http/modern-missing-version-header.txt
+++ b/tests/golden/http/modern-missing-version-header.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 105
+Content-Length: 100
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"JSON-RPC batch requests are not supported"}}
+{"jsonrpc":"2.0","id":22,"error":{"code":-32020,"message":"MCP-Protocol-Version header is missing"}}

--- a/tests/golden/http/modern-tools-list.txt
+++ b/tests/golden/http/modern-tools-list.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Type: application/json
+Content-Length: 1208
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
+Access-Control-Expose-Headers: Mcp-Session-Id
+Access-Control-Max-Age: 86400
+Connection: keep-alive
+
+{"jsonrpc":"2.0","id":20,"result":{"tools":[{"name":"get_time","description":"Get the current server time in ISO format","inputSchema":{"type":"object","properties":{}}},{"name":"calculate","description":"Perform basic arithmetic calculations","inputSchema":{"type":"object","properties":{"operation":{"type":"string","description":"Operation: add, subtract, multiply, divide","enum":["add","subtract","multiply","divide"]},"a":{"type":"number","description":"First number"},"b":{"type":"number","description":"Second number"}},"required":["operation","a","b"]}},{"name":"echo","description":"Echo a message back to the user","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Message to echo back"}},"required":["message"]}},{"name":"list_files","description":"List files in a directory","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list files from"},"includehidden":{"type":"boolean","description":"Include hidden files in the listing"}},"required":["path"]}}],"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}},"ttlMs":0,"cacheScope":"private"}}

--- a/tests/golden/http/modern-unknown-method.txt
+++ b/tests/golden/http/modern-unknown-method.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 105
+Content-Length: 141
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"JSON-RPC batch requests are not supported"}}
+{"jsonrpc":"2.0","id":21,"error":{"code":-32601,"message":"Method [prompts/list] not found. The method does not exist or is not available."}}

--- a/tests/golden/http/modern-unsupported-version.txt
+++ b/tests/golden/http/modern-unsupported-version.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 105
+Content-Length: 151
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -9,4 +9,4 @@ Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
 
-{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"JSON-RPC batch requests are not supported"}}
+{"jsonrpc":"2.0","id":23,"error":{"code":-32022,"message":"Unsupported protocol version","data":{"supported":["2026-07-28"],"requested":"1900-01-01"}}}

--- a/tests/golden/http/post-initialize-sse.txt
+++ b/tests/golden/http/post-initialize-sse.txt
@@ -1,7 +1,7 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: text/event-stream; charset=utf-8
-Content-Length: 341
+Content-Length: 254
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
@@ -13,4 +13,4 @@ X-Accel-Buffering: no
 
 id: <n>
 event: message
-data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"supportsProgress":false,"supportsCancellation":false},"resources":{"subscribe":false,"listChanged":false}},"sessionId":"<guid>","serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}
+data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false}},"serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}

--- a/tests/golden/http/post-initialize.txt
+++ b/tests/golden/http/post-initialize.txt
@@ -1,13 +1,12 @@
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json
-Content-Length: 312
+Content-Length: 225
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Headers: Accept, Content-Type, Last-Event-ID, Mcp-Protocol-Version, Mcp-Session-Id
 Access-Control-Expose-Headers: Mcp-Session-Id
 Access-Control-Max-Age: 86400
 Connection: keep-alive
-Mcp-Session-Id: <guid>
 
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"supportsProgress":false,"supportsCancellation":false},"resources":{"subscribe":false,"listChanged":false}},"sessionId":"<guid>","serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false}},"serverInfo":{"name":"delphi-mcp-server","version":"1.0.0"}}}

--- a/tests/golden/legacy/id-null.json
+++ b/tests/golden/legacy/id-null.json
@@ -4,5 +4,12 @@
     "id": null,
     "method": "ping"
   },
-  "expectedText": ""
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+      "code": -32600,
+      "message": "id must not be null"
+    }
+  }
 }

--- a/tests/golden/legacy/initialize-2025-03-26.json
+++ b/tests/golden/legacy/initialize-2025-03-26.json
@@ -20,18 +20,16 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
         "tools": {
-          "supportsProgress": false,
-          "supportsCancellation": false
+          "listChanged": false
         },
         "resources": {
           "subscribe": false,
           "listChanged": false
         }
       },
-      "sessionId": "<masked>",
       "serverInfo": {
         "name": "delphi-mcp-server",
         "version": "1.0.0"

--- a/tests/golden/legacy/initialize-2025-11-25.json
+++ b/tests/golden/legacy/initialize-2025-11-25.json
@@ -20,18 +20,16 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
         "tools": {
-          "supportsProgress": false,
-          "supportsCancellation": false
+          "listChanged": false
         },
         "resources": {
           "subscribe": false,
           "listChanged": false
         }
       },
-      "sessionId": "<masked>",
       "serverInfo": {
         "name": "delphi-mcp-server",
         "version": "1.0.0"

--- a/tests/golden/legacy/initialize-unknown-version.json
+++ b/tests/golden/legacy/initialize-unknown-version.json
@@ -20,18 +20,16 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
         "tools": {
-          "supportsProgress": false,
-          "supportsCancellation": false
+          "listChanged": false
         },
         "resources": {
           "subscribe": false,
           "listChanged": false
         }
       },
-      "sessionId": "<masked>",
       "serverInfo": {
         "name": "delphi-mcp-server",
         "version": "1.0.0"

--- a/tests/golden/legacy/initialize-without-params.json
+++ b/tests/golden/legacy/initialize-without-params.json
@@ -11,18 +11,16 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
         "tools": {
-          "supportsProgress": false,
-          "supportsCancellation": false
+          "listChanged": false
         },
         "resources": {
           "subscribe": false,
           "listChanged": false
         }
       },
-      "sessionId": "<masked>",
       "serverInfo": {
         "name": "delphi-mcp-server",
         "version": "1.0.0"

--- a/tests/golden/legacy/missing-jsonrpc-field.json
+++ b/tests/golden/legacy/missing-jsonrpc-field.json
@@ -6,7 +6,9 @@
   "expected": {
     "jsonrpc": "2.0",
     "id": 25,
-    "result": {
+    "error": {
+      "code": -32600,
+      "message": "jsonrpc must be \"2.0\""
     }
   }
 }

--- a/tests/golden/legacy/missing-method.json
+++ b/tests/golden/legacy/missing-method.json
@@ -7,8 +7,8 @@
     "jsonrpc": "2.0",
     "id": 26,
     "error": {
-      "code": -32601,
-      "message": "Method [] not found. The method does not exist or is not available."
+      "code": -32600,
+      "message": "method must be a string"
     }
   }
 }

--- a/tests/golden/legacy/params-not-an-object.json
+++ b/tests/golden/legacy/params-not-an-object.json
@@ -11,14 +11,9 @@
   "expected": {
     "jsonrpc": "2.0",
     "id": 27,
-    "result": {
-      "content": [
-        {
-          "type": "text",
-          "text": "Error: Invalid tool parameters"
-        }
-      ],
-      "isError": true
+    "error": {
+      "code": -32602,
+      "message": "params must be an object"
     }
   }
 }

--- a/tests/golden/legacy/request-not-an-object.json
+++ b/tests/golden/legacy/request-not-an-object.json
@@ -4,8 +4,8 @@
     "jsonrpc": "2.0",
     "id": null,
     "error": {
-      "code": -32700,
-      "message": "JSON-RPC request must be an object"
+      "code": -32600,
+      "message": "JSON-RPC batch requests are not supported"
     }
   }
 }

--- a/tests/golden/modern/id-null.json
+++ b/tests/golden/modern/id-null.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+      "code": -32600,
+      "message": "id must not be null"
+    }
+  }
+}

--- a/tests/golden/modern/initialize-with-modern-meta.json
+++ b/tests/golden/modern/initialize-with-modern-meta.json
@@ -1,26 +1,32 @@
 {
   "request": {
     "jsonrpc": "2.0",
-    "id": 1,
+    "id": 12,
     "method": "initialize",
     "params": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
       },
       "clientInfo": {
         "name": "golden-client",
         "version": "1.0.0"
+      },
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
       }
     }
   },
-  "mask": [
-    "result.sessionId"
-  ],
   "expected": {
     "jsonrpc": "2.0",
-    "id": 1,
+    "id": 12,
     "result": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {
         "tools": {
           "listChanged": false

--- a/tests/golden/modern/invalid-log-level.json
+++ b/tests/golden/modern/invalid-log-level.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 11,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/logLevel": "loud"
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 11,
+    "error": {
+      "code": -32602,
+      "message": "params._meta.io.modelcontextprotocol/logLevel must be one of debug, info, notice, warning, error, critical, alert, emergency"
+    }
+  }
+}

--- a/tests/golden/modern/missing-client-capabilities.json
+++ b/tests/golden/modern/missing-client-capabilities.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "error": {
+      "code": -32602,
+      "message": "params._meta.io.modelcontextprotocol/clientCapabilities is required and must be an object"
+    }
+  }
+}

--- a/tests/golden/modern/missing-jsonrpc-field.json
+++ b/tests/golden/modern/missing-jsonrpc-field.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "id": 13,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 13,
+    "error": {
+      "code": -32600,
+      "message": "jsonrpc must be \"2.0\""
+    }
+  }
+}

--- a/tests/golden/modern/ping.json
+++ b/tests/golden/modern/ping.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "ping",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "error": {
+      "code": -32601,
+      "message": "Method [ping] not found. The method does not exist or is not available."
+    }
+  }
+}

--- a/tests/golden/modern/resources-list.json
+++ b/tests/golden/modern/resources-list.json
@@ -1,0 +1,59 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "resources/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "result": {
+      "resources": [
+        {
+          "uri": "project://readme",
+          "name": "Project README",
+          "description": "README.md file contents",
+          "mimeType": "text/markdown"
+        },
+        {
+          "uri": "logs://recent",
+          "name": "Recent Logs",
+          "description": "Recent log entries from all categories",
+          "mimeType": "application/json"
+        },
+        {
+          "uri": "project://info",
+          "name": "Project Information",
+          "description": "Basic information about the Delphi MCP Server project",
+          "mimeType": "application/json"
+        },
+        {
+          "uri": "server://status",
+          "name": "server_status",
+          "description": "Current server status and health information",
+          "mimeType": "application/json"
+        }
+      ],
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      },
+      "ttlMs": 0,
+      "cacheScope": "private"
+    }
+  }
+}

--- a/tests/golden/modern/resources-read-project-info.json
+++ b/tests/golden/modern/resources-read-project-info.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "resources/read",
+    "params": {
+      "uri": "project://info",
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "result": {
+      "contents": [
+        {
+          "uri": "project://info",
+          "mimeType": "application/json",
+          "text": "{\"name\":\"delphi-mcp-server\",\"version\":\"1.0.0\",\"description\":\"A Model Context Protocol (MCP) server implementation in Delphi\",\"language\":\"Delphi\",\"framework\":\"Indy HTTP Server (TIdHTTPServer)\",\"protocol\":\"MCP 2025-06-18\",\"transport\":\"Streamable HTTP\",\"author\":\"GDK Software\",\"repository\":\"https://github.com/GDKsoftware/delphi-mcp-server\",\"features\":[\"Tools capability\",\"Resources capability\",\"JSON-RPC 2.0 support\",\"CORS support\"]}"
+        }
+      ],
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      },
+      "ttlMs": 0,
+      "cacheScope": "private"
+    }
+  }
+}

--- a/tests/golden/modern/resources-templates-list.json
+++ b/tests/golden/modern/resources-templates-list.json
@@ -1,0 +1,35 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "resources/templates/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 6,
+    "result": {
+      "resourceTemplates": [
+      ],
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      },
+      "ttlMs": 0,
+      "cacheScope": "private"
+    }
+  }
+}

--- a/tests/golden/modern/server-discover-without-meta.json
+++ b/tests/golden/modern/server-discover-without-meta.json
@@ -1,12 +1,12 @@
 {
   "request": {
     "jsonrpc": "2.0",
-    "id": 21,
+    "id": "discover-2",
     "method": "server/discover"
   },
   "expected": {
     "jsonrpc": "2.0",
-    "id": 21,
+    "id": "discover-2",
     "error": {
       "code": -32602,
       "message": "server/discover requires params._meta.io.modelcontextprotocol/protocolVersion"

--- a/tests/golden/modern/server-discover.json
+++ b/tests/golden/modern/server-discover.json
@@ -1,0 +1,45 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": "discover-1",
+    "method": "server/discover",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": "discover-1",
+    "result": {
+      "resultType": "complete",
+      "supportedVersions": [
+        "2026-07-28"
+      ],
+      "capabilities": {
+        "tools": {
+          "listChanged": false
+        },
+        "resources": {
+          "subscribe": false,
+          "listChanged": false
+        }
+      },
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      },
+      "ttlMs": 0,
+      "cacheScope": "public"
+    }
+  }
+}

--- a/tests/golden/modern/tools-call-echo.json
+++ b/tests/golden/modern/tools-call-echo.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+      "name": "echo",
+      "arguments": {
+        "message": "hello modern"
+      },
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Echo: hello modern"
+        }
+      ],
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/golden/modern/tools-call-unknown-tool.json
+++ b/tests/golden/modern/tools-call-unknown-tool.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "no_such_tool",
+      "arguments": {
+      },
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Error: Tool not found: no_such_tool"
+        }
+      ],
+      "isError": true,
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/golden/modern/tools-list.json
+++ b/tests/golden/modern/tools-list.json
@@ -1,0 +1,112 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "tools": [
+        {
+          "name": "get_time",
+          "description": "Get the current server time in ISO format",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+            }
+          }
+        },
+        {
+          "name": "calculate",
+          "description": "Perform basic arithmetic calculations",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "description": "Operation: add, subtract, multiply, divide",
+                "enum": [
+                  "add",
+                  "subtract",
+                  "multiply",
+                  "divide"
+                ]
+              },
+              "a": {
+                "type": "number",
+                "description": "First number"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number"
+              }
+            },
+            "required": [
+              "operation",
+              "a",
+              "b"
+            ]
+          }
+        },
+        {
+          "name": "echo",
+          "description": "Echo a message back to the user",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "description": "Message to echo back"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        {
+          "name": "list_files",
+          "description": "List files in a directory",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Directory path to list files from"
+              },
+              "includehidden": {
+                "type": "boolean",
+                "description": "Include hidden files in the listing"
+              }
+            },
+            "required": [
+              "path"
+            ]
+          }
+        }
+      ],
+      "resultType": "complete",
+      "_meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "delphi-mcp-server",
+          "version": "1.0.0"
+        }
+      },
+      "ttlMs": 0,
+      "cacheScope": "private"
+    }
+  }
+}

--- a/tests/golden/modern/unknown-method.json
+++ b/tests/golden/modern/unknown-method.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "method": "prompts/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "golden-client",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "error": {
+      "code": -32601,
+      "message": "Method [prompts/list] not found. The method does not exist or is not available."
+    }
+  }
+}

--- a/tests/golden/modern/unknown-protocol-version.json
+++ b/tests/golden/modern/unknown-protocol-version.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "1900-01-01",
+        "io.modelcontextprotocol/clientCapabilities": {
+        }
+      }
+    }
+  },
+  "expected": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "error": {
+      "code": -32022,
+      "message": "Unsupported protocol version",
+      "data": {
+        "supported": [
+          "2026-07-28"
+        ],
+        "requested": "1900-01-01"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Dual-era JSON-RPC core: server/discover and per-request `_meta`

After this change a 2026-07-28 client talks to the server over stdio and over the HTTP happy path, while `initialize`-based clients (2025-06-18, 2025-11-25) are served as before. The era is decided per request in one place, `TMCPJsonRpcProcessor.BuildRequestContext`; nothing is negotiated per connection and no session is minted.

### Behaviour

| Request | Era | Outcome |
|---|---|---|
| `initialize` | legacy | Echoes `2025-06-18` or `2025-11-25`, otherwise answers `2025-11-25`; capabilities come from the registered managers; no `sessionId`, no `supportsProgress`/`supportsCancellation` |
| `_meta.io.modelcontextprotocol/protocolVersion` present | modern | `clientCapabilities` required and `logLevel` checked (`-32602`), unknown revision `-32022` with `data.supported`, HTTP header/body mismatch `-32020`, `ping`/`logging/setLevel`/`resources/subscribe`/`resources/unsubscribe` `-32601` |
| `server/discover` or `subscriptions/listen` without `_meta` | modern, malformed | `-32602` |
| HTTP header names a modern revision, body has no `_meta` | modern, malformed | `-32602`; an unknown header revision is `-32600` |
| everything else | legacy | negotiated stdio revision, header revision, or `2025-11-25` |

Modern results carry `resultType: "complete"`, `_meta.io.modelcontextprotocol/serverInfo` and, for `server/discover`, `tools/list`, `resources/list`, `resources/templates/list` and `resources/read`, `ttlMs`/`cacheScope` when the handler did not set them. Legacy results are untouched. The HTTP status of every outcome is computed (`TMCPProcessResult.HttpStatus`: 400/404 for modern protocol errors, always 200 for legacy) but the transport still answers 200; wiring it is the next step together with the header validation.

Message-shape errors now use the JSON-RPC codes: batch arrays, `id: null`, missing `method` or `jsonrpc` are `-32600`, a non-object `params` is `-32602`. Client responses are ignored.

### Code

- New units `MCPServer.Errors`, `MCPServer.RequestContext`, `MCPServer.Capabilities`; new interfaces `IMCPCapabilityManagerEx`, `IMCPCapabilityProvider`, `IMCPManagerEnumerator`, `IMCPRegistryAware` and the types `TMCPProtocolEra`, `TMCPRequestId`, `TMCPLegacySession` in `MCPServer.Types`.
- `TMCPJsonRpcProcessor.ProcessRequestEx` (body, status, era) next to the unchanged `ProcessRequest`; `Create(Registry, Settings)` overload; handlers reach the request through `TMCPRequestContext.Current` or `IMCPCapabilityManagerEx`.
- `TMCPCoreManager`: `server/discover`, revision negotiation, no session state; `TMCPManagerRegistry` enumerates managers and injects itself.
- Settings: `[Server] Title`, `Description`, `WebsiteUrl`, `Instructions`; `[Protocol] LenientModernPing`, `DiscoverListsLegacyVersions`, `DiscoverTtlMs`.
- Existing interfaces, GUIDs, constructors and `ExecuteWithParams` are unchanged.

### Tests and runs

- 120 DUnitX tests, green on Win32 and Win64: era detection per branch, status policy, envelope, discover, thread-local context, 50 concurrent `initialize` calls, capability builder, 38 legacy and 16 modern golden cases.
- Legacy goldens re-recorded only where the wire changed on purpose (initialize, batch, `id: null`, missing `method`/`jsonrpc`, non-object `params`, `server/discover` without `_meta`); the other cases are byte-identical.
- HTTP goldens: six modern cases added; `initialize` no longer carries `Mcp-Session-Id`.
- Conformance `--requirements 2026-07-28`: 87 passed / 75 failed (was 32 / 128); `tools-list`, `tools-call-simple-text`, `tools-call-error`, `resources-list`, `resources-read-text`, `resources-templates-read` and four `input-required-result-*` scenarios now pass. `--requirements 2025-11-25` unchanged (39 / 23). Baselines regenerated.
- Inspector smoke: legacy, auto, modern and stdio all list the four tools.
- stdio smoke passes; Linux64 compiles.
