### PR TITLE
Add tool annotations and server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,28 @@ initialization
 end.
 ```
 
+### Declaring Tool Annotations
+
+MCP clients decide things like whether to run tool calls in parallel, or whether to prompt the
+user for confirmation before a call, based on [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations)
+such as `readOnlyHint` and `openWorldHint`. Without them, a client has to assume the worst case:
+that a tool may write, may destroy data, and may call out to the network. If your tool never
+does any of that, say so by calling `MarkReadOnly` in its constructor:
+
+```pascal
+constructor TCustomTool.Create;
+begin
+  inherited;
+  FName := 'custom_tool';
+  FDescription := 'A custom tool that processes input';
+  MarkReadOnly; // readOnlyHint: true, openWorldHint: false (pass True for a tool that calls out)
+end;
+```
+
+This is entirely optional; a tool that never calls `MarkReadOnly` is reported to clients without
+an `annotations` object, which is the same as declaring nothing (the spec's defaults apply).
+Annotations are hints, not a security boundary — clients are not required to act on them.
+
 ### Creating Custom Resources
 
 ```pascal
@@ -454,6 +476,23 @@ The server provides four essential resources accessible via URIs:
 ## Configuration
 
 The server supports configuration through `settings.ini` files. A default `settings.ini.example` is provided in the repository.
+
+### Server Instructions
+
+`Server.Instructions` in `settings.ini` (or `TMCPSettings.Instructions` in code) is returned as
+`instructions` in the `initialize` response. Per the MCP spec this is a hint the client MAY add
+to its system prompt; some clients (Claude Code) do, others (Claude.ai, Claude Desktop as of
+this writing) currently ignore the field. Use it for guidance that applies across tools —
+_when_ to reach for this server at all — rather than duplicating what a single tool's
+description already says:
+
+```ini
+[Server]
+Instructions=Call search_docs before answering any question about this product's API, even when you already know a similar API from another product.
+```
+
+Left empty (the default), the field is omitted from the response entirely rather than sent as
+an empty string.
 
 ### SSL/TLS Configuration
 

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -8,6 +8,9 @@ Host=localhost
 Name=delphi-mcp-server
 Version=1.0.0
 Endpoint=/mcp
+; Optional hint for the calling model, sent as "instructions" in the initialize response
+; (MCP spec: clients MAY add it to the system prompt). Leave empty to omit the field.
+Instructions=
 
 [CORS]
 ; Cross-Origin Resource Sharing configuration

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -15,6 +15,7 @@ type
     FServerName: string;
     FServerVersion: string;
     FEndpoint: string;
+    FInstructions: string;
     FCorsEnabled: Boolean;
     FCorsAllowedOrigins: string;
     FSettingsFile: string;
@@ -39,6 +40,10 @@ type
     property ServerName: string read FServerName write FServerName;
     property ServerVersion: string read FServerVersion write FServerVersion;
     property Endpoint: string read FEndpoint write FEndpoint;
+    { Optional guidance for the calling model, returned as "instructions" in the initialize
+      result (MCP spec: a hint the client MAY add to its system prompt). Empty by default;
+      the field is left out of the response entirely when empty. }
+    property Instructions: string read FInstructions write FInstructions;
     property CorsEnabled: Boolean read FCorsEnabled write FCorsEnabled;
     property CorsAllowedOrigins: string read FCorsAllowedOrigins write FCorsAllowedOrigins;
     property SettingsFile: string read FSettingsFile;
@@ -87,6 +92,7 @@ begin
   FServerName := 'delphi-mcp-server';
   FServerVersion := '1.0.0';
   FEndpoint := '/mcp';
+  FInstructions := '';
   FCorsEnabled := True;
   FCorsAllowedOrigins := 'http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1';
   FSSLEnabled := False;
@@ -115,7 +121,9 @@ begin
     IniFile.WriteString('Server', 'Name', FServerName);
     IniFile.WriteString('Server', 'Version', FServerVersion);
     IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    
+    IniFile.WriteString('Server', '; Optional hint added to the initialize response for the calling model', '');
+    IniFile.WriteString('Server', 'Instructions', FInstructions);
+
     IniFile.WriteString('CORS', '; Cross-Origin Resource Sharing configuration', '');
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', '; Comma-separated list of allowed origins', '');
@@ -145,7 +153,8 @@ begin
     FServerName := IniFile.ReadString('Server', 'Name', FServerName);
     FServerVersion := IniFile.ReadString('Server', 'Version', FServerVersion);
     FEndpoint := IniFile.ReadString('Server', 'Endpoint', FEndpoint);
-    
+    FInstructions := IniFile.ReadString('Server', 'Instructions', FInstructions);
+
     FCorsEnabled := IniFile.ReadBool('CORS', 'Enabled', FCorsEnabled);
     FCorsAllowedOrigins := IniFile.ReadString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
     
@@ -181,7 +190,8 @@ begin
     IniFile.WriteString('Server', 'Name', FServerName);
     IniFile.WriteString('Server', 'Version', FServerVersion);
     IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    
+    IniFile.WriteString('Server', 'Instructions', FInstructions);
+
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
     

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -124,12 +124,17 @@ begin
 {$ENDIF}
     
     ResultJSON.AddPair('sessionId', FSessionID);
-    
+
     ServerInfo := TJSONObject.Create;
     ResultJSON.AddPair('serverInfo', ServerInfo);
     ServerInfo.AddPair('name', FSettings.ServerName);
     ServerInfo.AddPair('version', FSettings.ServerVersion);
-    
+
+    { Optional per the MCP spec; left out entirely when empty rather than sent as "". }
+    if FSettings.Instructions <> '' then
+      ResultJSON.AddPair('instructions', FSettings.Instructions);
+
+
     TLogger.Info('Created new MCP session: ' + FSessionID);
     
     Result := TValue.From<TJSONObject>(ResultJSON);

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -186,6 +186,8 @@ function TMCPToolsManager.CreateToolJSON(const Tool: IMCPTool): TJSONObject;
 var
   Schema: TJSONObject;
   SchemaClone: TJSONObject;
+  ToolAnnotations: IMCPToolAnnotations;
+  AnnotationsSource: TJSONObject;
 begin
   Result := TJSONObject.Create;
   Result.AddPair('name', Tool.Name);
@@ -208,6 +210,14 @@ begin
     Schema.Free;
   end;
 
+  { Optional: only tools that implement IMCPToolAnnotations (the base classes do) carry
+    readOnlyHint/openWorldHint, so a tool built directly on IMCPTool is unaffected. }
+  if Supports(Tool, IMCPToolAnnotations, ToolAnnotations) then
+  begin
+    AnnotationsSource := ToolAnnotations.Annotations;
+    if Assigned(AnnotationsSource) then
+      Result.AddPair('annotations', TJSONObject(AnnotationsSource.Clone));
+  end;
 end;
 
 function TMCPToolsManager.BuildToolListResponse: TJSONObject;

--- a/src/Tools/MCPServer.Tool.Base.pas
+++ b/src/Tools/MCPServer.Tool.Base.pas
@@ -24,55 +24,79 @@ type
     property OutputSchema: TJSONObject read GetOutputSchema;
   end;
 
-  TMCPToolBase = class(TInterfacedObject, IMCPTool)
+  { Optional: a tool implements this alongside IMCPTool to describe its side effects and
+    network reach as MCP tool annotations (hints, not guarantees per the spec). tools/list
+    adds them to the response only when a tool supports this interface, so an existing
+    IMCPTool implementation that does not know about it keeps compiling and working unchanged. }
+  IMCPToolAnnotations = interface
+    ['{7B54B6B9-9A9B-4A9F-9C7B-1F6E2C6B7A9C}']
+    function GetAnnotations: TJSONObject;
+    property Annotations: TJSONObject read GetAnnotations;
+  end;
+
+  TMCPToolBase = class(TInterfacedObject, IMCPTool, IMCPToolAnnotations)
   protected
     FName: string;
     FTitle: string;
     FDescription: string;
+    FAnnotations: TJSONObject;
     function BuildSchema: TJSONObject; virtual; abstract;
+    { Declares the tool read-only (it never modifies state) and, unless OpenWorld is set,
+      confined to local/deterministic data (no calls to external services). }
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
   public
     constructor Create; virtual;
+    destructor Destroy; override;
 
     function GetName: string;
     function GetTitle: string;
     function GetDescription: string;
     function GetInputSchema: TJSONObject;
     function GetOutputSchema: TJSONObject;
+    function GetAnnotations: TJSONObject;
     function Execute(const Arguments: TJSONObject): TValue; virtual; abstract;
   end;
 
-  TMCPToolBase<T : class, constructor> = class(TInterfacedObject, IMCPTool)
+  TMCPToolBase<T : class, constructor> = class(TInterfacedObject, IMCPTool, IMCPToolAnnotations)
   protected
     FName: string;
     FTitle: string;
     FDescription: string;
+    FAnnotations: TJSONObject;
     function ExecuteWithParams(const Params: T): string;virtual; abstract;
     function GetParamsClass: TClass; virtual;
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
   public
     constructor Create; virtual;
+    destructor Destroy; override;
 
     function GetName: string;
     function GetTitle: string;
     function GetDescription: string;
     function GetInputSchema: TJSONObject;
     function GetOutputSchema: TJSONObject;
+    function GetAnnotations: TJSONObject;
     function Execute(const Arguments: TJSONObject): TValue;
   end;
 
-  TMCPToolBase<T,R : class, constructor> = class(TInterfacedObject, IMCPTool)
+  TMCPToolBase<T,R : class, constructor> = class(TInterfacedObject, IMCPTool, IMCPToolAnnotations)
   protected
     FName: string;
     FTitle: string;
     FDescription: string;
+    FAnnotations: TJSONObject;
     function ExecuteWithParams(const Params: T): R;virtual; abstract;
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
   public
     constructor Create; virtual;
+    destructor Destroy; override;
 
     function GetName: string;
     function GetTitle: string;
     function GetDescription: string;
     function GetInputSchema: TJSONObject;
     function GetOutputSchema: TJSONObject;
+    function GetAnnotations: TJSONObject;
     function Execute(const Arguments: TJSONObject): TValue;
   end;
 
@@ -90,6 +114,33 @@ uses
 constructor TMCPToolBase.Create;
 begin
   inherited Create;
+end;
+
+destructor TMCPToolBase.Destroy;
+begin
+  FAnnotations.Free;
+  inherited;
+end;
+
+procedure TMCPToolBase.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  if not Assigned(FAnnotations) then
+    FAnnotations := TJSONObject.Create;
+{$IF COMPILERVERSION <= 29}
+  FAnnotations.AddPair('readOnlyHint', TJSONTrue.Create);
+  if OpenWorld then
+    FAnnotations.AddPair('openWorldHint', TJSONTrue.Create)
+  else
+    FAnnotations.AddPair('openWorldHint', TJSONFalse.Create);
+{$ELSE}
+  FAnnotations.AddPair('readOnlyHint', TJSONBool.Create(True));
+  FAnnotations.AddPair('openWorldHint', TJSONBool.Create(OpenWorld));
+{$ENDIF}
+end;
+
+function TMCPToolBase.GetAnnotations: TJSONObject;
+begin
+  Result := FAnnotations;
 end;
 
 function TMCPToolBase.GetName: string;
@@ -125,6 +176,33 @@ end;
 constructor TMCPToolBase<T>.Create;
 begin
   inherited Create;
+end;
+
+destructor TMCPToolBase<T>.Destroy;
+begin
+  FAnnotations.Free;
+  inherited;
+end;
+
+procedure TMCPToolBase<T>.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  if not Assigned(FAnnotations) then
+    FAnnotations := TJSONObject.Create;
+{$IF COMPILERVERSION <= 29}
+  FAnnotations.AddPair('readOnlyHint', TJSONTrue.Create);
+  if OpenWorld then
+    FAnnotations.AddPair('openWorldHint', TJSONTrue.Create)
+  else
+    FAnnotations.AddPair('openWorldHint', TJSONFalse.Create);
+{$ELSE}
+  FAnnotations.AddPair('readOnlyHint', TJSONBool.Create(True));
+  FAnnotations.AddPair('openWorldHint', TJSONBool.Create(OpenWorld));
+{$ENDIF}
+end;
+
+function TMCPToolBase<T>.GetAnnotations: TJSONObject;
+begin
+  Result := FAnnotations;
 end;
 
 function TMCPToolBase<T>.GetName: string;
@@ -178,6 +256,33 @@ end;
 constructor TMCPToolBase<T, R>.Create;
 begin
   inherited Create;
+end;
+
+destructor TMCPToolBase<T, R>.Destroy;
+begin
+  FAnnotations.Free;
+  inherited;
+end;
+
+procedure TMCPToolBase<T, R>.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  if not Assigned(FAnnotations) then
+    FAnnotations := TJSONObject.Create;
+{$IF COMPILERVERSION <= 29}
+  FAnnotations.AddPair('readOnlyHint', TJSONTrue.Create);
+  if OpenWorld then
+    FAnnotations.AddPair('openWorldHint', TJSONTrue.Create)
+  else
+    FAnnotations.AddPair('openWorldHint', TJSONFalse.Create);
+{$ELSE}
+  FAnnotations.AddPair('readOnlyHint', TJSONBool.Create(True));
+  FAnnotations.AddPair('openWorldHint', TJSONBool.Create(OpenWorld));
+{$ENDIF}
+end;
+
+function TMCPToolBase<T, R>.GetAnnotations: TJSONObject;
+begin
+  Result := FAnnotations;
 end;
 
 function TMCPToolBase<T, R>.Execute(const Arguments: TJSONObject): TValue;


### PR DESCRIPTION
## Summary
- Add an optional `IMCPToolAnnotations` interface (implemented by `TMCPToolBase` and its two generic variants) with a `MarkReadOnly(OpenWorld: Boolean = False)` helper; `tools/list` includes `readOnlyHint`/`openWorldHint` for any tool that supports it, and leaves out `annotations` entirely for tools that don't, so this is backward compatible with any existing `IMCPTool` implementation.
- Add `TMCPSettings.Instructions` (`settings.ini`: `Server.Instructions`), surfaced as the optional top-level `instructions` field of the `initialize` response per the MCP spec, omitted when empty.
- Document both in the README and `settings.ini.example`.

## Why
Per the spec, clients MAY add `instructions` to their system prompt and MAY use tool annotations to decide things like parallel execution or auto-approval of read-only calls. Several consuming projects (Context4D among them) expose only read-only, local lookups and want to say so explicitly instead of clients assuming the worst-case defaults.

## Test plan
- [x] `dcc32`/`dcc64` build of a consumer project (Context4D) against this branch, Debug and Release, Win32 and Win64
- [x] Consumer's own smoke test (stdio and Streamable HTTP transports) verifies `instructions` in `initialize` and `readOnlyHint:true` on every tool in `tools/list`
- [ ] No automated tests in this repo itself (Windows + Delphi runner required, same as noted in consuming projects)