### PR TITLE
Review fixes: thread safety, lifetimes and input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,3 +288,29 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The result object of a `TMCPToolBase<T, R>` tool was cloned into
   `structuredContent` and never freed; every call leaked it.
 - Enumeration properties of a result were serialised as booleans.
+- Resource templates compiled their pattern into one shared `TRegEx` and
+  matched on it from every Indy thread at once; matching is thread-safe now.
+  Template variables are percent-decoded only: a `+` in a URI stays a `+`.
+- The stdio worker threads could still be running when the transport was
+  freed after the drain timeout; the transport now leaves the shared objects
+  in place for them instead of freeing them under a running thread.
+- The stdio line reader read a line longer than the limit into memory before
+  rejecting it; it now discards such a line chunk by chunk up to its newline.
+- `TMCPLegacySession` was read and written by several threads without a
+  lock.
+- Origin allow-list entries without a port did not match an `Origin` header
+  that spelled out the default port (`https://app.example:443`), and the
+  other way round.
+- `jsonrpc`, `method`, `protocolVersion`, `MCP-Name` and the cancel `reason`
+  were accepted when they were numbers, because `TJSONNumber` descends from
+  `TJSONString`; `IsJsonString` in `MCPServer.Types` tells them apart.
+- `completion/complete` for an unknown `ref/resource` answers `-32002` to a
+  legacy client (`-32602` stays for a modern one).
+- `TMCPCompletionManager` did not hold a reference to the prompts and
+  resources managers it was given as interfaces.
+- The `/info` endpoint listed the protocol versions in a fixed string; it
+  now derives them from the supported version lists, newest first.
+- An invalid JSON literal in a `[SchemaDefault]` attribute raises
+  `EArgumentException` instead of being silently dropped.
+- A tool result that fails to serialise no longer leaks the partial JSON
+  object; the DEBUG `outputSchema` check no longer leaks the schema.

--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ We welcome contributions! Here's how to help:
 ### Pull Requests
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Follow existing code style (inline vars, named constants)
+3. Follow the existing code style (inline vars, named constants, no comments in code); `coding-rules.md` in the repository root lists the conventions this library keeps on purpose
 4. Test your changes
 5. Submit a pull request
 

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -1,0 +1,33 @@
+# Coding rules
+
+This file records where this repository deviates from the GDK Delphi coding standard and why. Everything not listed here follows that standard.
+
+## Exceptions
+
+### Registration in `initialization` sections
+
+Tools, prompts, resources and resource templates register themselves in the `initialization` section of their own unit. Consumers add a unit to their project's `uses` clause and the item is available; that is the public contract of the library and the reason no central registration list exists. New tool, prompt and resource units follow the same pattern.
+
+### System.Generics.Collections
+
+The library has no third-party dependencies so that it can be dropped into any Delphi project. `System.Generics.Collections` is used instead of Spring4D collections.
+
+### Public global functions
+
+`MCPServer.Types` and a few other units expose global functions (`IsJsonString`, `StandardInputStream`, `StandardOutputStream`) because they are part of the public API and because attribute or record helpers cannot host them. Internal helpers still belong in classes or records.
+
+### Constructor parameter names in attributes
+
+Schema attributes and exception classes keep the `A` prefix on constructor parameters where the parameter would otherwise shadow a property of the same class (`Code`, `Message`, `Description`). Elsewhere parameters carry no prefix.
+
+### Framework callback signatures
+
+Indy event handlers keep the signature Indy declares, including `var` parameters (for example `OnQuerySSLPort`).
+
+### DUnitX fixtures
+
+The test runner uses RTTI discovery (`UseRTTI := True`). Test units have no `initialization` section.
+
+### Class section markers
+
+The `{ TClassName }` markers the IDE generates in the implementation section are kept. No other comments are used; behaviour is documented in the README, CHANGELOG and MIGRATION guide.

--- a/src/Core/MCPServer.Logger.pas
+++ b/src/Core/MCPServer.Logger.pas
@@ -12,14 +12,14 @@ type
   {$SCOPEDENUMS ON}
   TLogLevel = (Debug, Info, Warning, Error);
   {$SCOPEDENUMS OFF}
-  
+
   TLogMessageProc = reference to procedure(const Message: string);
 
   TLogger = class
   private
     class var FInstance: TLogger;
     class var FLock: TCriticalSection;
-    
+
     FLogToConsole: Boolean;
     FLogToFile: Boolean;
     FLogFile: TStreamWriter;
@@ -54,25 +54,22 @@ type
     class constructor Create;
     class destructor Destroy;
     destructor Destroy; override;
-    
+
     class function Instance: TLogger;
-    
+
     class procedure Debug(const Message: string); overload;
     class procedure Debug(const Format: string; const Args: array of const); overload;
-    
+
     class procedure Info(const Message: string); overload;
     class procedure Info(const Format: string; const Args: array of const); overload;
-    
+
     class procedure Warning(const Message: string); overload;
     class procedure Warning(const Format: string; const Args: array of const); overload;
-    
+
     class procedure Error(const Message: string); overload;
     class procedure Error(const Format: string; const Args: array of const); overload;
     class procedure Error(const Exception: Exception); overload;
 
-    /// Returns the JSON text with the values of _meta, requestState,
-    /// inputResponses and token-like members replaced, for logging. Text
-    /// that is not JSON is described by its length only.
     class function RedactJson(const Json: string): string;
 
     class property LogToConsole: Boolean read GetLogToConsole write SetLogToConsole;
@@ -81,10 +78,6 @@ type
     class property MinLogLevel: TLogLevel read GetMinLogLevel write SetMinLogLevel;
     class property OnLogMessage: TLogMessageProc read GetOnLogMessage write SetOnLogMessage;
     class property UseStdErr: Boolean read GetUseStdErr write SetUseStdErr;
-    /// True while a stdio transport owns stdout. Console logging then always
-    /// goes to stderr, and setting UseStdErr to False is refused with a
-    /// one-time warning, because anything on stdout that is not an MCP
-    /// message corrupts the channel. Set by TMCPStdioTransport.Create.
     class property StdoutReserved: Boolean read GetStdoutReserved write SetStdoutReserved;
   end;
 
@@ -142,7 +135,6 @@ begin
   Result := FInstance;
 end;
 
-
 procedure TLogger.EnsureLogFile;
 begin
   if FLogToFile and not Assigned(FLogFile) then
@@ -182,7 +174,6 @@ begin
   try
     if FLogToConsole then
     begin
-      // Never touch stdout while a stdio transport owns it.
       ToStdErr := FUseStdErr or FStdoutReserved;
 
       {$IFDEF MSWINDOWS}
@@ -202,14 +193,14 @@ begin
       SetConsoleTextAttribute(ConsoleHandle, 7);
       {$ENDIF}
     end;
-      
+
     if FLogToFile then
     begin
       EnsureLogFile;
       if Assigned(FLogFile) then
         FLogFile.WriteLine(LogLine);
     end;
-    
+
     if Assigned(FOnLogMessage) then
       FOnLogMessage(LogLine);
   finally
@@ -407,7 +398,6 @@ begin
     Exit;
   end;
 
-  // Refused: stdout belongs to the stdio transport. Warn once, on stderr.
   FLock.Enter;
   try
     WarnOnce := not lInstance.FStdoutWarningIssued;

--- a/src/Core/MCPServer.ManagerRegistry.pas
+++ b/src/Core/MCPServer.ManagerRegistry.pas
@@ -8,8 +8,6 @@ uses
   MCPServer.Types;
 
 type
-  /// Registration-ordered list of capability managers. Managers that
-  /// implement IMCPRegistryAware receive a reference to this registry.
   TMCPManagerRegistry = class(TInterfacedObject, IMCPManagerRegistry, IMCPManagerEnumerator)
   private
     FManagers: TList<IMCPCapabilityManager>;

--- a/src/Core/MCPServer.Registration.pas
+++ b/src/Core/MCPServer.Registration.pas
@@ -18,15 +18,6 @@ type
   TMCPPromptFactory = reference to function: IMCPPrompt;
   TMCPResourceTemplateFactory = reference to function: IMCPResourceTemplate;
 
-  /// Process-wide registry of tool, resource, prompt and resource-template
-  /// factories, enumerated in registration order.
-  ///
-  /// The dictionaries exist from the class constructor on, so registration
-  /// from unit initialization sections needs no lazy checks. Registration is
-  /// not synchronised: register everything before the managers are created.
-  /// TMCPToolsManager.Create and TMCPResourcesManager.Create read the
-  /// registry once, so in practice that means before TMCPIdHTTPServer.Start
-  /// or TMCPStdioTransport.Run.
   TMCPRegistry = class
   private
     class var FTools: TDictionary<string, TMCPToolFactory>;
@@ -45,8 +36,6 @@ type
     class procedure RegisterResource(const URI: string; Factory: TMCPResourceFactory);
     class procedure RegisterPrompt(const Name: string; Factory: TMCPPromptFactory);
     class procedure RegisterResourceTemplate(const UriTemplate: string; Factory: TMCPResourceTemplateFactory);
-    /// Removes a registration again (no-op for an unknown URI). Like
-    /// registration, only meaningful before the managers are created.
     class procedure UnregisterResource(const URI: string);
 
     class function CreateTool(const Name: string): IMCPTool;
@@ -54,13 +43,9 @@ type
     class function CreatePrompt(const Name: string): IMCPPrompt;
     class function CreateResourceTemplate(const UriTemplate: string): IMCPResourceTemplate;
 
-    /// Names in registration order.
     class function GetToolNames: TArray<string>;
-    /// URIs in registration order.
     class function GetResourceURIs: TArray<string>;
-    /// Names in registration order.
     class function GetPromptNames: TArray<string>;
-    /// Template strings in registration order.
     class function GetResourceTemplateURIs: TArray<string>;
 
     class function HasTool(const Name: string): Boolean;

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -44,10 +44,10 @@ type
   public
     constructor Create(const ASettingsFile: string = ''; const ACreateFile: Boolean = True);
     destructor Destroy; override;
-    
+
     procedure LoadFromFile;
     procedure SaveToFile;
-    
+
     property Port: Integer read FPort write FPort;
     property Host: string read FHost write FHost;
     property Protocol: string read GetProtocol;
@@ -62,42 +62,22 @@ type
     property SSLKeyFile: string read FSSLKeyFile write FSSLKeyFile;
     property SSLRootCertFile: string read FSSLRootCertFile write FSSLRootCertFile;
 
-    // Optional server identity ([Server] Title, Description, WebsiteUrl,
-    // Instructions); reported in initialize and server/discover when set.
     property ServerTitle: string read FServerTitle write FServerTitle;
     property ServerDescription: string read FServerDescription write FServerDescription;
     property ServerWebsiteUrl: string read FServerWebsiteUrl write FServerWebsiteUrl;
     property Instructions: string read FInstructions write FInstructions;
 
-    /// [Protocol] LenientModernPing: answer ping for 2026-07-28 requests
-    /// although the revision removed it. Default off.
     property LenientModernPing: Boolean read FLenientModernPing write FLenientModernPing;
-    /// [Protocol] DiscoverListsLegacyVersions: also list the initialize-based
-    /// revisions in server/discover and in unsupported-version errors. Default off.
     property DiscoverListsLegacyVersions: Boolean read FDiscoverListsLegacyVersions write FDiscoverListsLegacyVersions;
-    /// [Protocol] DiscoverTtlMs: cache hint on server/discover. Default 0.
     property DiscoverTtlMs: Integer read FDiscoverTtlMs write FDiscoverTtlMs;
 
-    /// [Server] BindAddress: the interface to listen on. Empty (default)
-    /// derives it from Host: a loopback Host binds 127.0.0.1 and ::1, any
-    /// other Host binds every interface.
     property BindAddress: string read FBindAddress write FBindAddress;
-    /// [Server] EndpointInfoPath: optional GET path that answers a small JSON
-    /// document with the endpoint URL and the protocol versions. Empty = off.
     property EndpointInfoPath: string read FEndpointInfoPath write FEndpointInfoPath;
-    /// [Server] MaxRequestBodyBytes: larger POST bodies get 413. Default 4 MB.
     property MaxRequestBodyBytes: Integer read FMaxRequestBodyBytes write FMaxRequestBodyBytes;
-    /// [Server] MaxJsonDepth: deeper nesting gets 400. Default 64.
     property MaxJsonDepth: Integer read FMaxJsonDepth write FMaxJsonDepth;
-    /// [Server] MaxConnections: Indy connection limit; 0 = unlimited.
     property MaxConnections: Integer read FMaxConnections write FMaxConnections;
-    /// [Server] MaxConcurrentRequests: worker threads of the stdio transport.
-    /// 1 (default) answers requests in the order they arrive.
     property MaxConcurrentRequests: Integer read FMaxConcurrentRequests write FMaxConcurrentRequests;
-    /// [Security] AllowedOrigins: origins that pass the Origin check next to
-    /// the loopback origins. Falls back to [CORS] AllowedOrigins when empty.
     property SecurityAllowedOrigins: string read FSecurityAllowedOrigins write FSecurityAllowedOrigins;
-    /// The effective allow-list for the Origin check.
     property AllowedOrigins: string read GetAllowedOrigins;
 
     const DEFAULT_MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
@@ -115,20 +95,20 @@ uses
 constructor TMCPSettings.Create(const ASettingsFile: string; const ACreateFile: Boolean);
 begin
   inherited Create;
-  
+
   if ASettingsFile = '' then
     FSettingsFile := TPath.Combine(ExtractFilePath(ParamStr(0)), 'settings.ini')
   else
     FSettingsFile := ASettingsFile;
-    
+
   LoadDefaults;
-  
+
   if ACreateFile and (not TFile.Exists(FSettingsFile)) then
   begin
     TLogger.Info('Settings file not found. Creating default settings: ' + FSettingsFile);
     CreateDefaultSettingsFile;
   end;
-  
+
   LoadFromFile;
 end;
 
@@ -219,7 +199,7 @@ begin
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', '; Comma-separated list of allowed origins', '');
     IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
-    
+
     IniFile.WriteString('SSL', '; SSL/TLS configuration (optional)', '');
     IniFile.WriteBool('SSL', 'Enabled', FSSLEnabled);
     IniFile.WriteString('SSL', 'CertFile', FSSLCertFile);
@@ -236,7 +216,7 @@ var
 begin
   if not TFile.Exists(FSettingsFile) then
     Exit;
-    
+
   IniFile := TIniFile.Create(FSettingsFile);
   try
     FPort := IniFile.ReadInteger('Server', 'Port', FPort);
@@ -263,12 +243,12 @@ begin
 
     FCorsEnabled := IniFile.ReadBool('CORS', 'Enabled', FCorsEnabled);
     FCorsAllowedOrigins := IniFile.ReadString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
-    
+
     FSSLEnabled := IniFile.ReadBool('SSL', 'Enabled', FSSLEnabled);
     FSSLCertFile := IniFile.ReadString('SSL', 'CertFile', FSSLCertFile);
     FSSLKeyFile := IniFile.ReadString('SSL', 'KeyFile', FSSLKeyFile);
     FSSLRootCertFile := IniFile.ReadString('SSL', 'RootCertFile', FSSLRootCertFile);
-    
+
     TLogger.Info('Settings loaded from: ' + FSettingsFile);
     TLogger.Info('Server: ' + Protocol + '://' + FHost + ':' + IntToStr(FPort));
     if FSSLEnabled then
@@ -315,7 +295,7 @@ begin
 
     IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
     IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
-    
+
     IniFile.WriteBool('SSL', 'Enabled', FSSLEnabled);
     IniFile.WriteString('SSL', 'CertFile', FSSLCertFile);
     IniFile.WriteString('SSL', 'KeyFile', FSSLKeyFile);

--- a/src/Managers/MCPServer.CompletionManager.pas
+++ b/src/Managers/MCPServer.CompletionManager.pas
@@ -14,19 +14,14 @@ uses
   MCPServer.ResourcesManager;
 
 type
-  /// completion/complete for a prompt argument (ref/prompt) or a resource
-  /// template variable (ref/resource, tried as a template's uriTemplate
-  /// first, then as an exact resource's URI).
-  ///
-  /// A target that does not implement IMCPCompletable answers no
-  /// suggestions rather than an error, since not offering completion for a
-  /// known prompt or resource is a valid choice.
   TMCPCompletionManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPCapabilityProvider)
   strict private
     FPrompts: TMCPPromptsManager;
     FResources: TMCPResourcesManager;
+    FPromptsRef: IInterface;
+    FResourcesRef: IInterface;
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
-    function ResolveTarget(const Ref: TJSONObject): IInterface;
+    function ResolveTarget(const Ref: TJSONObject; Era: TMCPProtocolEra): IInterface;
     function ParseContext(const Params: TJSONObject): TArray<TPair<string, string>>;
     function BuildCompletionJSON(const Completion: TMCPCompletion): TJSONObject;
   public
@@ -58,6 +53,8 @@ begin
   inherited Create;
   FPrompts := Prompts;
   FResources := Resources;
+  FPromptsRef := Prompts;
+  FResourcesRef := Resources;
 end;
 
 function TMCPCompletionManager.GetCapabilityName: string;
@@ -97,7 +94,7 @@ begin
     raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
 end;
 
-function TMCPCompletionManager.ResolveTarget(const Ref: TJSONObject): IInterface;
+function TMCPCompletionManager.ResolveTarget(const Ref: TJSONObject; Era: TMCPProtocolEra): IInterface;
 var
   Prompt: IMCPPrompt;
   Template: IMCPResourceTemplate;
@@ -129,7 +126,7 @@ begin
     else if FResources.TryGetResource(Uri, Resource) then
       Result := Resource
     else
-      raise EMCPError.ResourceNotFound(Uri, TMCPProtocolEra.Modern);
+      raise EMCPError.ResourceNotFound(Uri, Era);
   end
   else
     raise EMCPError.InvalidParams('params.ref.type must be "ref/prompt" or "ref/resource"');
@@ -198,7 +195,7 @@ begin
 
   TLogger.Info('MCP Complete called for argument: ' + TJSONString(ArgumentNameValue).Value);
 
-  var Target := ResolveTarget(TJSONObject(RefValue));
+  var Target := ResolveTarget(TJSONObject(RefValue), Era);
   var Completion: TMCPCompletion;
   if Supports(Target, IMCPCompletable, Completable) then
     Completion := Completable.Complete(TJSONString(ArgumentNameValue).Value, TJSONString(ArgumentValueValue).Value,

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -11,8 +11,6 @@ uses
   MCPServer.Logger;
 
 type
-  /// Lifecycle methods: server/discover for modern clients, initialize and
-  /// ping for legacy clients. Holds no per-client state.
   TMCPCoreManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPRegistryAware)
   private
     FSettings: TMCPSettings;
@@ -37,7 +35,6 @@ type
     function Discover(const Context: IMCPRequestContext): TValue;
     function Ping: TValue;
 
-    /// Sessions are no longer minted; always empty. Kept for consumers.
     property SessionID: string read GetSessionID;
     property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
   end;
@@ -164,7 +161,6 @@ begin
     Negotiated := Context.ProtocolVersion
   else
   begin
-    // Called outside the processor: negotiate from the params directly.
     var Requested := '';
     if Assigned(Params) then
     begin
@@ -189,7 +185,6 @@ begin
     if FSettings.Instructions <> '' then
       ResultJSON.AddPair('instructions', FSettings.Instructions);
 
-    // stdio remembers the negotiated revision for later legacy requests.
     if Assigned(Context) and Assigned(Context.LegacySession) then
       Context.LegacySession.ProtocolVersion := Negotiated;
 

--- a/src/Managers/MCPServer.PromptsManager.pas
+++ b/src/Managers/MCPServer.PromptsManager.pas
@@ -13,13 +13,6 @@ uses
   MCPServer.Prompt.Base;
 
 type
-  /// prompts/list and prompts/get over the prompts registered in
-  /// TMCPRegistry, listed in registration order.
-  ///
-  /// A missing or unknown prompt name is -32602 (EMCPError.UnknownPrompt);
-  /// a missing required argument or a wrong argument type is -32602 too
-  /// (mapped from the prompt's own EArgumentException), since prompts/get
-  /// has no isError concept to report it through instead.
   TMCPPromptsManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPCapabilityProvider)
   strict private
     FPrompts: TDictionary<string, IMCPPrompt>;
@@ -35,9 +28,7 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    /// Adds a prompt to this manager only (next to the ones from TMCPRegistry).
     procedure AddPrompt(const Prompt: IMCPPrompt);
-    /// The prompt registered under Name, or nil.
     function TryGetPrompt(const Name: string; out Prompt: IMCPPrompt): Boolean;
 
     function GetCapabilityName: string;
@@ -52,7 +43,6 @@ type
     function GetPrompt(const Params: System.JSON.TJSONObject): TValue; overload;
     function GetPrompt(const Params: TJSONObject; Era: TMCPProtocolEra): TValue; overload;
 
-    /// Cache hints on prompts/list for modern clients; 0 and 'private' unless set.
     property ListTtlMs: Integer read FListTtlMs write FListTtlMs;
     property ListCacheScope: string read FListCacheScope write FListCacheScope;
   end;
@@ -149,7 +139,6 @@ end;
 
 procedure TMCPPromptsManager.CheckCursor(const Params: TJSONObject);
 begin
-  // Every list fits in one page; a cursor is never one this server issued.
   if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -13,12 +13,6 @@ uses
   MCPServer.Resource.Base;
 
 type
-  /// resources/list, resources/read and resources/templates/list over the
-  /// resources registered in TMCPRegistry, listed in registration order.
-  ///
-  /// An unknown resource is a JSON-RPC error: -32602 with data.uri in the
-  /// modern era, -32002 in the initialize-based revisions. A failing read is
-  /// -32603. Resources that implement IMCPBinaryResource are read as blobs.
   TMCPResourcesManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPCapabilityProvider)
   private
     FResources: TDictionary<string, IMCPResource>;
@@ -34,18 +28,14 @@ type
     function CreateResourceJSON(const Resource: IMCPResource): TJSONObject;
     function CreateResourceTemplateJSON(const Template: IMCPResourceTemplate): TJSONObject;
     function CreateContentsItem(const Resource: IMCPResource): TJSONObject;
-    /// Exact match first, then the first matching template; nil when neither.
     function FindResource(const URI: string): IMCPResource;
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
   public
     constructor Create;
     destructor Destroy; override;
 
-    /// Adds a resource to this manager only (next to the ones from TMCPRegistry).
     procedure AddResource(const Resource: IMCPResource);
-    /// Adds a resource template to this manager only.
     procedure AddResourceTemplate(const Template: IMCPResourceTemplate);
-    /// Exact registration lookups, for completion/complete.
     function TryGetResource(const URI: string; out Resource: IMCPResource): Boolean;
     function TryGetResourceTemplate(const UriTemplate: string; out Template: IMCPResourceTemplate): Boolean;
 
@@ -63,7 +53,6 @@ type
     function ListResourceTemplates: TValue; overload;
     function ListResourceTemplates(const Params: TJSONObject; Era: TMCPProtocolEra): TValue; overload;
 
-    /// Cache hints on the list results for modern clients; 0 and 'private' unless set.
     property ListTtlMs: Integer read FListTtlMs write FListTtlMs;
     property ListCacheScope: string read FListCacheScope write FListCacheScope;
   end;
@@ -209,7 +198,6 @@ end;
 
 procedure TMCPResourcesManager.CheckCursor(const Params: TJSONObject);
 begin
-  // Every list fits in one page; a cursor is never one this server issued.
   if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -13,13 +13,6 @@ uses
   MCPServer.Tool.Base;
 
 type
-  /// tools/list and tools/call over the tools registered in TMCPRegistry,
-  /// listed in registration order.
-  ///
-  /// Protocol errors (-32602) are raised for a missing or unknown tool name
-  /// and malformed params; everything a tool itself reports (EMCPToolError,
-  /// argument validation, unexpected exceptions) becomes an isError result
-  /// the model can act on.
   TMCPToolsManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPCapabilityProvider)
   strict private
     FTools: TDictionary<string, IMCPTool>;
@@ -41,7 +34,6 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    /// Adds a tool to this manager only (next to the ones from TMCPRegistry).
     procedure AddTool(const Tool: IMCPTool);
 
     function GetCapabilityName: string;
@@ -56,7 +48,6 @@ type
     function CallTool(const Params: System.JSON.TJSONObject): TValue; overload;
     function CallTool(const Params: TJSONObject; Era: TMCPProtocolEra): TValue; overload;
 
-    /// Cache hints on tools/list for modern clients; 0 and 'private' unless set.
     property ListTtlMs: Integer read FListTtlMs write FListTtlMs;
     property ListCacheScope: string read FListCacheScope write FListCacheScope;
   end;
@@ -78,14 +69,18 @@ const
 procedure WarnIfStructuredContentMismatchesSchema(const Tool: IMCPTool; const Result: TJSONObject);
 begin
   var OutputSchema := Tool.OutputSchema;
-  var StructuredContent := Result.GetValue('structuredContent');
-  if not Assigned(OutputSchema) or not Assigned(StructuredContent) then
-    Exit;
+  try
+    var StructuredContent := Result.GetValue('structuredContent');
+    if not Assigned(OutputSchema) or not Assigned(StructuredContent) then
+      Exit;
 
-  var Errors: TArray<string>;
-  if not TMCPSchemaValidator.Validate(OutputSchema, StructuredContent, Errors) then
-    TLogger.Warning(Format('Tool "%s" structuredContent does not match its outputSchema: %s',
-      [Tool.Name, string.Join('; ', Errors)]));
+    var Errors: TArray<string>;
+    if not TMCPSchemaValidator.Validate(OutputSchema, StructuredContent, Errors) then
+      TLogger.Warning(Format('Tool "%s" structuredContent does not match its outputSchema: %s',
+        [Tool.Name, string.Join('; ', Errors)]));
+  finally
+    OutputSchema.Free;
+  end;
 end;
 {$ENDIF}
 
@@ -176,7 +171,6 @@ end;
 
 procedure TMCPToolsManager.CheckCursor(const Params: TJSONObject);
 begin
-  // Every list fits in one page; a cursor is never one this server issued.
   if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;
@@ -205,7 +199,6 @@ begin
 
   if ResultValue.IsType<TJSONArray> then
   begin
-    // A ready-made content array is passed through as is.
     Result := TJSONObject.Create;
     Result.AddPair('content', ResultValue.AsType<TJSONArray>);
     Exit;
@@ -217,7 +210,6 @@ begin
     begin
       var Text := ResultValue.AsString;
       ToolResult.AddText(Text);
-      // Text results keep signalling failure with an "Error:" prefix.
       ToolResult.IsError := Text.StartsWith('Error:') or Text.StartsWith('Error executing tool:');
     end
     else if ResultValue.IsType<TJSONObject> then
@@ -241,7 +233,6 @@ function TMCPToolsManager.ExecuteTool(const Tool: IMCPTool; const Arguments: TJS
 var
   ResultValue: TValue;
 begin
-  // "arguments" is optional on the wire; a tool always receives an object.
   var OwnedArguments: TJSONObject := nil;
   var EffectiveArguments := Arguments;
   if not Assigned(EffectiveArguments) then

--- a/src/Prompts/MCPServer.Prompt.Base.pas
+++ b/src/Prompts/MCPServer.Prompt.Base.pas
@@ -16,9 +16,6 @@ type
     Required: Boolean;
   end;
 
-  /// Builds the messages of a prompts/get result: one role plus one content
-  /// block per message, the same block shapes tools/call uses (text, image,
-  /// audio, resource_link, embedded resource).
   TMCPPromptMessages = class
   strict private
     FMessages: TJSONArray;
@@ -28,7 +25,6 @@ type
     destructor Destroy; override;
 
     function AddText(const Role, Text: string): TMCPPromptMessages;
-    /// Data is the raw content; it is Base64-encoded here.
     function AddImage(const Role: string; const Data: TBytes; const MimeType: string): TMCPPromptMessages; overload;
     function AddImage(const Role, Base64Data, MimeType: string): TMCPPromptMessages; overload;
     function AddAudio(const Role: string; const Data: TBytes; const MimeType: string): TMCPPromptMessages; overload;
@@ -37,13 +33,9 @@ type
       const MimeType: string = ''): TMCPPromptMessages;
     function AddEmbeddedText(const Role, Uri, MimeType, Text: string): TMCPPromptMessages;
     function AddEmbeddedBlob(const Role, Uri, MimeType: string; const Data: TBytes): TMCPPromptMessages;
-    /// Reads Resource (text, or blob for an IMCPBinaryResource) and embeds
-    /// it under Role.
     function AddEmbeddedResource(const Role: string; const Resource: IMCPResource): TMCPPromptMessages;
-    /// Annotations for the message added last (audience, priority, lastModified).
     function WithAnnotations(const Annotations: TJSONObject): TMCPPromptMessages;
 
-    /// The messages array for the result; the caller owns the clone.
     function ToJson: TJSONArray;
   end;
 
@@ -53,9 +45,6 @@ type
     function GetTitle: string;
     function GetDescription: string;
     function GetArguments: TArray<TMCPPromptArgument>;
-    /// Arguments is never nil (an empty object when the request omitted
-    /// it). Builds the messages into Messages; returns the optional
-    /// result-level description.
     function Get(const Arguments: TJSONObject; Messages: TMCPPromptMessages): string;
 
     property Name: string read GetName;
@@ -64,7 +53,6 @@ type
     property Arguments: TArray<TMCPPromptArgument> read GetArguments;
   end;
 
-  /// Prompt with a hand-written argument list and raw JSON arguments.
   TMCPPromptBase = class(TInterfacedObject, IMCPPrompt, IMCPPromptMetadata)
   protected
     FName: string;
@@ -84,12 +72,6 @@ type
     function Get(const Arguments: TJSONObject; Messages: TMCPPromptMessages): string; virtual; abstract;
   end;
 
-  /// Prompt whose arguments are the string properties of a class T; the
-  /// argument list comes from T's RTTI, [SchemaDescription] and [Optional]
-  /// (a required property that is missing from arguments is -32602).
-  ///
-  /// T must declare only string properties: prompts/get arguments are
-  /// always plain strings on the wire.
   TMCPPromptBase<T: class, constructor> = class(TInterfacedObject, IMCPPrompt, IMCPPromptMetadata)
   protected
     FName: string;
@@ -300,7 +282,7 @@ begin
           Continue;
 
         var Arg: TMCPPromptArgument;
-        Arg.Name := LowerCase(Prop.Name);
+        Arg.Name := TMCPSerializer.GetWireName(Prop);
         Arg.Description := '';
         Arg.Required := True;
         for var Attr in Prop.GetAttributes do

--- a/src/Prompts/MCPServer.Prompt.ContentSamples.pas
+++ b/src/Prompts/MCPServer.Prompt.ContentSamples.pas
@@ -1,9 +1,5 @@
 unit MCPServer.Prompt.ContentSamples;
 
-/// One prompt per content type, matching the fixtures the official
-/// conformance suite calls by name (test_simple_prompt and friends), the
-/// same role MCPServer.Tool.ContentSamples plays for tools.
-
 interface
 
 uses

--- a/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
+++ b/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
@@ -18,10 +18,6 @@ type
     property Level: string read FLevel write FLevel;
   end;
 
-  /// Asks the model to summarize the server's recent log entries, embedding
-  /// logs://recent (or a level-filtered view of it) as a resource. The
-  /// level argument completes against the levels actually present in the
-  /// log buffer.
   TSummarizeLogsPrompt = class(TMCPPromptBase<TSummarizeLogsParams>, IMCPCompletable)
   protected
     function ExecuteWithParams(const Params: TSummarizeLogsParams; Messages: TMCPPromptMessages): string; override;

--- a/src/Protocol/MCPServer.Capabilities.pas
+++ b/src/Protocol/MCPServer.Capabilities.pas
@@ -7,11 +7,6 @@ uses
   MCPServer.Types;
 
 type
-  /// Derives the server capabilities from the registered managers.
-  ///
-  /// Every manager that implements IMCPCapabilityProvider adds its own entry.
-  /// A registry that cannot enumerate its managers yields the built-in
-  /// defaults (tools and resources). The logging capability is never emitted.
   TMCPCapabilityBuilder = class
   public
     class function Build(const Registry: IMCPManagerRegistry; Era: TMCPProtocolEra): TJSONObject;

--- a/src/Protocol/MCPServer.ContentBlocks.pas
+++ b/src/Protocol/MCPServer.ContentBlocks.pas
@@ -1,10 +1,5 @@
 unit MCPServer.ContentBlocks;
 
-/// Content block builders shared by tools/call results (an array of blocks)
-/// and prompts/get messages (one block per message): the wire shape for
-/// text, image, audio, resource link and embedded resource content is the
-/// same in both places.
-
 interface
 
 uses
@@ -19,7 +14,6 @@ function CreateResourceLinkBlock(const Uri, Name: string; const Description: str
 function CreateEmbeddedTextBlock(const Uri, MimeType, Text: string): TJSONObject;
 function CreateEmbeddedBlobBlock(const Uri, MimeType, Base64Blob: string): TJSONObject;
 
-/// Base64 without line breaks, as the schema requires for blobs.
 function EncodeBase64Blob(const Data: TBytes): string;
 
 implementation

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -8,11 +8,6 @@ uses
   MCPServer.Types;
 
 type
-  /// A JSON-RPC error a handler or the processor wants to send back.
-  ///
-  /// Code and Message become the error object; Data (owned, optional) becomes
-  /// error.data. HttpStatus is the status a modern HTTP response must carry;
-  /// 0 leaves the decision to the processor's status policy.
   EMCPError = class(Exception)
   private
     FCode: Integer;
@@ -23,7 +18,6 @@ type
       AHttpStatus: Integer = 0); reintroduce;
     destructor Destroy; override;
 
-    /// Hands the data object to the caller; the exception no longer owns it.
     function DetachData: TJSONValue;
 
     class function ParseError(const AMessage: string): EMCPError;
@@ -31,17 +25,11 @@ type
     class function MethodNotFound(const Method: string): EMCPError;
     class function InvalidParams(const AMessage: string; AData: TJSONValue = nil): EMCPError;
     class function InternalError(const AMessage: string): EMCPError;
-    /// -32020 (HTTP 400): headers missing or different from the body.
     class function HeaderMismatch(const AMessage: string): EMCPError;
-    /// -32021 (HTTP 400): the client did not declare a capability the request needs.
     class function MissingRequiredClientCapability(const RequiredCapabilities: TJSONObject): EMCPError;
-    /// -32022 (HTTP 400): the requested revision is not served.
     class function UnsupportedProtocolVersion(const Requested: string; const Supported: TArray<string>): EMCPError;
-    /// -32602 with data.name: tools/call names a tool the server does not have.
     class function UnknownTool(const Name: string): EMCPError;
     class function UnknownPrompt(const Name: string): EMCPError;
-    /// Resource not found with data.uri: -32602 in the modern era, -32002 in
-    /// the initialize-based revisions.
     class function ResourceNotFound(const Uri: string; Era: TMCPProtocolEra): EMCPError;
 
     property Code: Integer read FCode;
@@ -49,12 +37,8 @@ type
     property HttpStatus: Integer read FHttpStatus write FHttpStatus;
   end;
 
-  /// Raised by a tool to report a tool execution error: the message becomes
-  /// an isError result that the model can act on, not a protocol error.
   EMCPToolError = class(Exception);
 
-  /// Raised by IMCPRequestContext.CheckCancelled once the client cancelled
-  /// the request. The processor sends no response for it.
   EMCPRequestCancelled = class(Exception);
 
 const

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -14,21 +14,14 @@ uses
   MCPServer.Logger;
 
 type
-  /// Outcome of one JSON-RPC message. Body is empty when nothing must be
-  /// sent back (notifications, client responses). HttpStatus is the status
-  /// a Streamable HTTP transport should answer with.
   TMCPProcessResult = record
     Body: string;
     HttpStatus: Integer;
     Era: TMCPProtocolEra;
     IsNotification: Boolean;
-    /// True when the request was cancelled by the client; Body is empty.
     Cancelled: Boolean;
   end;
 
-  /// Transport-independent JSON-RPC pipeline: parse, validate the message
-  /// shape, detect the protocol era, dispatch to the owning manager, shape
-  /// the result for the era and decide the HTTP status.
   TMCPJsonRpcProcessor = class
   private
     FManagerRegistry: IMCPManagerRegistry;
@@ -62,32 +55,19 @@ type
     constructor Create(ManagerRegistry: IMCPManagerRegistry; Settings: TMCPSettings); overload;
     destructor Destroy; override;
 
-    /// Plain JSON-RPC layer without transport hints; returns the response body.
     function ProcessRequest(const RequestBody: string; const SessionID: string): string;
     function ProcessRequestEx(const RequestBody: string; const Hints: TMCPTransportHints): TMCPProcessResult; overload;
-    /// Message is the already parsed body (nil when parsing failed); the
-    /// caller keeps ownership.
     function ProcessRequestEx(const Message: TJSONValue; const Hints: TMCPTransportHints): TMCPProcessResult; overload;
 
-    /// Decides the era of a request and validates the modern _meta fields.
-    /// Raises EMCPError with the HTTP status a modern transport must use.
     function BuildRequestContext(const Method: string; const Params: TJSONObject;
       const RequestId: TMCPRequestId; const Hints: TMCPTransportHints): IMCPRequestContext;
-    /// The JSON-RPC error response body for an error a transport detected
-    /// itself (a duplicate id, an overlong line). The error's data is
-    /// detached into the body.
     function BuildErrorResponse(const RequestId: TMCPRequestId; const Error: EMCPError): string;
 
     property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
-    /// Server identity and protocol options. A processor created without
-    /// settings uses the defaults (settings.ini next to the executable when present).
     property Settings: TMCPSettings read FSettings write SetSettings;
   end;
 
 const
-  // The JSON-RPC error codes are defined in MCPServer.Types. These aliases
-  // keep consumer code that references MCPServer.JsonRpcProcessor.JSONRPC_*
-  // compiling.
   JSONRPC_PARSE_ERROR = MCPServer.Types.JSONRPC_PARSE_ERROR;
   JSONRPC_INVALID_REQUEST = MCPServer.Types.JSONRPC_INVALID_REQUEST;
   JSONRPC_METHOD_NOT_FOUND = MCPServer.Types.JSONRPC_METHOD_NOT_FOUND;
@@ -101,10 +81,8 @@ const
   RESULT_TYPE_COMPLETE = 'complete';
   CACHE_SCOPE_PRIVATE = 'private';
 
-  /// Methods that only exist in the initialize-based revisions.
   LEGACY_ONLY_METHODS: array[0..4] of string = (
     'ping', 'initialize', 'logging/setLevel', 'resources/subscribe', 'resources/unsubscribe');
-  /// Methods that only exist with per-request _meta.
   MODERN_ONLY_METHODS: array[0..1] of string = ('server/discover', 'subscriptions/listen');
   LOG_LEVELS: array[0..7] of string = (
     'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency');
@@ -195,7 +173,6 @@ end;
 
 function TMCPJsonRpcProcessor.EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
 begin
-  // Before the body is understood only the header can tell the era apart.
   if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader
     and IsModernProtocolVersion(Hints.ProtocolVersionHeader) then
     Result := TMCPProtocolEra.Modern
@@ -206,8 +183,6 @@ end;
 function TMCPJsonRpcProcessor.EraFromMessage(const Method: string; const Params: TJSONObject;
   const Hints: TMCPTransportHints): TMCPProtocolEra;
 begin
-  // The era that decides the status of a rejected request: a body that
-  // names a protocol version in _meta is modern even when it fails validation.
   Result := EraFromHeaders(Hints);
   if (Result = TMCPProtocolEra.Modern) or not Assigned(Params) then
     Exit;
@@ -256,7 +231,6 @@ procedure TMCPJsonRpcProcessor.ValidateMirroredHeaders(const Method: string; con
 var
   Decoded: string;
 begin
-  // Mcp-Method mirrors the method on every modern POST.
   if not Hints.HasMethodHeader then
     raise EMCPError.HeaderMismatch('Mcp-Method header is missing');
   if Hints.MethodHeader <> Method then
@@ -264,7 +238,6 @@ begin
       'Header mismatch: Mcp-Method header value ''%s'' does not match body value ''%s''',
       [Hints.MethodHeader, Method]));
 
-  // Mcp-Name mirrors params.name (tools/call, prompts/get) or params.uri (resources/read).
   var SourceField := '';
   if (Method = 'tools/call') or (Method = 'prompts/get') then
     SourceField := 'name'
@@ -282,7 +255,7 @@ begin
   if Assigned(Params) then
   begin
     var Source := Params.GetValue(SourceField);
-    if Source is TJSONString then
+    if IsJsonString(Source) then
       BodyValue := TJSONString(Source).Value;
   end;
   if Decoded <> BodyValue then
@@ -298,9 +271,6 @@ var
 begin
   var Meta := ExtractMeta(Params);
 
-  // 1. A protocol version in _meta makes the request modern, initialize
-  //    included: in that era it is an unknown method, which is what a
-  //    modern client probing the server expects.
   var VersionValue: TJSONValue := nil;
   if Assigned(Meta) then
     VersionValue := Meta.GetValue(MCP_META_PROTOCOL_VERSION);
@@ -338,27 +308,23 @@ begin
       Hints.LegacySession, FManagerRegistry, Hints.Sink));
   end;
 
-  // 2. initialize without modern _meta selects the legacy era and negotiates
-  //    the revision.
   if Method = 'initialize' then
   begin
     var Requested := '';
     if Assigned(Params) then
     begin
       var RequestedValue := Params.GetValue('protocolVersion');
-      if RequestedValue is TJSONString then
+      if IsJsonString(RequestedValue) then
         Requested := TJSONString(RequestedValue).Value;
     end;
     Exit(TMCPRequestContext.Create(TMCPProtocolEra.Legacy, NegotiateLegacyProtocolVersion(Requested),
       Method, RequestId, Meta, Hints.LegacySession, FManagerRegistry, Hints.Sink));
   end;
 
-  // 3. A modern-only method without _meta is a malformed modern request.
   if IsModernOnlyMethod(Method) then
     raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
       Format('%s requires params._meta.%s', [Method, MCP_META_PROTOCOL_VERSION]), nil, HTTP_STATUS_BAD_REQUEST);
 
-  // 4. On HTTP the header alone can still name the revision.
   if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader then
   begin
     var Header := Hints.ProtocolVersionHeader;
@@ -374,7 +340,6 @@ begin
       Hints.LegacySession, FManagerRegistry, Hints.Sink));
   end;
 
-  // 5. Legacy, with the version negotiated on this process when known.
   Version := '';
   if Assigned(Hints.LegacySession) then
     Version := Hints.LegacySession.ProtocolVersion;
@@ -417,7 +382,6 @@ end;
 
 procedure TMCPJsonRpcProcessor.HandleCancelled(const Params: TJSONObject; const Hints: TMCPTransportHints);
 begin
-  // Only a transport that tracks its requests can act on the notification.
   if not Assigned(Hints.Tracker) or not Assigned(Params) then
     Exit;
 
@@ -430,7 +394,7 @@ begin
 
   var Reason := '';
   var ReasonValue := Params.GetValue('reason');
-  if ReasonValue is TJSONString then
+  if IsJsonString(ReasonValue) then
     Reason := TJSONString(ReasonValue).Value;
 
   if not Hints.Tracker.TryCancel(RequestId, Reason) then
@@ -504,7 +468,6 @@ function TMCPJsonRpcProcessor.ResultToJson(const Value: TValue; const Context: I
 begin
   if Context.Era = TMCPProtocolEra.Legacy then
   begin
-    // Byte-for-byte what the initialize-based revisions always received.
     if Value.IsEmpty then
       Result := nil
     else if Value.IsType<TJSONObject> then
@@ -516,7 +479,6 @@ begin
     Exit;
   end;
 
-  // Modern results are always objects with a resultType.
   var ResultObject: TJSONObject;
   if Value.IsType<TJSONObject> then
     ResultObject := Value.AsType<TJSONObject>
@@ -533,9 +495,6 @@ end;
 
 function TMCPJsonRpcProcessor.StatusForError(Era: TMCPProtocolEra; const Error: EMCPError): Integer;
 begin
-  // Legacy clients read 404 as "session terminated". They get 200 for every
-  // JSON-RPC error; the one 4xx their revisions define is 400 for a bad
-  // MCP-Protocol-Version header, which arrives with the status set.
   if Era = TMCPProtocolEra.Legacy then
   begin
     if Error.HttpStatus = HTTP_STATUS_BAD_REQUEST then
@@ -587,7 +546,6 @@ end;
 
 function TMCPJsonRpcProcessor.ExceptionToError(Era: TMCPProtocolEra; const E: Exception): EMCPError;
 begin
-  // The text heuristic predates typed errors; legacy answers keep it.
   if (Era = TMCPProtocolEra.Legacy) and (Pos('not found', E.Message) > 0) then
     Result := EMCPError.Create(JSONRPC_METHOD_NOT_FOUND, E.Message)
   else
@@ -642,14 +600,12 @@ begin
       end;
 
       var JsonRpc := Request.GetValue('jsonrpc');
-      if not (JsonRpc is TJSONString) or (TJSONString(JsonRpc).Value <> JSONRPC_VERSION) then
+      if not IsJsonString(JsonRpc) or (TJSONString(JsonRpc).Value <> JSONRPC_VERSION) then
         raise EMCPError.InvalidRequest('jsonrpc must be "2.0"');
 
       var MethodValue := Request.GetValue('method');
-      if not (MethodValue is TJSONString) then
+      if not IsJsonString(MethodValue) then
       begin
-        // A message with result or error is a response sent by the client;
-        // it is never answered.
         if Assigned(Request.GetValue('result')) or Assigned(Request.GetValue('error')) then
         begin
           if Era = TMCPProtocolEra.Modern then
@@ -669,7 +625,11 @@ begin
       if Assigned(ParamsValue) then
       begin
         if not (ParamsValue is TJSONObject) then
+        begin
+          if Era = TMCPProtocolEra.Modern then
+            raise EMCPError.Create(JSONRPC_INVALID_PARAMS, 'params must be an object', nil, HTTP_STATUS_BAD_REQUEST);
           raise EMCPError.InvalidParams('params must be an object');
+        end;
         Params := TJSONObject(ParamsValue);
       end;
 
@@ -690,8 +650,6 @@ begin
           Hints.Tracker.Untrack(Context);
       end;
 
-      // A cancelled request gets no response, whether or not the handler
-      // noticed the cancellation.
       if Context.IsCancelled then
       begin
         if ExecuteResult.IsObject then

--- a/src/Protocol/MCPServer.Mrtr.pas
+++ b/src/Protocol/MCPServer.Mrtr.pas
@@ -1,0 +1,167 @@
+unit MCPServer.Mrtr;
+
+interface
+
+uses
+  System.SysUtils,
+  System.JSON;
+
+const
+  RESULT_TYPE_INPUT_REQUIRED = 'input_required';
+  MCP_METHOD_ELICITATION_CREATE = 'elicitation/create';
+  MCP_METHOD_SAMPLING_CREATE_MESSAGE = 'sampling/createMessage';
+  MCP_METHOD_ROOTS_LIST = 'roots/list';
+  ELICITATION_MODE_FORM = 'form';
+  ELICITATION_ACTION_ACCEPT = 'accept';
+
+type
+  TMCPInputRequests = class
+  strict private
+    FRequests: TJSONObject;
+    function AddRequest(const Key, Method: string; const Params: TJSONObject): TMCPInputRequests;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function AddElicitation(const Key, Message: string; const RequestedSchema: TJSONObject): TMCPInputRequests;
+    function AddSampling(const Key, UserText: string; MaxTokens: Integer;
+      const SystemPrompt: string = ''): TMCPInputRequests;
+    function AddListRoots(const Key: string): TMCPInputRequests;
+
+    function Count: Integer;
+    function Methods: TArray<string>;
+    class function RequiredCapability(const Method: string): string; static;
+    class function FieldSchema(const Field: string; const FieldType: string = 'string'): TJSONObject; static;
+    function ToJson: TJSONObject;
+  end;
+
+  EMCPInputRequired = class(Exception)
+  strict private
+    FRequests: TMCPInputRequests;
+    FState: TJSONObject;
+  public
+    constructor Create(Requests: TMCPInputRequests; State: TJSONObject = nil);
+    destructor Destroy; override;
+    property Requests: TMCPInputRequests read FRequests;
+    property State: TJSONObject read FState;
+  end;
+
+implementation
+
+{ TMCPInputRequests }
+
+class function TMCPInputRequests.FieldSchema(const Field: string; const FieldType: string): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.AddPair('type', 'object');
+  var Properties := TJSONObject.Create;
+  Result.AddPair('properties', Properties);
+  var Schema := TJSONObject.Create;
+  Schema.AddPair('type', FieldType);
+  Properties.AddPair(Field, Schema);
+  var Required := TJSONArray.Create;
+  Required.Add(Field);
+  Result.AddPair('required', Required);
+end;
+
+constructor TMCPInputRequests.Create;
+begin
+  inherited Create;
+  FRequests := TJSONObject.Create;
+end;
+
+destructor TMCPInputRequests.Destroy;
+begin
+  FRequests.Free;
+  inherited;
+end;
+
+function TMCPInputRequests.AddRequest(const Key, Method: string; const Params: TJSONObject): TMCPInputRequests;
+begin
+  var Request := TJSONObject.Create;
+  Request.AddPair('method', Method);
+  Request.AddPair('params', Params);
+  FRequests.AddPair(Key, Request);
+  Result := Self;
+end;
+
+function TMCPInputRequests.AddElicitation(const Key, Message: string;
+  const RequestedSchema: TJSONObject): TMCPInputRequests;
+begin
+  var Params := TJSONObject.Create;
+  Params.AddPair('mode', ELICITATION_MODE_FORM);
+  Params.AddPair('message', Message);
+  Params.AddPair('requestedSchema', RequestedSchema);
+  Result := AddRequest(Key, MCP_METHOD_ELICITATION_CREATE, Params);
+end;
+
+function TMCPInputRequests.AddSampling(const Key, UserText: string; MaxTokens: Integer;
+  const SystemPrompt: string): TMCPInputRequests;
+begin
+  var Params := TJSONObject.Create;
+  var Messages := TJSONArray.Create;
+  Params.AddPair('messages', Messages);
+  var Message := TJSONObject.Create;
+  Messages.AddElement(Message);
+  Message.AddPair('role', 'user');
+  var Content := TJSONObject.Create;
+  Message.AddPair('content', Content);
+  Content.AddPair('type', 'text');
+  Content.AddPair('text', UserText);
+  if SystemPrompt <> '' then
+    Params.AddPair('systemPrompt', SystemPrompt);
+  Params.AddPair('maxTokens', TJSONNumber.Create(MaxTokens));
+  Result := AddRequest(Key, MCP_METHOD_SAMPLING_CREATE_MESSAGE, Params);
+end;
+
+function TMCPInputRequests.AddListRoots(const Key: string): TMCPInputRequests;
+begin
+  Result := AddRequest(Key, MCP_METHOD_ROOTS_LIST, TJSONObject.Create);
+end;
+
+function TMCPInputRequests.Count: Integer;
+begin
+  Result := FRequests.Count;
+end;
+
+function TMCPInputRequests.Methods: TArray<string>;
+begin
+  Result := nil;
+  for var Pair in FRequests do
+    Result := Result + [TJSONObject(Pair.JsonValue).GetValue<string>('method')];
+end;
+
+class function TMCPInputRequests.RequiredCapability(const Method: string): string;
+begin
+  if Method = MCP_METHOD_ELICITATION_CREATE then
+    Result := 'elicitation'
+  else if Method = MCP_METHOD_SAMPLING_CREATE_MESSAGE then
+    Result := 'sampling'
+  else if Method = MCP_METHOD_ROOTS_LIST then
+    Result := 'roots'
+  else
+    Result := '';
+end;
+
+function TMCPInputRequests.ToJson: TJSONObject;
+begin
+  Result := TJSONObject(FRequests.Clone);
+end;
+
+{ EMCPInputRequired }
+
+constructor EMCPInputRequired.Create(Requests: TMCPInputRequests; State: TJSONObject);
+begin
+  inherited Create('Input from the client is required to complete this request');
+  FRequests := Requests;
+  FState := State;
+end;
+
+destructor EMCPInputRequired.Destroy;
+begin
+  FRequests.Free;
+  FState.Free;
+  inherited;
+end;
+
+end.

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -9,14 +9,10 @@ uses
   MCPServer.Types;
 
 const
-  /// Progress notifications for one request are sent at most this often,
-  /// except for the one that reaches the total.
   PROGRESS_MIN_INTERVAL_MS = 50;
 
 type
-  /// What the transport knows about a request before the processor sees it.
   TMCPTransportHints = record
-    /// True when the transport carries HTTP headers (Streamable HTTP).
     HasHeaderLayer: Boolean;
     HasProtocolVersionHeader: Boolean;
     ProtocolVersionHeader: string;
@@ -25,27 +21,17 @@ type
     HasNameHeader: Boolean;
     NameHeader: string;
     RemoteAddress: string;
-    /// Per-process legacy state (stdio); nil for stateless transports.
     LegacySession: TMCPLegacySession;
-    /// Channel for request-scoped notifications (progress); nil when the
-    /// transport cannot deliver them before the response.
     Sink: IMCPMessageSink;
-    /// In-flight bookkeeping for notifications/cancelled; nil when the
-    /// transport signals cancellation another way.
     Tracker: IMCPRequestTracker;
 
-    /// No headers, no session: the plain JSON-RPC layer.
     class function None: TMCPTransportHints; static;
-    /// stdio: no headers, one session slot per process.
     class function ForStdio(const Session: TMCPLegacySession): TMCPTransportHints; overload; static;
-    /// stdio with a channel for progress notifications and cancellation.
     class function ForStdio(const Session: TMCPLegacySession; const Sink: IMCPMessageSink;
       const Tracker: IMCPRequestTracker): TMCPTransportHints; overload; static;
-    /// HTTP: the MCP-Protocol-Version header, empty and HasHeader False when absent.
     class function ForHttp(const HasVersionHeader: Boolean; const VersionHeader: string): TMCPTransportHints; static;
   end;
 
-  /// Default IMCPRequestContext implementation and the thread-local Current.
   TMCPRequestContext = class(TInterfacedObject, IMCPRequestContext)
   private
     FEra: TMCPProtocolEra;
@@ -62,12 +48,10 @@ type
     FLastProgressTick: UInt64;
     function MetaObject(const Key: string): TJSONObject;
   public
-    /// Meta is cloned; the context owns its copy. Sink is where progress
-    /// notifications go; nil disables them.
-    constructor Create(AEra: TMCPProtocolEra; const AProtocolVersion, AMethod: string;
-      const ARequestId: TMCPRequestId; const AMeta: TJSONObject;
-      const ALegacySession: TMCPLegacySession; const AManagerRegistry: IMCPManagerRegistry;
-      const ASink: IMCPMessageSink = nil);
+    constructor Create(Era: TMCPProtocolEra; const ProtocolVersion, Method: string;
+      const RequestId: TMCPRequestId; const Meta: TJSONObject;
+      const LegacySession: TMCPLegacySession; const ManagerRegistry: IMCPManagerRegistry;
+      const Sink: IMCPMessageSink = nil);
     destructor Destroy; override;
 
     function GetEra: TMCPProtocolEra;
@@ -89,9 +73,7 @@ type
     function HasProgressToken: Boolean;
     procedure ReportProgress(const Progress: Double; const Total: Double = -1; const Message: string = '');
 
-    /// The context of the request the calling thread is serving, or nil.
     class function Current: IMCPRequestContext;
-    /// Set by the processor around a handler call; nil clears it.
     class procedure SetCurrent(const Value: IMCPRequestContext);
   end;
 
@@ -101,8 +83,6 @@ uses
   MCPServer.Errors;
 
 threadvar
-  // Raw pointer with manual reference counting: a managed threadvar is not
-  // finalised when a thread ends.
   CurrentContextPointer: Pointer;
 
 { TMCPTransportHints }
@@ -136,20 +116,20 @@ end;
 
 { TMCPRequestContext }
 
-constructor TMCPRequestContext.Create(AEra: TMCPProtocolEra; const AProtocolVersion, AMethod: string;
-  const ARequestId: TMCPRequestId; const AMeta: TJSONObject; const ALegacySession: TMCPLegacySession;
-  const AManagerRegistry: IMCPManagerRegistry; const ASink: IMCPMessageSink);
+constructor TMCPRequestContext.Create(Era: TMCPProtocolEra; const ProtocolVersion, Method: string;
+  const RequestId: TMCPRequestId; const Meta: TJSONObject; const LegacySession: TMCPLegacySession;
+  const ManagerRegistry: IMCPManagerRegistry; const Sink: IMCPMessageSink);
 begin
   inherited Create;
-  FEra := AEra;
-  FProtocolVersion := AProtocolVersion;
-  FMethod := AMethod;
-  FRequestId := ARequestId;
-  if Assigned(AMeta) then
-    FMeta := TJSONObject(AMeta.Clone);
-  FLegacySession := ALegacySession;
-  FManagerRegistry := AManagerRegistry;
-  FSink := ASink;
+  FEra := Era;
+  FProtocolVersion := ProtocolVersion;
+  FMethod := Method;
+  FRequestId := RequestId;
+  if Assigned(Meta) then
+    FMeta := TJSONObject(Meta.Clone);
+  FLegacySession := LegacySession;
+  FManagerRegistry := ManagerRegistry;
+  FSink := Sink;
 end;
 
 destructor TMCPRequestContext.Destroy;
@@ -211,7 +191,7 @@ begin
     Exit;
 
   var Value := FMeta.GetValue(MCP_META_LOG_LEVEL);
-  if Value is TJSONString then
+  if IsJsonString(Value) then
     Result := TJSONString(Value).Value;
 end;
 
@@ -255,8 +235,6 @@ begin
   if HasClientCapability(Path) then
     Exit;
 
-  // Rebuild the dotted path as nested objects: 'elicitation.form' becomes
-  // {"elicitation": {"form": {}}}.
   var Required := TJSONObject.Create;
   var Node := Required;
   for var Segment in Path.Split(['.']) do
@@ -276,7 +254,7 @@ end;
 procedure TMCPRequestContext.CheckCancelled;
 begin
   if IsCancelled then
-    raise EMCPRequestCancelled.Create('Request ' + FRequestId.AsText + ' was cancelled by the client');
+    raise EMCPRequestCancelled.CreateFmt('Request %s was cancelled by the client', [FRequestId.AsText]);
 end;
 
 procedure TMCPRequestContext.Cancel;
@@ -287,8 +265,6 @@ end;
 function TMCPRequestContext.HasProgressToken: Boolean;
 begin
   var Token := GetProgressToken;
-  // A whole-valued number or a string; TJSONNumber must be checked first
-  // since it descends from TJSONString.
   if not Assigned(Token) then
     Exit(False);
   if Token is TJSONNumber then
@@ -300,8 +276,6 @@ procedure TMCPRequestContext.ReportProgress(const Progress, Total: Double; const
 const
   JSON_RPC_VERSION = '2.0';
 begin
-  // Nothing to deliver without a token or a channel, and nothing more for a
-  // request the client cancelled.
   if not Assigned(FSink) or not HasProgressToken or IsCancelled then
     Exit;
 

--- a/src/Protocol/MCPServer.RequestState.pas
+++ b/src/Protocol/MCPServer.RequestState.pas
@@ -1,0 +1,264 @@
+unit MCPServer.RequestState;
+
+interface
+
+uses
+  System.SysUtils,
+  System.JSON;
+
+type
+  TMCPRequestStateSealer = class
+  public
+    const DEFAULT_TTL_SECONDS = 600;
+    const TOKEN_VERSION = 1;
+  strict private
+    FKey: TBytes;
+    FTtlSeconds: Integer;
+    FKeyIsEphemeral: Boolean;
+    function Signature(const Payload: TBytes): TBytes;
+    class function Base64Url(const Bytes: TBytes): string; static;
+    class function TryFromBase64Url(const Text: string; out Bytes: TBytes): Boolean; static;
+    class function SameBytes(const A, B: TBytes): Boolean; static;
+    class function CanonicalJson(const Value: TJSONValue): string; static;
+  public
+    constructor Create(const Key: string; TtlSeconds: Integer = DEFAULT_TTL_SECONDS);
+
+    function Seal(const State: TJSONObject; const Method, ArgumentDigest, Principal: string): string;
+    function Open(const Token, Method, ArgumentDigest, Principal: string): TJSONObject;
+
+    class function DigestOf(const Params: TJSONObject): string; static;
+
+    property KeyIsEphemeral: Boolean read FKeyIsEphemeral;
+    property TtlSeconds: Integer read FTtlSeconds;
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  System.Hash,
+  System.DateUtils,
+  System.NetEncoding,
+  System.Generics.Collections,
+  System.Generics.Defaults,
+  MCPServer.Errors,
+  MCPServer.Logger;
+
+const
+  KEY_BYTES = 32;
+  TOKEN_SEPARATOR = '.';
+  PAYLOAD_VERSION = 'v';
+  PAYLOAD_METHOD = 'm';
+  PAYLOAD_DIGEST = 'a';
+  PAYLOAD_EXPIRY = 'exp';
+  PAYLOAD_PRINCIPAL = 'p';
+  PAYLOAD_STATE = 's';
+  EXCLUDED_MEMBERS: array[0..2] of string = ('_meta', 'inputResponses', 'requestState');
+
+{ TMCPRequestStateSealer }
+
+constructor TMCPRequestStateSealer.Create(const Key: string; TtlSeconds: Integer);
+begin
+  inherited Create;
+  FTtlSeconds := TtlSeconds;
+  if Key.Trim <> '' then
+    FKey := TEncoding.UTF8.GetBytes(Key)
+  else
+  begin
+    SetLength(FKey, KEY_BYTES);
+    Randomize;
+    for var I := 0 to High(FKey) do
+      FKey[I] := Byte(Random(256));
+    FKeyIsEphemeral := True;
+    TLogger.Warning('[Security] RequestStateKey is not set: requestState tokens are sealed with a random key ' +
+      'and stop verifying after a restart or on another instance');
+  end;
+end;
+
+function TMCPRequestStateSealer.Signature(const Payload: TBytes): TBytes;
+begin
+  Result := THashSHA2.GetHMACAsBytes(Payload, FKey, THashSHA2.TSHA2Version.SHA256);
+end;
+
+class function TMCPRequestStateSealer.Base64Url(const Bytes: TBytes): string;
+begin
+  var Encoding := TBase64Encoding.Create(0);
+  try
+    Result := Encoding.EncodeBytesToString(Bytes).Replace('+', '-').Replace('/', '_').TrimRight(['=']);
+  finally
+    Encoding.Free;
+  end;
+end;
+
+class function TMCPRequestStateSealer.TryFromBase64Url(const Text: string; out Bytes: TBytes): Boolean;
+begin
+  Bytes := nil;
+  if Text = '' then
+    Exit(False);
+  for var C in Text do
+    if not (CharInSet(C, ['A'..'Z', 'a'..'z', '0'..'9', '-', '_'])) then
+      Exit(False);
+
+  var Standard := Text.Replace('-', '+').Replace('_', '/');
+  while Length(Standard) mod 4 <> 0 do
+    Standard := Standard + '=';
+  try
+    Bytes := TNetEncoding.Base64.DecodeStringToBytes(Standard);
+    Result := Length(Bytes) > 0;
+  except
+    Result := False;
+  end;
+end;
+
+class function TMCPRequestStateSealer.SameBytes(const A, B: TBytes): Boolean;
+begin
+  var Difference := Length(A) xor Length(B);
+  var Longest := Length(A);
+  if Length(B) > Longest then
+    Longest := Length(B);
+  for var I := 0 to Longest - 1 do
+  begin
+    var Left := 0;
+    var Right := 0;
+    if I < Length(A) then
+      Left := A[I];
+    if I < Length(B) then
+      Right := B[I];
+    Difference := Difference or (Left xor Right);
+  end;
+  Result := Difference = 0;
+end;
+
+class function TMCPRequestStateSealer.CanonicalJson(const Value: TJSONValue): string;
+begin
+  if Value is TJSONObject then
+  begin
+    var Names := TList<string>.Create;
+    try
+      for var Pair in TJSONObject(Value) do
+        Names.Add(Pair.JsonString.Value);
+      Names.Sort(TComparer<string>.Construct(
+        function(const Left, Right: string): Integer
+        begin
+          Result := CompareStr(Left, Right);
+        end));
+      var Parts := TStringBuilder.Create;
+      try
+        Parts.Append('{');
+        for var I := 0 to Names.Count - 1 do
+        begin
+          if I > 0 then
+            Parts.Append(',');
+          Parts.Append(TJSONString.Create(Names[I]).ToJSON).Append(':')
+            .Append(CanonicalJson(TJSONObject(Value).GetValue(Names[I])));
+        end;
+        Parts.Append('}');
+        Result := Parts.ToString;
+      finally
+        Parts.Free;
+      end;
+    finally
+      Names.Free;
+    end;
+  end
+  else if Value is TJSONArray then
+  begin
+    var Parts := TStringBuilder.Create;
+    try
+      Parts.Append('[');
+      for var I := 0 to TJSONArray(Value).Count - 1 do
+      begin
+        if I > 0 then
+          Parts.Append(',');
+        Parts.Append(CanonicalJson(TJSONArray(Value).Items[I]));
+      end;
+      Parts.Append(']');
+      Result := Parts.ToString;
+    finally
+      Parts.Free;
+    end;
+  end
+  else if Assigned(Value) then
+    Result := Value.ToJSON
+  else
+    Result := 'null';
+end;
+
+class function TMCPRequestStateSealer.DigestOf(const Params: TJSONObject): string;
+begin
+  var Salient := TJSONObject.Create;
+  try
+    if Assigned(Params) then
+      for var Pair in Params do
+      begin
+        var Excluded := False;
+        for var Name in EXCLUDED_MEMBERS do
+          if Pair.JsonString.Value = Name then
+            Excluded := True;
+        if not Excluded then
+          Salient.AddPair(Pair.JsonString.Value, TJSONValue(Pair.JsonValue.Clone));
+      end;
+    Result := THashSHA2.GetHashString(CanonicalJson(Salient), THashSHA2.TSHA2Version.SHA256);
+  finally
+    Salient.Free;
+  end;
+end;
+
+function TMCPRequestStateSealer.Seal(const State: TJSONObject; const Method, ArgumentDigest,
+  Principal: string): string;
+begin
+  var Payload := TJSONObject.Create;
+  try
+    Payload.AddPair(PAYLOAD_VERSION, TJSONNumber.Create(TOKEN_VERSION));
+    Payload.AddPair(PAYLOAD_METHOD, Method);
+    Payload.AddPair(PAYLOAD_DIGEST, ArgumentDigest);
+    Payload.AddPair(PAYLOAD_EXPIRY, TJSONNumber.Create(DateTimeToUnix(Now, False) + FTtlSeconds));
+    Payload.AddPair(PAYLOAD_PRINCIPAL, Principal);
+    if Assigned(State) then
+      Payload.AddPair(PAYLOAD_STATE, TJSONObject(State.Clone))
+    else
+      Payload.AddPair(PAYLOAD_STATE, TJSONObject.Create);
+
+    var PayloadBytes := TEncoding.UTF8.GetBytes(Payload.ToJSON);
+    Result := Base64Url(PayloadBytes) + TOKEN_SEPARATOR + Base64Url(Signature(PayloadBytes));
+  finally
+    Payload.Free;
+  end;
+end;
+
+function TMCPRequestStateSealer.Open(const Token, Method, ArgumentDigest, Principal: string): TJSONObject;
+var
+  PayloadBytes, SignatureBytes: TBytes;
+begin
+  var Separator := Token.LastIndexOf(TOKEN_SEPARATOR);
+  if (Separator <= 0) or not TryFromBase64Url(Token.Substring(0, Separator), PayloadBytes)
+    or not TryFromBase64Url(Token.Substring(Separator + 1), SignatureBytes)
+    or not SameBytes(SignatureBytes, Signature(PayloadBytes)) then
+    raise EMCPError.InvalidParams('requestState failed integrity verification');
+
+  var Payload := TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes)) as TJSONObject;
+  if not Assigned(Payload) then
+    raise EMCPError.InvalidParams('requestState failed integrity verification');
+  try
+    if Payload.GetValue<Integer>(PAYLOAD_VERSION, 0) <> TOKEN_VERSION then
+      raise EMCPError.InvalidParams('requestState has an unsupported version');
+    if Payload.GetValue<string>(PAYLOAD_METHOD, '') <> Method then
+      raise EMCPError.InvalidParams('requestState belongs to another method');
+    if Payload.GetValue<string>(PAYLOAD_DIGEST, '') <> ArgumentDigest then
+      raise EMCPError.InvalidParams('requestState belongs to another request');
+    if Payload.GetValue<string>(PAYLOAD_PRINCIPAL, '') <> Principal then
+      raise EMCPError.InvalidParams('requestState belongs to another principal');
+    if Payload.GetValue<Int64>(PAYLOAD_EXPIRY, 0) < DateTimeToUnix(Now, False) then
+      raise EMCPError.InvalidParams('requestState has expired');
+
+    var State := Payload.GetValue(PAYLOAD_STATE);
+    if State is TJSONObject then
+      Result := TJSONObject(State.Clone)
+    else
+      Result := TJSONObject.Create;
+  finally
+    Payload.Free;
+  end;
+end;
+
+end.

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -9,25 +9,6 @@ uses
   System.JSON;
 
 type
-  /// JSON Schema (2020-12 subset) for a parameter or result class, derived
-  /// from its published/public properties:
-  ///
-  ///   Integer, Int64, Byte ...        integer
-  ///   Double, Single, Currency        number
-  ///   TDateTime / TDate / TTime       string with format date-time / date / time
-  ///   string                          string
-  ///   Boolean                         boolean
-  ///   other enumerations              string with the enum names
-  ///   sets                            array of enum names
-  ///   dynamic arrays, TList<T>        array with typed items
-  ///   TJSONArray / TJSONObject        array / object (free form)
-  ///   other classes                   nested object schema
-  ///
-  /// Property attributes: [SchemaDescription], [SchemaTitle], [SchemaFormat],
-  /// [SchemaMinimum], [SchemaMaximum], [SchemaMinLength], [SchemaMaxLength],
-  /// [SchemaPattern], [SchemaDefault], [SchemaEnum], [SchemaName] (overrides
-  /// the wire name) and [Optional]. Class attributes:
-  /// [SchemaAdditionalProperties] and [SchemaDialect] (root schema only).
   TMCPSchemaGenerator = class
   private
     const MAX_NESTING_DEPTH = 8;
@@ -95,7 +76,6 @@ end;
 
 class function TMCPSchemaGenerator.ListItemType(RttiType: TRttiType): TRttiType;
 begin
-  // TList<T> and TObjectList<T> expose Items[Index: NativeInt]: T.
   Result := nil;
   var ItemsProp := RttiType.GetIndexedProperty('Items');
   if not Assigned(ItemsProp) or not Assigned(ItemsProp.ReadMethod) then
@@ -203,7 +183,6 @@ end;
 
 class function TMCPSchemaGenerator.NumberValue(const Value: Double): TJSONNumber;
 begin
-  // Whole bounds are written as integers, so "minimum": 1 rather than 1.0.
   if Frac(Value) = 0 then
     Result := TJSONNumber.Create(Trunc(Value))
   else
@@ -242,7 +221,13 @@ begin
     else if Attr is SchemaPatternAttribute then
       PropSchema.AddPair('pattern', SchemaPatternAttribute(Attr).Pattern)
     else if Attr is SchemaDefaultAttribute then
-      PropSchema.AddPair('default', TJSONObject.ParseJSONValue(SchemaDefaultAttribute(Attr).Json));
+    begin
+      var DefaultValue := TJSONObject.ParseJSONValue(SchemaDefaultAttribute(Attr).Json);
+      if not Assigned(DefaultValue) then
+        raise EArgumentException.CreateFmt('[SchemaDefault] on %s is not valid JSON: %s',
+          [Prop.Name, SchemaDefaultAttribute(Attr).Json]);
+      PropSchema.AddPair('default', DefaultValue);
+    end;
   end;
 end;
 
@@ -287,8 +272,6 @@ begin
         ExplicitAdditionalProperties := True;
       end;
 
-    // A tool without parameters accepts an empty object and nothing else,
-    // unless the class said otherwise.
     if not ExplicitAdditionalProperties and (Properties.Count = 0) then
       Result.AddPair('additionalProperties', TJSONBool.Create(False));
   except

--- a/src/Protocol/MCPServer.Schema.Validator.pas
+++ b/src/Protocol/MCPServer.Schema.Validator.pas
@@ -1,17 +1,5 @@
 unit MCPServer.Schema.Validator;
 
-/// A JSON Schema (2020-12) subset validator for hand-written schemas and for
-/// checking a tool's structuredContent against its outputSchema.
-///
-/// Covers: type (string or array, including "null"), enum, const, required,
-/// properties (recursive), additionalProperties (boolean), items
-/// (recursive), minimum/maximum, minLength/maxLength, pattern. A same-
-/// document "$ref" ("#/$defs/Name" or "#/definitions/Name") is resolved;
-/// anything else (a network reference, "#/properties/..." and similar) is a
-/// validation error rather than a crash or a silent no-op, since the
-/// specification forbids network references. Nesting deeper than
-/// MAX_DEPTH is a validation error, not a stack overflow.
-
 interface
 
 uses
@@ -24,8 +12,6 @@ type
   public
     const MAX_DEPTH = 32;
 
-    /// True when Instance satisfies Schema; Errors lists every violation
-    /// found (empty when Result is True).
     class function Validate(const Schema: TJSONObject; const Instance: TJSONValue;
       out Errors: TArray<string>): Boolean;
   private
@@ -58,8 +44,6 @@ end;
 
 class function TMCPSchemaValidator.MatchesType(const Instance: TJSONValue; const TypeName: string): Boolean;
 begin
-  // TJSONNumber descends from TJSONString, so "string" must exclude it
-  // explicitly and "integer"/"number" must be checked before it.
   if TypeName = 'null' then
     Result := not Assigned(Instance) or (Instance is TJSONNull)
   else if TypeName = 'boolean' then
@@ -126,8 +110,6 @@ begin
     Exit((A is TJSONNumber) and (B is TJSONNumber) and (TJSONNumber(A).AsDouble = TJSONNumber(B).AsDouble));
   if (A is TJSONString) or (B is TJSONString) then
     Exit((A is TJSONString) and (B is TJSONString) and (TJSONString(A).Value = TJSONString(B).Value));
-  // Objects and arrays: canonical text is good enough for the schemas this
-  // server generates or ships with.
   Result := A.ToJSON = B.ToJSON;
 end;
 
@@ -213,7 +195,6 @@ begin
   if not CheckType(ResolvedSchema, Instance, TypeError) then
   begin
     AddError(Errors, Path, TypeError);
-    // The wrong JSON kind makes structural checks below meaningless.
     Exit(False);
   end;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -18,7 +18,6 @@ type
     class procedure DeserializeObject(Instance: TObject; const Json: TJSONObject);
     class function DeserializeArray(RttiType: TRttiType; const JsonArray: TJSONArray): TValue;
 
-    // Extracted type conversion methods
     class function ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
@@ -26,23 +25,19 @@ type
     class function TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;
     class function CreateInstanceFromType(const RttiType: TRttiType): TObject;
 
-    // Array deserialization helpers
     class function DeserializeDynamicArray(const DynArrayType: TRttiDynamicArrayType; const JsonArray: TJSONArray): TValue;
     class function DeserializeGenericList(const ListType: TRttiInstanceType; const JsonArray: TJSONArray): TValue;
     class function FindAddMethod(const ListType: TRttiInstanceType): TRttiMethod;
 
-    // Case-insensitive JSON value lookup
     class function GetJsonValueCaseInsensitive(const Json: TJSONObject; const PropName: string): TJSONValue;
 
-    // Single normalization rule shared by lookup and validation
     class function NormalizeKey(const Name: string): string; inline;
     class function IsRequiredProperty(const Prop: TRttiProperty): Boolean;
-    /// The wire name: [SchemaName] when present, otherwise the lowercased
-    /// property name, matching the schema generator.
-    class function GetWireName(const Prop: TRttiProperty): string;
   public
     class constructor Create;
     class destructor Destroy;
+
+    class function GetWireName(const Prop: TRttiProperty): string;
 
     class function Deserialize<T: class, constructor>(const Json: TJSONObject): T;
     class procedure Serialize(Obj: TObject; Json: TJSONObject);
@@ -137,7 +132,6 @@ begin
 
     JsonValue := GetJsonValueCaseInsensitive(Json, GetWireName(RttiProp));
 
-    // Absent and null both mean "not given"; a required parameter must be given.
     if not Assigned(JsonValue) or (JsonValue is TJSONNull) then
     begin
       if IsRequiredProperty(RttiProp) then
@@ -196,9 +190,9 @@ begin
     {$WARN UNSAFE_CAST OFF}
     PropValue := RttiProp.GetValue(Obj);
     {$WARN UNSAFE_CAST ON}
-    
+
     JsonValue := ConvertValueToJson(PropValue, RttiProp.PropertyType);
-    
+
     if Assigned(JsonValue) then
       Json.AddPair(PropName, JsonValue);
   end;
@@ -222,12 +216,10 @@ var
   NestedInstance: TObject;
 begin
   Result := TValue.Empty;
-  
+
   if not Assigned(JsonValue) then
     Exit;
-    
-  // Values must have the JSON type the schema advertises; a mismatch is an
-  // argument error the tool reports as isError, so the model can correct it.
+
   case RttiType.TypeKind of
     tkInteger, tkInt64:
       begin
@@ -357,12 +349,12 @@ var
   MetaClass: TClass;
 begin
   Result := nil;
-  
+
   if RttiType is TRttiInstanceType then
   begin
     InstanceType := TRttiInstanceType(RttiType);
     MetaClass := InstanceType.MetaclassType;
-    
+
     if Assigned(MetaClass) then
       Result := MetaClass.Create;
   end;
@@ -375,8 +367,6 @@ var
 begin
   Result := nil;
 
-  // Empty means nil for objects and [] for dynamic arrays; both are worth
-  // writing so the JSON has the property the schema advertises.
   if Value.IsEmpty then
   begin
     case RttiType.TypeKind of
@@ -408,14 +398,12 @@ begin
       if RttiType.Handle = TypeInfo(Boolean) then
         Result := TJSONBool.Create(Value.AsBoolean)
       else
-        Result := TJSONString.Create(GetEnumName(RttiType.Handle, Value.AsOrdinal));
+        Result := TJSONString.Create(GetEnumName(RttiType.Handle, Integer(Value.AsOrdinal)));
 
     tkSet:
       begin
-        // Every included element by its enum name.
         var Names := TJSONArray.Create;
         var ElementType := TRttiEnumerationType(TRttiSetType(RttiType).ElementType);
-        // A set is stored from the byte that holds its lowest element.
         var SetBits: Int64 := 0;
         Move(Value.GetReferenceToRawData^, SetBits, Min(Value.DataSize, SizeOf(SetBits)));
         var FirstBit := ElementType.MinValue and not 7;
@@ -461,9 +449,6 @@ begin
   end;
 end;
 
-// Serialises TList<T> and TObjectList<T> (anything with an integer-indexed
-// Items property and a Count) as a JSON array of their elements. Without
-// this a list came out as an object with count and capacity members.
 class function TMCPSerializer.TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;
 var
   ListType: TRttiType;
@@ -485,7 +470,6 @@ begin
     or not Assigned(ItemsProp.ReadMethod) then
     Exit;
 
-  // Only integer indexes: TDictionary<TKey, TValue> also has Count and Items.
   IndexParams := ItemsProp.ReadMethod.GetParameters;
   if (Length(IndexParams) <> 1) or not (IndexParams[0].ParamType.TypeKind in [tkInteger, tkInt64]) then
     Exit;
@@ -512,10 +496,10 @@ end;
 class function TMCPSerializer.DeserializeArray(RttiType: TRttiType; const JsonArray: TJSONArray): TValue;
 begin
   Result := TValue.Empty;
-  
+
   if RttiType is TRttiDynamicArrayType then
     Result := DeserializeDynamicArray(TRttiDynamicArrayType(RttiType), JsonArray)
-  else if (RttiType is TRttiInstanceType) and 
+  else if (RttiType is TRttiInstanceType) and
           (TRttiInstanceType(RttiType).MetaclassType.InheritsFrom(TList)) then
     Result := DeserializeGenericList(TRttiInstanceType(RttiType), JsonArray);
 end;
@@ -534,12 +518,12 @@ begin
   Result := TValue.Empty;
   TValue.Make(nil, DynArrayType.Handle, Result);
   DynArraySetLength(PPointer(Result.GetReferenceToRawData)^, Result.TypeInfo, 1, @ArrayLength);
-  
+
   for I := 0 to ArrayLength - 1 do
   begin
     JsonElement := JsonArray.Items[Integer(I)];
     ElementValue := ConvertJsonToValue(JsonElement, ElementType);
-    
+
     if not ElementValue.IsEmpty then
       Result.SetArrayElement(I, ElementValue);
   end;
@@ -555,25 +539,25 @@ var
   ParamType: TRttiType;
 begin
   ListInstance := ListType.MetaclassType.Create;
-  
+
   AddMethod := FindAddMethod(ListType);
   if not Assigned(AddMethod) then
   begin
     ListInstance.Free;
     Exit(TValue.Empty);
   end;
-  
+
   ParamType := AddMethod.GetParameters[0].ParamType;
-  
+
   for I := 0 to JsonArray.Count - 1 do
   begin
     JsonElement := JsonArray.Items[I];
     ElementValue := ConvertJsonToValue(JsonElement, ParamType);
-    
+
     if not ElementValue.IsEmpty then
       AddMethod.Invoke(ListInstance, [ElementValue]);
   end;
-  
+
   Result := ListInstance;
 end;
 
@@ -582,7 +566,7 @@ var
   Method: TRttiMethod;
 begin
   Result := nil;
-  
+
   for Method in ListType.GetMethods do
   begin
     if SameText(Method.Name, 'Add') and (Length(Method.GetParameters) = 1) then

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -9,44 +9,35 @@ uses
   System.Generics.Collections;
 
 const
-  /// Protocol version answered by the initialize handshake. Kept under its
-  /// historic name for library consumers.
   MCP_PROTOCOL_VERSION = '2025-06-18';
 
-  // Protocol revisions
   MCP_PROTOCOL_VERSION_2025_03_26 = '2025-03-26';
   MCP_PROTOCOL_VERSION_2025_06_18 = '2025-06-18';
   MCP_PROTOCOL_VERSION_2025_11_25 = '2025-11-25';
   MCP_PROTOCOL_VERSION_2026_07_28 = '2026-07-28';
 
-  /// Newest revision this server targets (stateless, per-request _meta).
   MCP_LATEST_PROTOCOL_VERSION = MCP_PROTOCOL_VERSION_2026_07_28;
-  /// Newest revision served through the initialize handshake.
   MCP_LATEST_LEGACY_PROTOCOL_VERSION = MCP_PROTOCOL_VERSION_2025_11_25;
 
   MCP_LEGACY_PROTOCOL_VERSIONS: array[0..1] of string = (
-    MCP_PROTOCOL_VERSION_2025_06_18,
-    MCP_PROTOCOL_VERSION_2025_11_25
+    MCP_PROTOCOL_VERSION_2025_11_25,
+    MCP_PROTOCOL_VERSION_2025_06_18
   );
   MCP_MODERN_PROTOCOL_VERSIONS: array[0..0] of string = (
     MCP_PROTOCOL_VERSION_2026_07_28
   );
 
-  // JSON-RPC 2.0 error codes
   JSONRPC_PARSE_ERROR = -32700;
   JSONRPC_INVALID_REQUEST = -32600;
   JSONRPC_METHOD_NOT_FOUND = -32601;
   JSONRPC_INVALID_PARAMS = -32602;
   JSONRPC_INTERNAL_ERROR = -32603;
 
-  // MCP error codes reserved by the specification (basic/index.mdx, "Error Codes")
   MCP_ERROR_HEADER_MISMATCH = -32020;
   MCP_ERROR_MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
   MCP_ERROR_UNSUPPORTED_PROTOCOL_VERSION = -32022;
-  /// Resource not found in 2025-11-25 and earlier; 2026-07-28 uses JSONRPC_INVALID_PARAMS.
   MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY = -32002;
 
-  // Reserved _meta keys (2026-07-28)
   MCP_META_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
   MCP_META_CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
   MCP_META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
@@ -58,12 +49,9 @@ const
   MCP_METHOD_NOTIFICATIONS_CANCELLED = 'notifications/cancelled';
   MCP_METHOD_NOTIFICATIONS_PROGRESS = 'notifications/progress';
 
-  // Cache scopes (server/utilities/caching.mdx)
   MCP_CACHE_SCOPE_PUBLIC = 'public';
   MCP_CACHE_SCOPE_PRIVATE = 'private';
 
-  /// Methods whose complete results must carry ttlMs and cacheScope
-  /// (server/utilities/caching.mdx, "Cacheable Results").
   MCP_CACHEABLE_METHODS: array[0..5] of string = (
     'server/discover',
     'tools/list',
@@ -75,8 +63,6 @@ const
 
 function IsLegacyProtocolVersion(const Version: string): Boolean;
 function IsModernProtocolVersion(const Version: string): Boolean;
-/// The revision answered to an initialize request: the requested one when it
-/// is served, otherwise the newest legacy revision.
 function NegotiateLegacyProtocolVersion(const Requested: string): string;
 
 type
@@ -91,7 +77,6 @@ type
     property Description: string read FDescription;
   end;
 
-  /// Human-readable title of a parameter (JSON Schema "title").
   SchemaTitleAttribute = class(TCustomAttribute)
   private
     FTitle: string;
@@ -100,7 +85,6 @@ type
     property Title: string read FTitle;
   end;
 
-  /// JSON Schema "format" of a string parameter, for example 'date-time' or 'uri'.
   SchemaFormatAttribute = class(TCustomAttribute)
   private
     FFormat: string;
@@ -109,7 +93,6 @@ type
     property Format: string read FFormat;
   end;
 
-  /// JSON Schema "minimum" of a numeric parameter.
   SchemaMinimumAttribute = class(TCustomAttribute)
   private
     FMinimum: Double;
@@ -118,7 +101,6 @@ type
     property Minimum: Double read FMinimum;
   end;
 
-  /// JSON Schema "maximum" of a numeric parameter.
   SchemaMaximumAttribute = class(TCustomAttribute)
   private
     FMaximum: Double;
@@ -139,7 +121,6 @@ type
     property Values: TArray<string> read FValues;
   end;
 
-  /// JSON Schema "minLength" of a string parameter.
   SchemaMinLengthAttribute = class(TCustomAttribute)
   private
     FMinLength: Integer;
@@ -148,7 +129,6 @@ type
     property MinLength: Integer read FMinLength;
   end;
 
-  /// JSON Schema "maxLength" of a string parameter.
   SchemaMaxLengthAttribute = class(TCustomAttribute)
   private
     FMaxLength: Integer;
@@ -157,7 +137,6 @@ type
     property MaxLength: Integer read FMaxLength;
   end;
 
-  /// JSON Schema "pattern" of a string parameter (an ECMA-262 regex).
   SchemaPatternAttribute = class(TCustomAttribute)
   private
     FPattern: string;
@@ -166,8 +145,6 @@ type
     property Pattern: string read FPattern;
   end;
 
-  /// JSON Schema "default" of a parameter, given as its JSON text
-  /// (for example '"red"', '0', 'true').
   SchemaDefaultAttribute = class(TCustomAttribute)
   private
     FJson: string;
@@ -176,8 +153,6 @@ type
     property Json: string read FJson;
   end;
 
-  /// Explicit JSON property name, overriding the default (lowercased
-  /// property name) the generator and the serializer otherwise use.
   SchemaNameAttribute = class(TCustomAttribute)
   private
     FName: string;
@@ -186,8 +161,6 @@ type
     property Name: string read FName;
   end;
 
-  /// Class-level: forbids properties the schema does not list. Applies to a
-  /// tool's or prompt's parameter class; default is to allow them.
   SchemaAdditionalPropertiesAttribute = class(TCustomAttribute)
   private
     FAllowed: Boolean;
@@ -196,7 +169,6 @@ type
     property Allowed: Boolean read FAllowed;
   end;
 
-  /// Class-level: the JSON Schema dialect ($schema) of a generated schema.
   SchemaDialectAttribute = class(TCustomAttribute)
   private
     FUri: string;
@@ -206,44 +178,36 @@ type
   end;
 
   TMCPToolsCapability = class;
-  
+
   IMCPCapabilityManager = interface
     ['{E5F7C3A1-8B4D-4F6E-9C2A-1D3E5F7A9B8C}']
     function GetCapabilityName: string;
     function HandlesMethod(const Method: string): Boolean;
     function ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
   end;
-  
+
   IMCPManagerRegistry = interface
     ['{A2B4C6D8-1E3F-5A7B-9C8D-2F4E6A8C0B2D}']
     procedure RegisterManager(const Manager: IMCPCapabilityManager);
     function GetManagerForMethod(const Method: string): IMCPCapabilityManager;
   end;
 
-  /// Optional view on a manager registry that can list its managers, used to
-  /// derive the server capabilities. Probed with Supports().
   IMCPManagerEnumerator = interface
     ['{6D1F0B2C-3A4E-4F5B-8C7D-9E0F1A2B3C4D}']
     function GetManagers: TArray<IMCPCapabilityManager>;
   end;
 
-  /// Implemented by managers that want a reference to the registry they are
-  /// registered in (TMCPManagerRegistry injects it). Keep the reference weak.
   IMCPRegistryAware = interface
     ['{2B7C9D1E-4F6A-4B8C-9D0E-1F2A3B4C5D6E}']
     procedure SetManagerRegistry(const Registry: IMCPManagerRegistry);
   end;
 
   {$SCOPEDENUMS ON}
-  /// Legacy: initialize-based revisions (2025-11-25 and earlier).
-  /// Modern: per-request _meta revisions (2026-07-28 and later).
   TMCPProtocolEra = (Legacy, Modern);
 
   TMCPRequestIdKind = (None, Null, Text, Number, Invalid);
   {$SCOPEDENUMS OFF}
 
-  /// The JSON-RPC id of a message. None means the member is absent
-  /// (notification); Invalid covers booleans, objects, arrays and fractions.
   TMCPRequestId = record
     Kind: TMCPRequestIdKind;
     Text: string;
@@ -251,33 +215,28 @@ type
     class function FromJson(const Value: TJSONValue): TMCPRequestId; static;
     class function FromNumber(const Value: Int64): TMCPRequestId; static;
     class function FromText(const Value: string): TMCPRequestId; static;
-    /// True for a string or integer id (a request that must be answered).
     function IsPresent: Boolean;
-    /// JSON value for the response; null when the id is absent or invalid.
     function ToJson: TJSONValue;
     function AsText: string;
   end;
 
-  /// Per-process legacy state for stdio: the protocol version negotiated by
-  /// the last initialize. Empty until an initialize has been answered.
   TMCPLegacySession = class
   private
     FProtocolVersion: string;
+    FLock: TObject;
+    function GetProtocolVersion: string;
+    procedure SetProtocolVersion(const Value: string);
   public
-    property ProtocolVersion: string read FProtocolVersion write FProtocolVersion;
+    constructor Create;
+    destructor Destroy; override;
+    property ProtocolVersion: string read GetProtocolVersion write SetProtocolVersion;
   end;
 
-  /// Where a transport delivers the server-to-client messages that belong to
-  /// a request in flight (notifications/progress). The stdio transport
-  /// writes them to stdout; a transport without such a channel passes nil.
   IMCPMessageSink = interface
     ['{2B7D4E90-6C1A-4F3B-9E8D-5A0C1B2D3E4F}']
     procedure Send(const Json: string);
   end;
 
-  /// What a handler may know about the request it is serving. Built once
-  /// per request by the JSON-RPC processor and reachable through
-  /// TMCPRequestContext.Current while the handler runs.
   IMCPRequestContext = interface
     ['{7E3A9C1B-5D2F-4A6E-8B0C-3D4E5F6A7B8C}']
     function GetEra: TMCPProtocolEra;
@@ -292,38 +251,19 @@ type
     function GetLegacySession: TMCPLegacySession;
     function GetManagerRegistry: IMCPManagerRegistry;
 
-    /// True when the client declared the capability, given as a dotted path
-    /// such as 'elicitation' or 'elicitation.form'. Always False for legacy
-    /// requests (their capabilities are not carried per request).
     function HasClientCapability(const Path: string): Boolean;
-    /// Raises EMCPError -32021 when the capability was not declared.
     procedure RequireClientCapability(const Path: string);
-    /// True once the client cancelled the request (notifications/cancelled
-    /// on stdio).
     function IsCancelled: Boolean;
-    /// Raises EMCPRequestCancelled when the request was cancelled; the
-    /// processor then sends no response. Long-running handlers call this
-    /// between steps.
     procedure CheckCancelled;
-    /// Marks the request cancelled. Called by the transport.
     procedure Cancel;
-    /// True when the request carries _meta.progressToken.
     function HasProgressToken: Boolean;
-    /// Sends notifications/progress for this request when it carries a
-    /// progress token and the transport can deliver it; otherwise nothing
-    /// happens. Progress must increase: a value at or below the last one is
-    /// dropped, and so is a notification within PROGRESS_MIN_INTERVAL_MS of
-    /// the previous one unless it reaches Total. Total < 0 means unknown.
     procedure ReportProgress(const Progress: Double; const Total: Double = -1; const Message: string = '');
 
     property Era: TMCPProtocolEra read GetEra;
     property ProtocolVersion: string read GetProtocolVersion;
     property Method: string read GetMethod;
     property RequestId: TMCPRequestId read GetRequestId;
-    /// The request's _meta object (nil when absent). Owned by the context.
     property Meta: TJSONObject read GetMeta;
-    /// io.modelcontextprotocol/clientCapabilities (never nil for modern
-    /// requests, nil for legacy requests).
     property ClientCapabilities: TJSONObject read GetClientCapabilities;
     property ClientInfo: TJSONObject read GetClientInfo;
     property LogLevel: string read GetLogLevel;
@@ -332,36 +272,24 @@ type
     property ManagerRegistry: IMCPManagerRegistry read GetManagerRegistry;
   end;
 
-  /// In-flight bookkeeping a transport keeps so notifications/cancelled can
-  /// reach the request it names. The processor binds every request context
-  /// while its handler runs.
   IMCPRequestTracker = interface
     ['{8C5E1F2A-3B4D-4E6F-A1B2-C3D4E5F6A7B8}']
-    /// Binds the context to its request id for the duration of the handler.
-    /// A request cancelled before its handler started begins cancelled.
     procedure Track(const Context: IMCPRequestContext);
     procedure Untrack(const Context: IMCPRequestContext);
-    /// Cancels the request with that id; False when it is unknown or done.
     function TryCancel(const RequestId: TMCPRequestId; const Reason: string): Boolean;
   end;
 
-  /// Managers that want the request context receive it through this
-  /// interface; the processor falls back to IMCPCapabilityManager.ExecuteMethod.
   IMCPCapabilityManagerEx = interface
     ['{9F4B2D6A-1C3E-4E5F-A7B8-C9D0E1F2A3B4}']
     function ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
       const Context: IMCPRequestContext): TValue;
   end;
 
-  /// Managers that contribute an entry to the server capabilities
-  /// (for example "tools": {"listChanged": false}).
   IMCPCapabilityProvider = interface
     ['{C5D7E9F1-2A4B-4C6D-8E0F-1A2B3C4D5E6F}']
     procedure DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
   end;
 
-  /// Optional tool metadata for tools/list: annotations (readOnlyHint and
-  /// friends) and icons. Both may be nil. The tool keeps ownership.
   IMCPToolMetadata = interface
     ['{D2E4F6A8-1B3C-4D5E-9F0A-2B3C4D5E6F70}']
     function GetAnnotations: TJSONObject;
@@ -370,15 +298,11 @@ type
     property Icons: TJSONArray read GetIcons;
   end;
 
-  /// Resources whose contents are bytes rather than text; resources/read
-  /// answers with a Base64 "blob" instead of "text".
   IMCPBinaryResource = interface
     ['{E3F5A7B9-2C4D-4E6F-A0B1-3C4D5E6F7081}']
     function ReadBinary: TBytes;
   end;
 
-  /// Optional resource metadata for resources/list: title, size in bytes
-  /// (-1 when unknown) and annotations (may be nil, the resource keeps ownership).
   IMCPResourceMetadata = interface
     ['{F4A6B8CA-3D5E-4F70-B1C2-4D5E6F708192}']
     function GetTitle: string;
@@ -389,9 +313,6 @@ type
     property Annotations: TJSONObject read GetAnnotations;
   end;
 
-  /// Cache hints a resource attaches to its resources/read result in the
-  /// modern era: ttlMs (milliseconds, 0 = immediately stale) and cacheScope
-  /// ('public' or 'private').
   IMCPCacheableResource = interface
     ['{05B7C9DB-4E6F-4081-C2D3-5E6F708192A3}']
     function GetTtlMs: Integer;
@@ -400,15 +321,12 @@ type
     property CacheScope: string read GetCacheScope;
   end;
 
-  /// Optional icons for prompts/list. May be nil; the prompt keeps ownership.
   IMCPPromptMetadata = interface
     ['{16C8DAEC-5F70-4192-D3E4-6F708192A3B4}']
     function GetIcons: TJSONArray;
     property Icons: TJSONArray read GetIcons;
   end;
 
-  /// One suggestion set from completion/complete: at most 100 values, an
-  /// optional total (-1 when unknown) and whether more exist beyond Values.
   TMCPCompletion = record
     Values: TArray<string>;
     Total: Integer;
@@ -416,8 +334,6 @@ type
     class function Create(const Values: TArray<string>; Total: Integer = -1): TMCPCompletion; static;
   end;
 
-  /// Implemented by a prompt or resource template that offers argument
-  /// completion; checked with Supports before completion/complete calls it.
   IMCPCompletable = interface
     ['{27D9EBFD-6081-42A3-E4F5-708192A3B4C5}']
     function Complete(const ArgumentName, Value: string;
@@ -485,7 +401,48 @@ type
     property Tools: TArray<TMCPTool> read FTools write FTools;
   end;
 
+function IsJsonString(const Value: TJSONValue): Boolean;
+
 implementation
+
+function IsJsonString(const Value: TJSONValue): Boolean;
+begin
+  Result := (Value is TJSONString) and not (Value is TJSONNumber);
+end;
+
+{ TMCPLegacySession }
+
+constructor TMCPLegacySession.Create;
+begin
+  inherited Create;
+  FLock := TObject.Create;
+end;
+
+destructor TMCPLegacySession.Destroy;
+begin
+  FLock.Free;
+  inherited;
+end;
+
+function TMCPLegacySession.GetProtocolVersion: string;
+begin
+  TMonitor.Enter(FLock);
+  try
+    Result := FProtocolVersion;
+  finally
+    TMonitor.Exit(FLock);
+  end;
+end;
+
+procedure TMCPLegacySession.SetProtocolVersion(const Value: string);
+begin
+  TMonitor.Enter(FLock);
+  try
+    FProtocolVersion := Value;
+  finally
+    TMonitor.Exit(FLock);
+  end;
+end;
 
 function IsLegacyProtocolVersion(const Version: string): Boolean;
 begin
@@ -524,7 +481,6 @@ begin
     Result.Kind := TMCPRequestIdKind.Null
   else if Value is TJSONNumber then
   begin
-    // Only integers are valid ids; a fraction is not.
     var Number := TJSONNumber(Value);
     if Frac(Number.AsDouble) = 0 then
     begin

--- a/src/Resources/MCPServer.Resource.Base.pas
+++ b/src/Resources/MCPServer.Resource.Base.pas
@@ -8,6 +8,7 @@ uses
   System.JSON,
   System.Generics.Collections,
   System.RegularExpressions,
+  System.SyncObjs,
   MCPServer.Types;
 
 type
@@ -25,13 +26,6 @@ type
     property MimeType: string read GetMimeType;
   end;
 
-  /// Resource whose data is a class T serialised as JSON (mime type
-  /// application/json) or, for other mime types, the string in T's Content
-  /// property.
-  ///
-  /// The protected fields FTitle, FSize (-1 = unknown), FAnnotations (nil),
-  /// FTtlMs (0) and FCacheScope ('private') have safe defaults; set them in
-  /// the constructor of a descendant.
   TMCPResourceBase<T: class, constructor> = class(TInterfacedObject, IMCPResource,
     IMCPResourceMetadata, IMCPCacheableResource)
   protected
@@ -72,7 +66,6 @@ type
     property Text: string read FText write FText;
   end;
 
-  /// Variables captured from a URI matched against a template.
   TMCPTemplateVars = TDictionary<string, string>;
 
   IMCPResourceTemplate = interface
@@ -82,11 +75,7 @@ type
     function GetTitle: string;
     function GetDescription: string;
     function GetMimeType: string;
-    /// True when URI matches the template; the captured variables
-    /// (percent-decoded) are added to Vars.
     function Matches(const URI: string; Vars: TMCPTemplateVars): Boolean;
-    /// Builds the resource for a URI already confirmed to match, with its
-    /// captured variables.
     function CreateResource(const URI: string; Vars: TMCPTemplateVars): IMCPResource;
 
     property UriTemplate: string read GetUriTemplate;
@@ -96,19 +85,14 @@ type
     property MimeType: string read GetMimeType;
   end;
 
-  /// Resource template matched by URI, RFC 6570 level 1 (simple string
-  /// expansion, "{var}", one path segment) and a level 2 subset (reserved
-  /// expansion, "{+var}", matches the rest of the URI including "/").
-  /// "{/var}" and "{?var}" are not supported.
-  ///
-  /// Set FUriTemplate, FName and the optional FTitle/FDescription/FMimeType
-  /// in the constructor of a descendant, as with TMCPResourceBase<T>.
   TMCPResourceTemplateBase = class(TInterfacedObject, IMCPResourceTemplate)
   strict private
-    FRegex: TRegEx;
+    FPattern: string;
     FVariableNames: TArray<string>;
     FCompiled: Boolean;
+    FCompileLock: TCriticalSection;
     procedure EnsureCompiled;
+    class function PercentDecode(const Text: string): string; static;
     class function CompilePattern(const UriTemplate: string; out VariableNames: TArray<string>): string; static;
   protected
     FUriTemplate: string;
@@ -118,6 +102,7 @@ type
     FMimeType: string;
   public
     constructor Create; virtual;
+    destructor Destroy; override;
 
     function GetUriTemplate: string;
     function GetName: string;
@@ -131,7 +116,6 @@ type
 implementation
 
 uses
-  System.NetEncoding,
   MCPServer.Serializer;
 
 { TMCPResourceBase<T> }
@@ -246,6 +230,37 @@ constructor TMCPResourceTemplateBase.Create;
 begin
   inherited Create;
   FMimeType := '';
+  FCompileLock := TCriticalSection.Create;
+end;
+
+destructor TMCPResourceTemplateBase.Destroy;
+begin
+  FCompileLock.Free;
+  inherited;
+end;
+
+class function TMCPResourceTemplateBase.PercentDecode(const Text: string): string;
+begin
+  var Bytes: TBytes := nil;
+  var Utf8 := TEncoding.UTF8.GetBytes(Text);
+  var I := 0;
+  while I < Length(Utf8) do
+  begin
+    if (Utf8[I] = Ord('%')) and (I + 2 < Length(Utf8)) then
+    begin
+      var Hex := Char(Utf8[I + 1]) + Char(Utf8[I + 2]);
+      var Value := StrToIntDef('$' + Hex, -1);
+      if Value >= 0 then
+      begin
+        Bytes := Bytes + [Byte(Value)];
+        Inc(I, 3);
+        Continue;
+      end;
+    end;
+    Bytes := Bytes + [Utf8[I]];
+    Inc(I);
+  end;
+  Result := TEncoding.UTF8.GetString(Bytes);
 end;
 
 class function TMCPResourceTemplateBase.CompilePattern(const UriTemplate: string;
@@ -281,6 +296,10 @@ begin
         end;
         if VarName = '' then
           raise EArgumentException.CreateFmt('Empty variable name in URI template "%s"', [UriTemplate]);
+        for var C in VarName do
+          if not CharInSet(C, ['A'..'Z', 'a'..'z', '0'..'9', '_']) then
+            raise EArgumentException.CreateFmt('Variable name "%s" in URI template "%s" may only contain letters, digits and underscores',
+              [VarName, UriTemplate]);
 
         Names.Add(VarName);
         Position := CloseBrace + 1;
@@ -303,10 +322,16 @@ end;
 
 procedure TMCPResourceTemplateBase.EnsureCompiled;
 begin
-  if FCompiled then
-    Exit;
-  FRegex := TRegEx.Create(CompilePattern(FUriTemplate, FVariableNames));
-  FCompiled := True;
+  FCompileLock.Enter;
+  try
+    if not FCompiled then
+    begin
+      FPattern := CompilePattern(FUriTemplate, FVariableNames);
+      FCompiled := True;
+    end;
+  finally
+    FCompileLock.Leave;
+  end;
 end;
 
 function TMCPResourceTemplateBase.GetUriTemplate: string;
@@ -337,11 +362,11 @@ end;
 function TMCPResourceTemplateBase.Matches(const URI: string; Vars: TMCPTemplateVars): Boolean;
 begin
   EnsureCompiled;
-  var Match := FRegex.Match(URI);
+  var Match := TRegEx.Match(URI, FPattern);
   Result := Match.Success;
   if Result then
     for var VarName in FVariableNames do
-      Vars.AddOrSetValue(VarName, TNetEncoding.URL.Decode(Match.Groups[VarName].Value));
+      Vars.AddOrSetValue(VarName, PercentDecode(Match.Groups[VarName].Value));
 end;
 
 end.

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -34,7 +34,7 @@ type
   public
     constructor Create;
     destructor Destroy; override;
-    
+
     property Entries: TObjectList<TLogEntry> read FEntries write FEntries;
     property TotalCount: NativeInt read FTotalCount write FTotalCount;
     property FilteredCount: NativeInt read FFilteredCount write FFilteredCount;
@@ -49,10 +49,10 @@ type
   public
     constructor Create;
     destructor Destroy; override;
-    
+
     class function Instance: TLogBuffer;
     class procedure Finalize;
-    
+
     procedure AddLog(const ALevel, AMessage, ACategory: string);
     function GetLogs(AMaxCount: NativeInt = 100; const ALevel: string = ''): TObjectList<TLogEntry>;
   end;
@@ -64,7 +64,6 @@ type
     constructor Create; override;
   end;
 
-  /// A single log level, e.g. "logs://INFO"; matched by TLogsByLevelTemplate.
   TLogsByLevelResource = class(TMCPResourceBase<TLogEntries>)
   private
     FLevel: string;
@@ -74,9 +73,6 @@ type
     constructor CreateForLevel(const AUri, ALevel: string); reintroduce;
   end;
 
-  /// logs://{level}: the same recent-log data as logs://recent, filtered to
-  /// one level. Completes the level argument against the levels actually
-  /// present in the buffer.
   TLogsByLevelTemplate = class(TMCPResourceTemplateBase, IMCPCompletable)
   public
     constructor Create; override;
@@ -167,10 +163,9 @@ begin
     {$ELSE}
     Entry.ThreadID := TThread.CurrentThread.ThreadID;
     {$ENDIF}
-    
+
     FLogs.Add(Entry);
-    
-    // Remove earliest entries if buffer exceeds maximum capacity
+
     while FLogs.Count > FMaxEntries do
     begin
       FLogs[0].Free;
@@ -188,11 +183,11 @@ var
   StartIndex: NativeInt;
 begin
   Result := TObjectList<TLogEntry>.Create(True);
-  
+
   FLock.Acquire;
   try
     StartIndex := Max(0, FLogs.Count - AMaxCount);
-    
+
     for i := StartIndex to FLogs.Count - 1 do
     begin
       Entry := FLogs[i];
@@ -221,7 +216,6 @@ begin
   FName := 'Recent Logs';
   FDescription := 'Recent log entries from all categories';
   FMimeType := 'application/json';
-  // Live data: never cache, never share between callers.
   FTtlMs := 0;
   FCacheScope := MCP_CACHE_SCOPE_PRIVATE;
 end;
@@ -237,14 +231,11 @@ begin
     Result.Entries.AddRange(Logs);
     Result.TotalCount := Logs.Count;
     Result.FilteredCount := Logs.Count;
-    // GetLogs returns copies in an owning list; Result.Entries owns them
-    // from here on, otherwise they would be freed twice.
     Logs.OwnsObjects := False;
   finally
     Logs.Free;
   end;
 end;
-
 
 { TLogsByLevelResource }
 
@@ -319,15 +310,13 @@ end;
 
 initialization
   TLogBuffer.FLock := TCriticalSection.Create;
-  
-  // Example initialization logs
+
   TLogBuffer.Instance.AddLog('INFO', 'MCP Server started', 'SYSTEM');
   TLogBuffer.Instance.AddLog('INFO', 'Resources manager initialized', 'SYSTEM');
   TLogBuffer.Instance.AddLog('INFO', 'Tools manager initialized', 'SYSTEM');
   TLogBuffer.Instance.AddLog('WARNING', 'Debug mode is enabled', 'CONFIG');
   TLogBuffer.Instance.AddLog('INFO', 'Server listening on port 8080', 'SERVER');
-  
-  // Register Logs resources
+
   TMCPRegistry.RegisterResource('logs://recent',
     function: IMCPResource
     begin
@@ -341,7 +330,7 @@ initialization
       Result := TLogsByLevelTemplate.Create;
     end
   );
-  
+
 
 finalization
   TLogBuffer.Finalize;

--- a/src/Resources/MCPServer.Resource.Project.pas
+++ b/src/Resources/MCPServer.Resource.Project.pas
@@ -25,7 +25,7 @@ type
   public
     constructor Create;
     destructor Destroy; override;
-    
+
     property Name: string read FName write FName;
     property Version: string read FVersion write FVersion;
     property Description: string read FDescription write FDescription;
@@ -59,7 +59,6 @@ type
     constructor Create; override;
   end;
 
-
 implementation
 
 uses
@@ -91,7 +90,6 @@ begin
   FName := 'Project Information';
   FDescription := 'Basic information about the Delphi MCP Server project';
   FMimeType := 'application/json';
-  // Static content: an hour of caching, shareable between callers.
   FTtlMs := PROJECT_RESOURCE_TTL_MS;
   FCacheScope := MCP_CACHE_SCOPE_PUBLIC;
 end;
@@ -160,7 +158,6 @@ begin
 '''';
 end;
 
-
 initialization
   TMCPRegistry.RegisterResource('project://info',
     function: IMCPResource
@@ -168,13 +165,13 @@ initialization
       Result := TProjectInfoResource.Create;
     end
   );
-  
+
   TMCPRegistry.RegisterResource('project://readme',
     function: IMCPResource
     begin
       Result := TProjectReadmeResource.Create;
     end
   );
-  
+
 
 end.

--- a/src/Resources/MCPServer.Resource.Samples.pas
+++ b/src/Resources/MCPServer.Resource.Samples.pas
@@ -15,8 +15,6 @@ type
     property Content: string read FContent write FContent;
   end;
 
-  /// A static text resource. The URIs of these sample resources follow the
-  /// official conformance suite, which reads them by URI.
   TStaticTextResource = class(TMCPResourceBase<TStaticText>)
   protected
     function GetResourceData: TStaticText; override;
@@ -24,7 +22,6 @@ type
     constructor Create; override;
   end;
 
-  /// A static binary resource (a 1x1 PNG), read through IMCPBinaryResource.
   TStaticBinaryResource = class(TMCPResourceBase<TStaticText>, IMCPBinaryResource)
   protected
     function GetResourceData: TStaticText; override;
@@ -44,7 +41,6 @@ type
     property Data: string read FData write FData;
   end;
 
-  /// test://template/{id}/data, matched by TTemplateDataResourceTemplate.
   TTemplateDataResource = class(TMCPResourceBase<TTemplateData>)
   private
     FId: string;
@@ -106,7 +102,6 @@ end;
 
 function TStaticBinaryResource.GetResourceData: TStaticText;
 begin
-  // Text reads of a binary resource hand out the Base64 form.
   Result := TStaticText.Create;
   Result.Content := SAMPLE_PNG_BASE64;
 end;

--- a/src/Resources/MCPServer.Resource.Server.pas
+++ b/src/Resources/MCPServer.Resource.Server.pas
@@ -28,7 +28,6 @@ type
     property ActiveConnections: Integer read FActiveConnections write FActiveConnections;
   end;
 
-
   TServerStatusResource = class(TMCPResourceBase<TServerStatus>)
   private
     class var FServerStartTime: TDateTime;
@@ -40,24 +39,13 @@ type
     function GetResourceData: TServerStatus; override;
   public
     constructor Create; override;
-    /// Resets the start time and the counters. Runs from the unit
-    /// initialization and again from MCPServer.dpr before a transport starts.
     class procedure Initialize;
-    /// Re-registers the resource as server://<Prefix>status and removes the
-    /// URI registered before. The registry is read once, when
-    /// TMCPResourcesManager is created, so call this before the managers are
-    /// built (before TMCPIdHTTPServer.Start or TMCPStdioTransport.Run).
     class procedure SetNamePrefix(const Prefix: string);
-    /// Registers server://status (or the prefixed URI). The unit
-    /// initialization does this once, so the resource is available by default.
     class procedure RegisterServerStatusResource;
-    // The counters are updated from every Indy connection thread, so they
-    // use atomic operations.
     class procedure IncrementRequestCount;
     class procedure ConnectionOpened;
     class procedure ConnectionClosed;
   end;
-
 
 implementation
 
@@ -68,7 +56,6 @@ uses
   {$ENDIF}
   System.Classes,
   MCPServer.Registration;
-
 
 { TServerStatusResource }
 
@@ -114,7 +101,6 @@ end;
 
 class procedure TServerStatusResource.ConnectionClosed;
 begin
-  // Never below zero, and without a moment in which a reader can see -1.
   var Current := AtomicCmpExchange(FActiveConnections, 0, 0);
   while Current > 0 do
   begin
@@ -147,7 +133,7 @@ begin
   Result.Uptime := SecondsBetween(Now, FServerStartTime);
   Result.RequestCount := AtomicCmpExchange(FRequestCount, 0, 0);
   Result.ActiveConnections := AtomicCmpExchange(FActiveConnections, 0, 0);
-  
+
   {$IFDEF MSWINDOWS}
   ProcessMemoryCounters.cb := SizeOf(ProcessMemoryCounters);
   if GetProcessMemoryInfo(GetCurrentProcess, @ProcessMemoryCounters, SizeOf(ProcessMemoryCounters)) then
@@ -155,10 +141,9 @@ begin
   else
     Result.MemoryUsed := 0;
   {$ELSE}
-  Result.MemoryUsed := 0; // Not implemented for other platforms
+  Result.MemoryUsed := 0;
   {$ENDIF}
 end;
-
 
 initialization
   TServerStatusResource.Initialize;

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -6,46 +6,29 @@ uses
   System.SysUtils;
 
 type
-  /// Values of the headers the Streamable HTTP transport mirrors from the
-  /// body (Mcp-Name, Mcp-Param-*). Header values are visible ASCII; anything
-  /// else travels Base64-encoded between the sentinels =?base64? and ?=.
   TMCPHeaderValue = record
     const SENTINEL_PREFIX = '=?base64?';
     const SENTINEL_SUFFIX = '?=';
 
-    /// Visible ASCII (0x21 to 0x7E), space and horizontal tab only.
     class function IsHeaderSafe(const Value: string): Boolean; static;
     class function IsSentinel(const Value: string): Boolean; static;
-    /// Strict Base64: alphabet, length a multiple of four, padding only at
-    /// the end. Returns False on any deviation.
     class function TryDecodeBase64(const Text: string; out Bytes: TBytes): Boolean; static;
-    /// Decodes a header value to the string it stands for. A sentinel value
-    /// is Base64-decoded as UTF-8; a plain value must be header-safe.
     class function TryDecode(const Value: string; out Decoded: string): Boolean; static;
   end;
 
   TMCPAcceptHeader = record
-    /// True when one of the comma-separated entries names the media type
-    /// (parameters ignored, case-insensitive).
     class function Accepts(const AcceptHeader, MediaType: string): Boolean; static;
   end;
 
-  /// Origin validation for DNS-rebinding protection.
   TMCPOriginPolicy = record
     const ALLOW_ALL = '*';
 
-    /// An origin whose host is localhost, 127.0.0.1 or [::1], any port.
     class function IsLoopback(const Origin: string): Boolean; static;
-    /// Absent origins and loopback origins pass. Otherwise the origin must be
-    /// in the allow-list: scheme://host[:port], compared case-insensitively;
-    /// a ':*' port allows any port; '*' allows everything. 'null' never passes.
     class function IsAllowed(const Origin: string; const AllowList: TArray<string>): Boolean; static;
     class function Matches(const Origin, Pattern: string): Boolean; static;
   end;
 
   TMCPJsonLimits = record
-    /// Nesting depth of objects and arrays in a JSON text, ignoring the
-    /// contents of strings. Zero for a scalar.
     class function NestingDepth(const Json: string): Integer; static;
   end;
 
@@ -66,7 +49,6 @@ end;
 
 class function TMCPHeaderValue.IsSentinel(const Value: string): Boolean;
 begin
-  // The markers are case-sensitive and must appear exactly as shown.
   Result := (Length(Value) >= Length(SENTINEL_PREFIX) + Length(SENTINEL_SUFFIX))
     and Value.StartsWith(SENTINEL_PREFIX, False) and Value.EndsWith(SENTINEL_SUFFIX, False);
 end;
@@ -137,6 +119,16 @@ end;
 
 { TMCPOriginPolicy }
 
+function DefaultPortOf(const Scheme: string): string;
+begin
+  if Scheme = 'https' then
+    Result := '443'
+  else if Scheme = 'http' then
+    Result := '80'
+  else
+    Result := '';
+end;
+
 procedure SplitOrigin(const Origin: string; out Scheme, Host, Port: string);
 begin
   Scheme := '';
@@ -150,7 +142,6 @@ begin
   Scheme := Rest.Substring(0, SchemeEnd).ToLower;
   Rest := Rest.Substring(SchemeEnd + 3);
 
-  // IPv6 hosts are bracketed; the port follows the closing bracket.
   var PortStart: Integer;
   if Rest.StartsWith('[') then
   begin
@@ -194,6 +185,11 @@ begin
   SplitOrigin(Pattern, PatternScheme, PatternHost, PatternPort);
   if (OriginScheme = '') or (PatternScheme = '') then
     Exit(False);
+
+  if (OriginPort = '') then
+    OriginPort := DefaultPortOf(OriginScheme);
+  if (PatternPort = '') then
+    PatternPort := DefaultPortOf(PatternScheme);
 
   Result := (OriginScheme = PatternScheme) and (OriginHost = PatternHost)
     and ((PatternPort = '*') or (OriginPort = PatternPort));

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -30,10 +30,6 @@ uses
   MCPServer.JsonRpcProcessor;
 
 type
-  /// Streamable HTTP transport on Indy. The request pipeline is:
-  /// Origin check (403), CORS headers, endpoint check (404), OPTIONS (204),
-  /// any verb but POST (405), then the JSON-RPC processor decides body and
-  /// status. Notifications are answered with 202 and an empty body.
   TMCPIdHTTPServer = class(TComponent)
   private
     FHTTPServer: TIdHTTPServer;
@@ -72,9 +68,7 @@ type
     destructor Destroy; override;
     procedure Start;
     procedure Stop;
-    /// Addresses the server listens on after Start ("ip:port").
     function BoundAddresses: TArray<string>;
-    /// Port after Start; a Settings port of 0 lets the system choose one.
     property Port: Word read FPort write FPort;
     property Active: Boolean read FActive;
     property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry write FManagerRegistry;
@@ -236,8 +230,6 @@ begin
     Exit;
   end;
 
-  // No BindAddress: a loopback Host means a local server, anything else is
-  // reachable at the address the host name resolves to.
   if SameText(Host, 'localhost') or (Host = LOOPBACK_IPV4) or (Host = LOOPBACK_IPV6) then
   begin
     AddBinding(LOOPBACK_IPV4, Id_IPv4);
@@ -268,12 +260,10 @@ begin
   end;
 
   {$IFDEF USE_TAURUS_TLS}
-  // TaurusTLS with OpenSSL 3.x/4.x support
   FSSLHandler := TTaurusTLSServerIOHandler.Create(Self);
   FSSLHandler.DefaultCert.PublicKey := FSettings.SSLCertFile;
   FSSLHandler.DefaultCert.PrivateKey := FSettings.SSLKeyFile;
   {$ELSE}
-  // Standard Indy SSL with OpenSSL 1.0.2; TLS 1.2 is the only version offered.
   FSSLHandler := TIdServerIOHandlerSSLOpenSSL.Create(Self);
   FSSLHandler.SSLOptions.CertFile := FSettings.SSLCertFile;
   FSSLHandler.SSLOptions.KeyFile := FSettings.SSLKeyFile;
@@ -302,7 +292,6 @@ end;
 
 function TMCPIdHTTPServer.HeaderPresent(RequestInfo: TIdHTTPRequestInfo; const Name: string): Boolean;
 begin
-  // TIdHeaderList matches names case-insensitively.
   Result := RequestInfo.RawHeaders.IndexOfName(Name) >= 0;
 end;
 
@@ -402,7 +391,6 @@ begin
     ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := Origin;
 
   var AllowHeaders := CORS_ALLOW_HEADERS;
-  // Reflect what a preflight asks for, so Mcp-Param-* headers pass as well.
   for var Requested in HeaderValue(RequestInfo, 'Access-Control-Request-Headers').Split([',']) do
   begin
     var Name := Requested.Trim;
@@ -422,8 +410,12 @@ begin
   try
     Info.AddPair('url', FSettings.Protocol + '://' + FSettings.Host + ':' + IntToStr(FPort) + FSettings.Endpoint);
     Info.AddPair('transport', 'streamable-http');
-    Info.AddPair('protocolVersions', TJSONArray.Create
-      .Add(MCP_LATEST_PROTOCOL_VERSION).Add(MCP_PROTOCOL_VERSION_2025_11_25).Add(MCP_PROTOCOL_VERSION_2025_06_18));
+    var Versions := TJSONArray.Create;
+    Info.AddPair('protocolVersions', Versions);
+    for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+      Versions.Add(Version);
+    for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+      Versions.Add(Version);
     SendJson(ResponseInfo, HTTP_STATUS_OK, Info.ToJSON);
   finally
     Info.Free;
@@ -443,8 +435,6 @@ end;
 
 procedure TMCPIdHTTPServer.EchoLegacySessionId(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
 begin
-  // Never minted; an incoming id is handed back unchanged when it is a
-  // plausible header value.
   var SessionId := HeaderValue(RequestInfo, HEADER_SESSION_ID);
   if (SessionId <> '') and TMCPHeaderValue.IsHeaderSafe(SessionId) and not SessionId.Contains(' ') then
     ResponseInfo.CustomHeaders.Values[HEADER_SESSION_ID] := SessionId;
@@ -511,7 +501,6 @@ end;
 
 procedure TMCPIdHTTPServer.SendEmpty(ResponseInfo: TIdHTTPResponseInfo; Status: Integer);
 begin
-  // An assigned, empty stream keeps Indy from writing its default HTML body.
   ResponseInfo.ResponseNo := Status;
   ResponseInfo.ContentStream := TMemoryStream.Create;
   ResponseInfo.FreeContentStream := True;
@@ -539,7 +528,6 @@ end;
 
 procedure TMCPIdHTTPServer.SendJsonRpcError(ResponseInfo: TIdHTTPResponseInfo; Status, Code: Integer; const Message: string);
 begin
-  // Transport-level rejections carry an error body without an id.
   var Response := TJSONObject.Create;
   try
     Response.AddPair('jsonrpc', '2.0');

--- a/src/Server/MCPServer.StdioChannel.pas
+++ b/src/Server/MCPServer.StdioChannel.pas
@@ -1,10 +1,5 @@
 unit MCPServer.StdioChannel;
 
-/// The byte-level side of the stdio transport: one UTF-8 encoded JSON-RPC
-/// message per line, LF-delimited, no BOM, and the standard handles as
-/// streams. Text I/O is deliberately not used: it decodes stdin with the
-/// console code page on Windows and would alter every non-ASCII character.
-
 interface
 
 uses
@@ -15,17 +10,11 @@ uses
 
 type
   TMCPLineStatus = (
-    /// A complete line was decoded.
     Ok,
-    /// The line exceeded the limit; it was skipped up to its newline.
     TooLong,
-    /// The bytes were not valid UTF-8; the line was skipped.
     InvalidUtf8
   );
 
-  /// Reads LF-delimited UTF-8 lines from a byte stream. A trailing CR is
-  /// dropped, a leading byte-order mark is ignored, the last line needs no
-  /// newline.
   TMCPLineReader = class
   strict private
     const READ_CHUNK_BYTES = 64 * 1024;
@@ -40,13 +29,9 @@ type
     function DecodeLine(Start, Count: Integer; out Line: string): TMCPLineStatus;
   public
     constructor Create(Stream: TStream; MaxLineBytes: Integer);
-    /// False at the end of the stream. Status says whether Line is usable.
     function ReadLine(out Line: string; out Status: TMCPLineStatus): Boolean;
   end;
 
-  /// Writes one message per line, UTF-8 with a bare LF, and serialises
-  /// concurrent writers so lines never interleave. Any newline inside a
-  /// message is replaced by a space: the framing does not allow it.
   TMCPLineWriter = class(TInterfacedObject, IMCPMessageSink)
   strict private
     FStream: TStream;
@@ -57,7 +42,6 @@ type
     procedure Send(const Json: string);
   end;
 
-/// Streams over the process's standard input and output handles.
 function StandardInputStream: TStream;
 function StandardOutputStream: TStream;
 
@@ -103,7 +87,6 @@ end;
 
 function TMCPLineReader.Fill: Boolean;
 begin
-  // Grow the buffer when a line is longer than a chunk, then append a chunk.
   if Length(FPending) - FPendingLength < READ_CHUNK_BYTES then
     SetLength(FPending, Length(FPending) + READ_CHUNK_BYTES);
 
@@ -142,11 +125,9 @@ begin
   try
     Line := TEncoding.UTF8.GetString(FPending, Start, Count);
   except
-    // Some malformed sequences raise instead of decoding leniently.
     Line := '';
     Exit(TMCPLineStatus.InvalidUtf8);
   end;
-  // The RTL decoder answers an empty string for other malformed input.
   if (Line = '') and (Count > 0) then
     Exit(TMCPLineStatus.InvalidUtf8);
   Result := TMCPLineStatus.Ok;
@@ -172,9 +153,37 @@ begin
       end;
     ScanFrom := FPendingLength;
 
+    if FPendingLength > FMaxLineBytes then
+    begin
+      FPendingLength := 0;
+      var Skipped: TArray<Byte>;
+      SetLength(Skipped, READ_CHUNK_BYTES);
+      while True do
+      begin
+        var Count := Integer(FStream.Read(Skipped[0], Length(Skipped)));
+        if Count <= 0 then
+        begin
+          FEndOfStream := True;
+          Line := '';
+          Status := TMCPLineStatus.TooLong;
+          Exit(True);
+        end;
+        for var I := 0 to Count - 1 do
+          if Skipped[I] = 10 then
+          begin
+            var Rest: Integer := Count - (I + 1);
+            if Rest > 0 then
+              Move(Skipped[I + 1], FPending[0], Rest);
+            FPendingLength := Rest;
+            Line := '';
+            Status := TMCPLineStatus.TooLong;
+            Exit(True);
+          end;
+      end;
+    end;
+
     if FEndOfStream or not Fill then
     begin
-      // The final line may end without a newline.
       if FPendingLength = 0 then
         Exit(False);
       Status := DecodeLine(0, FPendingLength, Line);

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -1,16 +1,5 @@
 unit MCPServer.StdioTransport;
 
-/// The stdio transport: JSON-RPC messages on stdin, one per line, answered
-/// on stdout; every log line on stderr.
-///
-/// A reader thread (the calling thread of Run) parses each line. Messages
-/// without an id and legacy ping are handled on that thread at once, so a
-/// notifications/cancelled reaches a request that is still running. Other
-/// requests go through a queue to MaxConcurrentRequests worker threads
-/// (default 1: responses in request order). A cancelled request gets no
-/// response. When stdin closes, queued and running work is drained for
-/// ShutdownDrainMs, the rest is cancelled, and Run returns.
-
 interface
 
 uses
@@ -27,8 +16,6 @@ uses
   MCPServer.Logger;
 
 type
-  /// The requests a stdio process has accepted and not yet answered, keyed
-  /// by id, so notifications/cancelled can reach them.
   TMCPStdioRequestTracker = class(TInterfacedObject, IMCPRequestTracker)
   strict private
     type
@@ -43,14 +30,11 @@ type
   public
     constructor Create;
     destructor Destroy; override;
-    /// Claims the id when it is read; False when that id is still in flight.
     function Reserve(const RequestId: TMCPRequestId): Boolean;
-    /// Drops the claim once the request is answered or refused.
     procedure Release(const RequestId: TMCPRequestId);
     procedure Track(const Context: IMCPRequestContext);
     procedure Untrack(const Context: IMCPRequestContext);
     function TryCancel(const RequestId: TMCPRequestId; const Reason: string): Boolean;
-    /// Cancels everything still in flight; returns how many there were.
     function CancelAll(const Reason: string): Integer;
   end;
 
@@ -70,6 +54,7 @@ type
     FQueue: TThreadedQueue<TJSONValue>;
     FWorkersDone: TCountdownEvent;
     FShutdownDrainMs: Integer;
+    FWorkerStuck: Boolean;
     function GetSettings: TMCPSettings;
     procedure SetSettings(const Value: TMCPSettings);
     function Hints: TMCPTransportHints;
@@ -87,16 +72,9 @@ type
   public
     constructor Create(ManagerRegistry: IMCPManagerRegistry; CoreManager: IMCPCapabilityManager);
     destructor Destroy; override;
-    /// Serves the process's standard input and output until stdin closes.
     procedure Run;
-    /// Serves the given streams until the input ends; what Run does with the
-    /// standard handles. Both streams stay owned by the caller.
     procedure RunWith(InputStream, OutputStream: TStream);
-    /// Server identity and protocol options; assign before Run. Without it the
-    /// processor uses the defaults (settings.ini next to the executable).
     property Settings: TMCPSettings read GetSettings write SetSettings;
-    /// How long Run waits for in-flight requests after stdin closed before
-    /// cancelling them. Default DEFAULT_SHUTDOWN_DRAIN_MS.
     property ShutdownDrainMs: Integer read FShutdownDrainMs write FShutdownDrainMs;
   end;
 
@@ -147,7 +125,6 @@ end;
 
 class function TMCPStdioRequestTracker.KeyOf(const RequestId: TMCPRequestId): string;
 begin
-  // 1 and "1" are different ids.
   if RequestId.Kind = TMCPRequestIdKind.Number then
     Result := 'n:' + RequestId.AsText
   else
@@ -192,7 +169,6 @@ begin
   finally
     FLock.Leave;
   end;
-  // The cancellation arrived before the handler started.
   if CancelNow then
     Context.Cancel;
 end;
@@ -227,7 +203,7 @@ begin
   if Reason <> '' then
     TLogger.Info(Format('Request %s cancelled by the client: %s', [RequestId.AsText, Reason]))
   else
-    TLogger.Info('Request ' + RequestId.AsText + ' cancelled by the client');
+    TLogger.Info(Format('Request %s cancelled by the client', [RequestId.AsText]));
 end;
 
 function TMCPStdioRequestTracker.CancelAll(const Reason: string): Integer;
@@ -236,7 +212,7 @@ begin
   try
     FLock.Enter;
     try
-      Result := FEntries.Count;
+      Result := Integer(FEntries.Count);
       for var Key in FEntries.Keys.ToArray do
       begin
         var Entry := FEntries[Key];
@@ -270,17 +246,18 @@ begin
   FTrackerIntf := FTracker;
   FShutdownDrainMs := DEFAULT_SHUTDOWN_DRAIN_MS;
 
-  // stdout carries MCP messages only; every log line must go to stderr,
-  // also for library consumers that never set UseStdErr themselves.
   TLogger.UseStdErr := True;
   TLogger.StdoutReserved := True;
 end;
 
 destructor TMCPStdioTransport.Destroy;
 begin
-  FJsonRpcProcessor.Free;
-  FLegacySession.Free;
-  FTrackerIntf := nil;
+  if not FWorkerStuck then
+  begin
+    FJsonRpcProcessor.Free;
+    FLegacySession.Free;
+    FTrackerIntf := nil;
+  end;
   inherited;
 end;
 
@@ -331,8 +308,6 @@ end;
 
 procedure TMCPStdioTransport.DispatchLine(const Message: TJSONValue);
 begin
-  // Malformed shapes, notifications, client responses and legacy ping are
-  // answered on the reader thread; every other request is queued.
   var Queued := False;
   try
     if Message is TJSONObject then
@@ -388,12 +363,11 @@ procedure TMCPStdioTransport.WorkerLoop;
 var
   Message: TJSONValue;
 begin
+  var Queue := FQueue;
+  var Done := FWorkersDone;
   try
-    while FQueue.PopItem(Message) = TWaitResult.wrSignaled do
+    while Queue.PopItem(Message) = TWaitResult.wrSignaled do
     begin
-      // A nil sentinel (one per worker, pushed by DrainAndStop) is the
-      // shutdown signal: everything queued ahead of it is real work and
-      // gets processed first, since the queue is FIFO.
       if not Assigned(Message) then
         Break;
       try
@@ -404,7 +378,7 @@ begin
       end;
     end;
   finally
-    FWorkersDone.Signal;
+    Done.Signal;
   end;
 end;
 
@@ -420,31 +394,27 @@ end;
 
 procedure TMCPStdioTransport.DrainAndStop;
 begin
-  // One sentinel per worker: whatever real work is already queued runs
-  // first (the queue is FIFO), then each worker pops its sentinel and
-  // stops. No new work is pushed after this point (the reader loop has
-  // already returned).
   for var I := 1 to WorkerCount do
     FQueue.PushItem(nil);
 
-  if FWorkersDone.WaitFor(FShutdownDrainMs) <> TWaitResult.wrSignaled then
+  if FWorkersDone.WaitFor(Cardinal(FShutdownDrainMs)) <> TWaitResult.wrSignaled then
   begin
     FTracker.CancelAll('stdin closed');
     FWorkersDone.WaitFor(SHUTDOWN_CANCEL_GRACE_MS);
   end;
 
-  // A worker that is still stuck in a handler owns nothing we free here; it
-  // ends with the process. Once every worker took its sentinel the queue
-  // holds nothing else, so it is safe to free here.
   if FWorkersDone.IsSet then
   begin
     FWorkersDone.Free;
     FQueue.Free;
+    FWorkersDone := nil;
+    FQueue := nil;
   end
   else
+  begin
+    FWorkerStuck := True;
     TLogger.Warning('A request handler did not stop; leaving it to the process exit');
-  FWorkersDone := nil;
-  FQueue := nil;
+  end;
 end;
 
 procedure TMCPStdioTransport.ReadLoop(InputStream: TStream);
@@ -470,7 +440,6 @@ begin
           DispatchLine(TJSONObject.ParseJSONValue(Line));
         end;
       except
-        // Never on stdout: a failure here has no request to answer.
         on E: Exception do
           TLogger.Error('Error reading stdio request: ' + E.Message);
       end;

--- a/src/Tools/MCPServer.Tool.Base.pas
+++ b/src/Tools/MCPServer.Tool.Base.pas
@@ -16,9 +16,6 @@ type
     function GetDescription: string;
     function GetInputSchema: TJSONObject;
     function GetOutputSchema: TJSONObject;
-    /// Returns a string (one text block), a TJSONObject (structured content),
-    /// a TJSONArray (content blocks) or a TMCPToolResult. The tools manager
-    /// takes ownership of objects.
     function Execute(const Arguments: TJSONObject): TValue;
 
     property Name: string read GetName;
@@ -28,14 +25,6 @@ type
     property OutputSchema: TJSONObject read GetOutputSchema;
   end;
 
-  /// Tool with a hand-written schema and raw JSON arguments.
-  ///
-  /// The protected fields FAnnotations and FIcons (nil by default) are
-  /// reported in tools/list when set; the tool owns them. Execute validates
-  /// Arguments against BuildSchema (raising EArgumentException, which the
-  /// tools manager reports as an isError result) before calling DoExecute;
-  /// this is the only validation a hand-written schema gets, since it does
-  /// not go through TMCPSerializer.
   TMCPToolBase = class(TInterfacedObject, IMCPTool, IMCPToolMetadata)
   protected
     FName: string;
@@ -59,11 +48,6 @@ type
     function Execute(const Arguments: TJSONObject): TValue;
   end;
 
-  /// Tool whose parameters are a class T; the schema comes from T's RTTI.
-  ///
-  /// Override ExecuteWithParams for a text result, or ExecuteWithContext for
-  /// any other result (TMCPToolResult, structured content) and access to the
-  /// request context. The default ExecuteWithContext calls ExecuteWithParams.
   TMCPToolBase<T : class, constructor> = class(TInterfacedObject, IMCPTool, IMCPToolMetadata)
   protected
     FName: string;
@@ -88,8 +72,6 @@ type
     function Execute(const Arguments: TJSONObject): TValue;
   end;
 
-  /// Tool with parameters T and a typed result R that is serialised as
-  /// structured content (with the compact JSON as text for older clients).
   TMCPToolBase<T,R : class, constructor> = class(TInterfacedObject, IMCPTool, IMCPToolMetadata)
   protected
     FName: string;
@@ -292,7 +274,12 @@ begin
   Response := ExecuteWithParams(Params);
   try
     var JsonObj := TJSONObject.Create;
-    TMCPSerializer.Serialize(Response, JsonObj);
+    try
+      TMCPSerializer.Serialize(Response, JsonObj);
+    except
+      JsonObj.Free;
+      raise;
+    end;
     Result := TValue.From<TJSONObject>(JsonObj);
   finally
     Response.Free;

--- a/src/Tools/MCPServer.Tool.Calculate.pas
+++ b/src/Tools/MCPServer.Tool.Calculate.pas
@@ -10,7 +10,7 @@ uses
 
 type
   TOperationType = (otAdd, otSubtract, otMultiply, otDivide);
-  
+
   TCalculateParams = class
   private
     FOperation: string;
@@ -20,10 +20,10 @@ type
     [SchemaDescription('Operation: add, subtract, multiply, divide')]
     [SchemaEnum('add', 'subtract', 'multiply', 'divide')]
     property Operation: string read FOperation write FOperation;
-    
+
     [SchemaDescription('First number')]
     property A: Double read FA write FA;
-    
+
     [SchemaDescription('Second number')]
     property B: Double read FB write FB;
   end;
@@ -74,7 +74,7 @@ begin
     Result := 'Error: Unknown operation: ' + Params.Operation;
     Exit;
   end;
-  
+
   Result := Format('%s %s %s = %g', [
     FloatToStr(Params.A), Params.Operation, FloatToStr(Params.B), ResultValue
   ]);

--- a/src/Tools/MCPServer.Tool.ContentSamples.pas
+++ b/src/Tools/MCPServer.Tool.ContentSamples.pas
@@ -13,8 +13,6 @@ type
   TNoParams = class
   end;
 
-  /// Plain text result. The names of these sample tools follow the official
-  /// conformance suite, which calls them by name.
   TSimpleTextTool = class(TMCPToolBase<TNoParams>)
   protected
     function ExecuteWithParams(const Params: TNoParams): string; override;
@@ -22,7 +20,6 @@ type
     constructor Create; override;
   end;
 
-  /// One image block (a 1x1 PNG).
   TImageContentTool = class(TMCPToolBase<TNoParams>)
   protected
     function ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue; override;
@@ -30,7 +27,6 @@ type
     constructor Create; override;
   end;
 
-  /// One audio block (a silent WAV).
   TAudioContentTool = class(TMCPToolBase<TNoParams>)
   protected
     function ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue; override;
@@ -38,7 +34,6 @@ type
     constructor Create; override;
   end;
 
-  /// An embedded text resource.
   TEmbeddedResourceTool = class(TMCPToolBase<TNoParams>)
   protected
     function ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue; override;
@@ -46,7 +41,6 @@ type
     constructor Create; override;
   end;
 
-  /// Text, image and an embedded resource in one result.
   TMultipleContentTypesTool = class(TMCPToolBase<TNoParams>)
   protected
     function ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue; override;
@@ -54,7 +48,6 @@ type
     constructor Create; override;
   end;
 
-  /// Always fails with a tool execution error (isError: true).
   TProgressToolParams = class
   private
     FSteps: Integer;
@@ -68,7 +61,6 @@ type
     property StepMs: Integer read FStepMs write FStepMs;
   end;
 
-  /// Reports progress for every step and stops when the client cancels.
   TProgressTool = class(TMCPToolBase<TProgressToolParams>)
   public
     const DEFAULT_STEPS = 5;
@@ -89,9 +81,6 @@ type
     constructor Create; override;
   end;
 
-  /// A hand-written schema exercising the JSON Schema 2020-12 keywords the
-  /// conformance suite checks for verbatim preservation: $schema, $defs,
-  /// $anchor, $ref, allOf/anyOf, if/then/else and additionalProperties.
   TJsonSchema202012Tool = class(TMCPToolBase)
   protected
     function BuildSchema: TJSONObject; override;
@@ -103,9 +92,7 @@ type
 const
   SAMPLE_TEXT_RESOURCE_URI = 'test://static-text';
   SAMPLE_TEXT_RESOURCE_CONTENT = 'This is the content of the static text resource.';
-  /// A 1x1 transparent PNG.
   SAMPLE_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
-  /// A WAV header for 8 kHz mono 8-bit audio with no samples.
   SAMPLE_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
 
 implementation
@@ -230,7 +217,7 @@ begin
       Context.CheckCancelled;
       Context.ReportProgress(Step - 1, Steps, Format('Step %d of %d', [Step, Steps]));
     end;
-    Sleep(StepMs);
+    Sleep(Cardinal(StepMs));
   end;
   if Assigned(Context) then
     Context.ReportProgress(Steps, Steps, 'Done');

--- a/src/Tools/MCPServer.Tool.ListFiles.pas
+++ b/src/Tools/MCPServer.Tool.ListFiles.pas
@@ -19,7 +19,7 @@ type
   public
     [SchemaDescription('Directory path to list files from')]
     property Path: string read FPath write FPath;
-    
+
     [Optional]
     [SchemaDescription('Include hidden files in the listing')]
     property IncludeHidden: Boolean read FIncludeHidden write FIncludeHidden;
@@ -67,7 +67,7 @@ begin
       Result := 'Error: Access denied - path outside allowed directory';
       Exit;
     end;
-    
+
     if TDirectory.Exists(NormalizedPath) then
     begin
       FileArray := TDirectory.GetFiles(NormalizedPath);
@@ -83,7 +83,7 @@ begin
           {$WARN SYMBOL_PLATFORM ON}
         end;
         {$ENDIF}
-          
+
         Files.Add(ExtractFileName(FileName));
       end;
       Result := 'Files in ' + NormalizedPath + ':' + sLineBreak + Files.Text;

--- a/src/Tools/MCPServer.Tool.Result.pas
+++ b/src/Tools/MCPServer.Tool.Result.pas
@@ -11,10 +11,6 @@ uses
   MCPServer.ContentBlocks;
 
 type
-  /// Builds a tools/call result: content blocks of every kind, optional
-  /// structured content, the error flag and result metadata. A tool returns
-  /// the instance from Execute (as a TValue); the tools manager serialises it
-  /// for the era of the request and frees it.
   TMCPToolResult = class
   private
     FContent: TJSONArray;
@@ -27,7 +23,6 @@ type
     destructor Destroy; override;
 
     function AddText(const Text: string): TMCPToolResult;
-    /// Data is the raw content; it is Base64-encoded here.
     function AddImage(const Data: TBytes; const MimeType: string): TMCPToolResult; overload;
     function AddImage(const Base64Data, MimeType: string): TMCPToolResult; overload;
     function AddAudio(const Data: TBytes; const MimeType: string): TMCPToolResult; overload;
@@ -36,20 +31,14 @@ type
       const MimeType: string = ''): TMCPToolResult;
     function AddEmbeddedText(const Uri, MimeType, Text: string): TMCPToolResult;
     function AddEmbeddedBlob(const Uri, MimeType: string; const Data: TBytes): TMCPToolResult;
-    /// Annotations for the block added last (audience, priority, lastModified).
     function WithAnnotations(const Annotations: TJSONObject): TMCPToolResult;
-    /// Takes ownership. Any JSON value; the initialize-based revisions only
-    /// carry it when it is an object, and a text block with the compact JSON
-    /// is added when no other content exists.
     function SetStructuredContent(const Value: TJSONValue): TMCPToolResult;
-    /// Takes ownership of the result-level _meta object.
     function SetMeta(const Meta: TJSONObject): TMCPToolResult;
     function SetError(const Message: string): TMCPToolResult;
 
     class function Text(const Text: string): TMCPToolResult;
     class function Error(const Message: string): TMCPToolResult;
 
-    /// The CallToolResult object for the era; the caller owns it.
     function ToJson(Era: TMCPProtocolEra): TJSONObject;
 
     property IsError: Boolean read FIsError write FIsError;
@@ -166,7 +155,6 @@ end;
 function TMCPToolResult.BuildContent(Era: TMCPProtocolEra): TJSONArray;
 begin
   Result := TJSONArray(FContent.Clone);
-  // The schema requires content; structured-only results get the JSON as text.
   if (Result.Count = 0) and Assigned(FStructuredContent) then
   begin
     var Block := TJSONObject.Create;
@@ -182,7 +170,6 @@ begin
   try
     Result.AddPair('content', BuildContent(Era));
 
-    // 2025-06-18 and 2025-11-25 define structuredContent as an object only.
     if Assigned(FStructuredContent)
       and ((Era = TMCPProtocolEra.Modern) or (FStructuredContent is TJSONObject)) then
       Result.AddPair('structuredContent', FStructuredContent.Clone as TJSONValue);

--- a/tests/MCPServer.Tests.Cancellation.pas
+++ b/tests/MCPServer.Tests.Cancellation.pas
@@ -12,7 +12,6 @@ uses
   MCPServer.Tests.Harness;
 
 type
-  /// Collects what a context sends through the sink.
   TRecordingSink = class(TInterfacedObject, IMCPMessageSink)
   private
     FMessages: TStrings;
@@ -21,8 +20,6 @@ type
     procedure Send(const Json: string);
   end;
 
-  /// A tracker that cancels every request as soon as it is tracked and
-  /// records the cancellations it is asked for.
   TCancellingTracker = class(TInterfacedObject, IMCPRequestTracker)
   private
     FCancelOnTrack: Boolean;
@@ -267,8 +264,5 @@ begin
     Harness.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TCancellationTests);
 
 end.

--- a/tests/MCPServer.Tests.Capabilities.pas
+++ b/tests/MCPServer.Tests.Capabilities.pas
@@ -25,7 +25,6 @@ uses
   MCPServer.Tests.Harness;
 
 type
-  /// A registry that cannot list its managers (a consumer's own implementation).
   TOpaqueRegistry = class(TInterfacedObject, IMCPManagerRegistry)
   public
     procedure RegisterManager(const Manager: IMCPCapabilityManager);
@@ -97,8 +96,5 @@ begin
     Capabilities.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TCapabilityBuilderTests);
 
 end.

--- a/tests/MCPServer.Tests.CompletionManager.pas
+++ b/tests/MCPServer.Tests.CompletionManager.pas
@@ -24,6 +24,7 @@ type
     [Test] procedure RefPrompt_MissingRefName_IsInvalidParams;
     [Test] procedure RefResource_Template_Completes;
     [Test] procedure RefResource_UnknownUri_IsNotFound;
+    [Test] procedure RefResource_UnknownUri_Legacy_IsLegacyNotFound;
     [Test] procedure MissingArgument_IsInvalidParams;
     [Test] procedure UnknownRefType_IsInvalidParams;
     [Test] procedure CapabilitiesInclude_Completions;
@@ -144,6 +145,25 @@ begin
   end;
 end;
 
+procedure TCompletionManagerTests.RefResource_UnknownUri_Legacy_IsLegacyNotFound;
+begin
+  var Manager := TMCPCompletionManager.Create(FHarness.PromptsManager, FHarness.ResourcesManager);
+  var Params := TJSONObject.ParseJSONValue(
+    '{"ref":{"type":"ref/resource","uri":"nope://missing"},"argument":{"name":"x","value":""}}') as TJSONObject;
+  try
+    try
+      Manager.Complete(Params, TMCPProtocolEra.Legacy).AsType<TJSONObject>.Free;
+      Assert.Fail('expected an error');
+    except
+      on E: EMCPError do
+        Assert.AreEqual(MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY, E.Code);
+    end;
+  finally
+    Params.Free;
+    Manager.Free;
+  end;
+end;
+
 procedure TCompletionManagerTests.MissingArgument_IsInvalidParams;
 begin
   var Manager := TMCPCompletionManager.Create(FHarness.PromptsManager, FHarness.ResourcesManager);
@@ -193,8 +213,5 @@ begin
     Manager.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TCompletionManagerTests);
 
 end.

--- a/tests/MCPServer.Tests.Constants.pas
+++ b/tests/MCPServer.Tests.Constants.pas
@@ -6,8 +6,6 @@ uses
   DUnitX.TestFramework;
 
 type
-  /// Guards the protocol constants in MCPServer.Types and the aliases that
-  /// keep MCPServer.JsonRpcProcessor.JSONRPC_* compiling for consumers.
   [TestFixture]
   TProtocolConstantsTests = class
   public
@@ -17,12 +15,14 @@ type
     [Test] procedure ProtocolVersions_AreConsistent;
     [Test] procedure MetaKeys_UseReservedPrefix;
     [Test] procedure CacheableMethods_MatchSpec;
+    [Test] procedure IsJsonString_AcceptsStringsOnly;
   end;
 
 implementation
 
 uses
   System.SysUtils,
+  System.JSON,
   MCPServer.Types,
   MCPServer.JsonRpcProcessor;
 
@@ -61,8 +61,8 @@ begin
   Assert.AreEqual('2025-11-25', MCP_LATEST_LEGACY_PROTOCOL_VERSION);
 
   Assert.AreEqual(2, Length(MCP_LEGACY_PROTOCOL_VERSIONS));
-  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_06_18, MCP_LEGACY_PROTOCOL_VERSIONS[0]);
-  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_11_25, MCP_LEGACY_PROTOCOL_VERSIONS[1]);
+  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_11_25, MCP_LEGACY_PROTOCOL_VERSIONS[0]);
+  Assert.AreEqual(MCP_PROTOCOL_VERSION_2025_06_18, MCP_LEGACY_PROTOCOL_VERSIONS[1]);
 
   Assert.AreEqual(1, Length(MCP_MODERN_PROTOCOL_VERSIONS));
   Assert.AreEqual(MCP_LATEST_PROTOCOL_VERSION, MCP_MODERN_PROTOCOL_VERSIONS[0]);
@@ -92,7 +92,20 @@ begin
   Assert.AreEqual('resources/read', MCP_CACHEABLE_METHODS[5]);
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TProtocolConstantsTests);
+procedure TProtocolConstantsTests.IsJsonString_AcceptsStringsOnly;
+begin
+  var Json := TJSONObject.ParseJSONValue('{"s":"text","n":12345,"f":1.5,"b":true,"o":{},"z":null}') as TJSONObject;
+  try
+    Assert.IsTrue(IsJsonString(Json.GetValue('s')));
+    Assert.IsFalse(IsJsonString(Json.GetValue('n')), 'a number is not a string');
+    Assert.IsFalse(IsJsonString(Json.GetValue('f')));
+    Assert.IsFalse(IsJsonString(Json.GetValue('b')));
+    Assert.IsFalse(IsJsonString(Json.GetValue('o')));
+    Assert.IsFalse(IsJsonString(Json.GetValue('z')));
+    Assert.IsFalse(IsJsonString(nil));
+  finally
+    Json.Free;
+  end;
+end;
 
 end.

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -8,12 +8,6 @@ uses
   MCPServer.Tests.Golden;
 
 type
-  /// Pins the legacy (initialize-based) wire behaviour of the JSON-RPC layer.
-  ///
-  /// Every test replays one file from tests\golden\legacy through a fresh
-  /// harness and compares the normalised response with the recorded one.
-  /// A golden file only changes when the wire behaviour changes on purpose;
-  /// such a change belongs in the CHANGELOG.
   [TestFixture]
   TLegacyGoldenTests = class
   private
@@ -25,7 +19,6 @@ type
     [TearDown]
     procedure TearDown;
 
-    // Lifecycle
     [Test] procedure Initialize_2025_06_18;
     [Test] procedure Initialize_2025_11_25;
     [Test] procedure Initialize_2025_03_26;
@@ -34,7 +27,6 @@ type
     [Test] procedure Notifications_Initialized;
     [Test] procedure Ping;
 
-    // Tools
     [Test] procedure Tools_List;
     [Test] procedure Tools_Call_Echo;
     [Test] procedure Tools_Call_Echo_Unicode;
@@ -49,7 +41,6 @@ type
     [Test] procedure Tools_Call_WithoutParams;
     [Test] procedure Tools_Call_EmptyName;
 
-    // Resources
     [Test] procedure Resources_List;
     [Test] procedure Resources_Read_ProjectInfo;
     [Test] procedure Resources_Read_ProjectReadme;
@@ -59,7 +50,6 @@ type
     [Test] procedure Resources_Read_WithoutParams;
     [Test] procedure Resources_Templates_List;
 
-    // Method and message shape
     [Test] procedure UnknownMethod;
     [Test] procedure ServerDiscover_WithoutMeta;
     [Test] procedure ParseError;
@@ -287,8 +277,5 @@ procedure TLegacyGoldenTests.ParamsNotAnObject;
 begin
   CheckGolden('params-not-an-object');
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TLegacyGoldenTests);
 
 end.

--- a/tests/MCPServer.Tests.Golden.Modern.pas
+++ b/tests/MCPServer.Tests.Golden.Modern.pas
@@ -8,8 +8,6 @@ uses
   MCPServer.Tests.Golden;
 
 type
-  /// Pins the wire behaviour for requests that carry per-request _meta
-  /// (MCP 2026-07-28), replayed through the plain JSON-RPC layer.
   [TestFixture]
   TModernGoldenTests = class
   private
@@ -77,7 +75,6 @@ end;
 
 procedure TModernGoldenTests.Server_Discover_AfterInitialize;
 begin
-  // A legacy handshake on the same process must not latch the server.
   FHarness.Process(INITIALIZE_REQUEST);
   CheckGolden('server-discover');
 end;
@@ -156,8 +153,5 @@ procedure TModernGoldenTests.MissingJsonRpcField;
 begin
   CheckGolden('missing-jsonrpc-field');
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TModernGoldenTests);
 
 end.

--- a/tests/MCPServer.Tests.Golden.pas
+++ b/tests/MCPServer.Tests.Golden.pas
@@ -11,12 +11,6 @@ uses
 type
   EGoldenError = class(Exception);
 
-  /// Locates the golden directory and exposes the record switch.
-  ///
-  /// The golden root is the "golden" folder under "tests". It is found by
-  /// walking up from the test executable, or taken from the environment
-  /// variable MCP_GOLDEN_DIR. Setting MCP_GOLDEN_RECORD=1 makes the golden
-  /// tests overwrite the expected sections instead of comparing.
   TGoldenFiles = class
   public
     const RECORD_ENVIRONMENT_VARIABLE = 'MCP_GOLDEN_RECORD';
@@ -31,15 +25,6 @@ type
     class function RecordMode: Boolean;
   end;
 
-  /// Replaces known-volatile values in a parsed JSON response so that two
-  /// runs can be compared byte for byte.
-  ///
-  /// A path is a dotted member path with array indexes, for example
-  /// "result.content[0].text". A pattern may use [*] to match any index.
-  /// Mask paths are replaced by the placeholder string; shape paths are
-  /// replaced by their shape (every leaf becomes its JSON type name, and a
-  /// string that itself contains a JSON document is parsed first). Paths must
-  /// end at an object member.
   TGoldenNormalizer = class
   private
     class function ReplaceIndexes(const Segment: string): string;
@@ -58,15 +43,6 @@ type
     class procedure Normalize(const Root: TJSONValue; const MaskPaths, ShapePaths: TArray<string>);
   end;
 
-  /// One golden case file. Fields:
-  ///   request          JSON value sent as the request body, or
-  ///   requestText      raw request body for non-JSON input
-  ///   mask             optional list of paths replaced by "<masked>"
-  ///   shape            optional list of paths replaced by their shape
-  ///   workingDirectory optional directory (relative to "tests") made
-  ///                    current while the request runs
-  ///   expected         normalised JSON response, or
-  ///   expectedText     raw response when it is empty or not JSON
   TGoldenCase = class
   private
     FFileName: string;
@@ -83,13 +59,8 @@ type
     constructor Create(const AFileName: string);
     destructor Destroy; override;
 
-    /// Applies mask and shape rules to an actual response and returns the
-    /// formatted text used for comparison. Empty or non-JSON responses are
-    /// returned unchanged.
     function NormalizeResponse(const ResponseBody: string): string;
-    /// The recorded expectation in the same formatted form.
     function ExpectedText: string;
-    /// Stores the normalised response as the new expectation and saves the file.
     procedure RecordExpected(const ResponseBody: string);
 
     property FileName: string read FFileName;
@@ -100,8 +71,6 @@ type
 
   TGoldenProcessFunc = reference to function(const RequestBody: string): string;
 
-  /// Replays one golden case through the given processing function and
-  /// compares (or records) the response.
   TGoldenRunner = class
   public
     class procedure Check(const Suite, CaseName: string; const Process: TGoldenProcessFunc);

--- a/tests/MCPServer.Tests.Harness.pas
+++ b/tests/MCPServer.Tests.Harness.pas
@@ -12,10 +12,6 @@ uses
   MCPServer.JsonRpcProcessor;
 
 type
-  /// Builds the same manager registry as MCPServer.dpr (core, tools,
-  /// resources, prompts and completion managers on top of the built-in
-  /// registrations) and drives the transport-independent JSON-RPC processor
-  /// directly.
   TMCPTestHarness = class
   private
     FSettings: TMCPSettings;
@@ -29,8 +25,6 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    /// Sends one JSON-RPC message through the processor and returns the raw
-    /// response body; an empty string means "no response" (notification).
     function Process(const RequestBody: string): string;
 
     property Settings: TMCPSettings read FSettings;
@@ -54,8 +48,6 @@ constructor TMCPTestHarness.Create;
 begin
   inherited Create;
 
-  // Never create a settings.ini next to the test executable; the defaults are
-  // the same values the server writes into a fresh settings.ini.
   FSettings := TMCPSettings.Create('', False);
 
   FManagerRegistry := TMCPManagerRegistry.Create;

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -22,7 +22,6 @@ type
     function Json: TJSONObject;
   end;
 
-  /// The Streamable HTTP transport, in-process on an ephemeral port.
   [TestFixture]
   THttpTransportTests = class
   private
@@ -435,7 +434,6 @@ begin
   StartServer;
   var Addresses := FServer.BoundAddresses;
   Assert.IsTrue(Length(Addresses) >= 1);
-  // Indy reports the IPv6 loopback in its expanded form.
   for var Address in Addresses do
     Assert.IsTrue(Address.StartsWith('127.0.0.1:') or Address.StartsWith('[::1]:')
       or Address.StartsWith('[0:0:0:0:0:0:0:1]:'), Address);
@@ -465,8 +463,5 @@ begin
   end;
   Assert.AreEqual(404, Send('GET', '/nothing', '', []).Status);
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(THttpTransportTests);
 
 end.

--- a/tests/MCPServer.Tests.HttpHeaders.pas
+++ b/tests/MCPServer.Tests.HttpHeaders.pas
@@ -6,8 +6,6 @@ uses
   DUnitX.TestFramework;
 
 type
-  /// Header value decoding (Base64 sentinel), Accept parsing, Origin policy
-  /// and the JSON depth scanner.
   [TestFixture]
   THttpHeadersTests = class
   public
@@ -24,6 +22,7 @@ type
     [Test] procedure Origin_AbsentAllowed_NullDenied;
     [Test] procedure Origin_AllowListMatchesSchemeHostAndPort;
     [Test] procedure Origin_PortWildcardAndAllowAll;
+    [Test] procedure Origin_DefaultPortEqualsExplicitPort;
     [Test] procedure NestingDepth_CountsObjectsAndArraysOutsideStrings;
   end;
 
@@ -146,6 +145,15 @@ begin
   Assert.IsFalse(TMCPOriginPolicy.IsAllowed('null', ['*']));
 end;
 
+procedure THttpHeadersTests.Origin_DefaultPortEqualsExplicitPort;
+begin
+  Assert.IsTrue(TMCPOriginPolicy.IsAllowed('https://app.example:443', ['https://app.example']));
+  Assert.IsTrue(TMCPOriginPolicy.IsAllowed('https://app.example', ['https://app.example:443']));
+  Assert.IsTrue(TMCPOriginPolicy.IsAllowed('http://app.example:80', ['http://app.example']));
+  Assert.IsFalse(TMCPOriginPolicy.IsAllowed('http://app.example:8080', ['http://app.example']));
+  Assert.IsFalse(TMCPOriginPolicy.IsAllowed('http://app.example:443', ['https://app.example']));
+end;
+
 procedure THttpHeadersTests.NestingDepth_CountsObjectsAndArraysOutsideStrings;
 begin
   Assert.AreEqual(0, TMCPJsonLimits.NestingDepth('"scalar"'));
@@ -154,8 +162,5 @@ begin
   Assert.AreEqual(1, TMCPJsonLimits.NestingDepth('{"a":"[[[{{{"}'));
   Assert.AreEqual(2, TMCPJsonLimits.NestingDepth('{"a":"\"[","b":[1]}'));
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(THttpHeadersTests);
 
 end.

--- a/tests/MCPServer.Tests.Logger.pas
+++ b/tests/MCPServer.Tests.Logger.pas
@@ -6,8 +6,6 @@ uses
   DUnitX.TestFramework;
 
 type
-  /// The stdout guard: while a stdio transport runs, console logging must
-  /// never reach stdout, whatever a consumer sets on TLogger.
   [TestFixture]
   TLoggerStdoutGuardTests = class
   private
@@ -108,8 +106,5 @@ begin
     Harness.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TLoggerStdoutGuardTests);
 
 end.

--- a/tests/MCPServer.Tests.Processor.pas
+++ b/tests/MCPServer.Tests.Processor.pas
@@ -14,7 +14,6 @@ uses
   MCPServer.Tests.Harness;
 
 type
-  /// A manager that records the context it was called with.
   TProbeManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx)
   public
     SeenContext: IMCPRequestContext;
@@ -26,7 +25,6 @@ type
       const Context: IMCPRequestContext): TValue;
   end;
 
-  /// Status policy, result envelope and dispatch through ProcessRequestEx.
   [TestFixture]
   TProcessorTests = class
   private
@@ -102,7 +100,6 @@ end;
 procedure TProcessorTests.Setup;
 begin
   FHarness := TMCPTestHarness.Create;
-  // One settings instance for the managers and the processor.
   FSettings := FHarness.Settings;
   FProcessor := TMCPJsonRpcProcessor.Create(FHarness.ManagerRegistry, FSettings);
 end;
@@ -165,7 +162,6 @@ end;
 
 procedure TProcessorTests.Modern_ApplicationInvalidParams_Is200;
 begin
-  // An error a manager raises without an explicit status stays application level.
   var Probe := TProbeManager.Create;
   var Registry: IMCPManagerRegistry := TMCPManagerRegistry.Create;
   Registry.RegisterManager(Probe);
@@ -362,8 +358,5 @@ begin
 
   Assert.AreEqual(0, Failures);
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TProcessorTests);
 
 end.

--- a/tests/MCPServer.Tests.Prompt.pas
+++ b/tests/MCPServer.Tests.Prompt.pas
@@ -202,8 +202,4 @@ begin
   end;
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TPromptMessagesTests);
-  TDUnitX.RegisterTestFixture(TPromptBaseTests);
-
 end.

--- a/tests/MCPServer.Tests.PromptsManager.pas
+++ b/tests/MCPServer.Tests.PromptsManager.pas
@@ -210,7 +210,4 @@ begin
   end;
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TPromptsManagerTests);
-
 end.

--- a/tests/MCPServer.Tests.Registration.pas
+++ b/tests/MCPServer.Tests.Registration.pas
@@ -6,8 +6,6 @@ uses
   DUnitX.TestFramework;
 
 type
-  /// TMCPRegistry is filled from unit initialization sections; these tests
-  /// only read it so the golden tests keep seeing the shipped registry.
   [TestFixture]
   TRegistryTests = class
   public
@@ -67,7 +65,6 @@ end;
 
 procedure TRegistryTests.ServerStatus_IsRegisteredByDefault;
 begin
-  // Registered by the initialization section of MCPServer.Resource.Server.
   var Status := TMCPRegistry.CreateResource('server://status');
   Assert.AreEqual('server://status', Status.URI);
   Assert.AreEqual('server_status', Status.Name);
@@ -101,8 +98,5 @@ begin
   Assert.AreEqual('echo', First.Name);
   Assert.AreNotSame(First, Second);
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TRegistryTests);
 
 end.

--- a/tests/MCPServer.Tests.RequestContext.pas
+++ b/tests/MCPServer.Tests.RequestContext.pas
@@ -13,7 +13,6 @@ uses
   MCPServer.Tests.Harness;
 
 type
-  /// Era detection, one branch per test, straight against BuildRequestContext.
   [TestFixture]
   TRequestContextTests = class
   private
@@ -125,8 +124,6 @@ end;
 
 procedure TRequestContextTests.Initialize_WithModernMeta_IsNotFound;
 begin
-  // A modern client probing with initialize must learn that the method does
-  // not exist in its era; only an initialize without modern _meta is legacy.
   ExpectError(Request('initialize', '{"protocolVersion":"2025-11-25",' + META_MODERN + '}'), TMCPTransportHints.None,
     JSONRPC_METHOD_NOT_FOUND, 404, 'initialize is legacy-only');
 
@@ -180,7 +177,6 @@ begin
   var Context := Build(Request('tools/list', '{' + META_MODERN + '}'), Hints);
   Assert.AreEqual(TMCPProtocolEra.Modern, Context.Era);
 
-  // The mirrored method header is compared case-sensitively.
   Hints.MethodHeader := 'TOOLS/LIST';
   ExpectError(Request('tools/list', '{' + META_MODERN + '}'), Hints,
     MCP_ERROR_HEADER_MISMATCH, 400, 'Mcp-Method differs from the body');
@@ -203,7 +199,6 @@ begin
   Hints.NameHeader := 'file:///cafe.txt';
   ExpectError(Body, Hints, MCP_ERROR_HEADER_MISMATCH, 400, 'Mcp-Name differs from params.uri');
 
-  // "file:///café.txt" as UTF-8 in the Base64 sentinel form.
   Hints.NameHeader := '=?base64?ZmlsZTovLy9jYWbDqS50eHQ=?=';
   var Context := Build(Body, Hints);
   Assert.AreEqual(TMCPProtocolEra.Modern, Context.Era);
@@ -364,8 +359,5 @@ begin
     end;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TRequestContextTests);
 
 end.

--- a/tests/MCPServer.Tests.ResourcesManager.pas
+++ b/tests/MCPServer.Tests.ResourcesManager.pas
@@ -13,7 +13,6 @@ type
   TFailingData = class
   end;
 
-  /// A resource whose read raises.
   TFailingResource = class(TMCPResourceBase<TFailingData>)
   protected
     function GetResourceData: TFailingData; override;
@@ -28,7 +27,6 @@ type
     property Value: string read FValue write FValue;
   end;
 
-  /// A resource matched by TEchoTemplate; echoes the captured variable.
   TEchoResource = class(TMCPResourceBase<TEchoTemplateData>)
   private
     FValue: string;
@@ -38,8 +36,6 @@ type
     constructor CreateForValue(const AUri, AValue: string);
   end;
 
-  /// echo://{value}, used to test template matching independent of the
-  /// server's own logs://{level} template.
   TEchoTemplate = class(TMCPResourceTemplateBase)
   public
     constructor Create; override;
@@ -70,12 +66,15 @@ type
     [Test] procedure Templates_Cursor_IsInvalidParams;
     [Test] procedure Read_ViaTemplate_ResolvesWithActualUri;
     [Test] procedure Read_TemplateMismatch_IsNotFound;
+    [Test] procedure Read_ViaTemplate_PercentDecodes_KeepsPlusLiteral;
+    [Test] procedure Read_ViaTemplate_ConcurrentReads_Succeed;
   end;
 
 implementation
 
 uses
   System.SysUtils,
+  System.Threading,
   System.Generics.Collections,
   MCPServer.Errors;
 
@@ -330,6 +329,32 @@ begin
   end;
 end;
 
+procedure TResourcesManagerTests.Read_ViaTemplate_PercentDecodes_KeepsPlusLiteral;
+begin
+  var Json := Read('echo://a%20b+c%2Fd', TMCPProtocolEra.Modern);
+  try
+    Assert.AreEqual('{"value":"a b+c/d"}', Json.GetValue<string>('contents[0].text'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TResourcesManagerTests.Read_ViaTemplate_ConcurrentReads_Succeed;
+const
+  READS = 400;
+begin
+  TParallel.For(1, READS,
+    procedure(Index: Integer)
+    begin
+      var Json := Read(Format('echo://item%d', [Index]), TMCPProtocolEra.Modern);
+      try
+        Assert.AreEqual(Format('{"value":"item%d"}', [Index]), Json.GetValue<string>('contents[0].text'));
+      finally
+        Json.Free;
+      end;
+    end);
+end;
+
 procedure TResourcesManagerTests.Read_TemplateMismatch_IsNotFound;
 begin
   try
@@ -340,8 +365,5 @@ begin
       Assert.AreEqual(JSONRPC_INVALID_PARAMS, E.Code);
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TResourcesManagerTests);
 
 end.

--- a/tests/MCPServer.Tests.Schema.pas
+++ b/tests/MCPServer.Tests.Schema.pas
@@ -270,7 +270,4 @@ begin
   end;
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TSchemaGeneratorTests);
-
 end.

--- a/tests/MCPServer.Tests.SchemaValidator.pas
+++ b/tests/MCPServer.Tests.SchemaValidator.pas
@@ -294,7 +294,4 @@ begin
   end;
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TSchemaValidatorTests);
-
 end.

--- a/tests/MCPServer.Tests.Serializer.pas
+++ b/tests/MCPServer.Tests.Serializer.pas
@@ -256,7 +256,4 @@ begin
   end;
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TSerializerTests);
-
 end.

--- a/tests/MCPServer.Tests.ServerStatus.pas
+++ b/tests/MCPServer.Tests.ServerStatus.pas
@@ -6,8 +6,6 @@ uses
   DUnitX.TestFramework;
 
 type
-  /// The counters behind server://status are updated from every Indy
-  /// connection thread; these tests guard the atomic implementation.
   [TestFixture]
   TServerStatusResourceTests = class
   private
@@ -122,8 +120,5 @@ begin
     Status.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TServerStatusResourceTests);
 
 end.

--- a/tests/MCPServer.Tests.Stdio.pas
+++ b/tests/MCPServer.Tests.Stdio.pas
@@ -12,8 +12,6 @@ uses
   MCPServer.Tests.Harness;
 
 type
-  /// Drives TMCPStdioTransport.RunWith over in-memory streams: the bytes a
-  /// client would write to stdin in, the bytes it would read from stdout out.
   [TestFixture]
   TStdioTransportTests = class
   private
@@ -175,8 +173,6 @@ procedure TStdioTransportTests.DuplicateId_WhileInFlight_IsInvalidRequest;
 begin
   var Slow := '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"test_tool_with_progress","arguments":{"steps":4,"stepMs":100}}}';
   var Lines := Run([Slow, '{"jsonrpc":"2.0","id":7,"method":"ping"}']);
-  // ping is answered inline and is never a duplicate; the second queued
-  // request with the same id is.
   Lines := Run([Slow, Slow]);
   Assert.AreEqual(2, Integer(Length(Lines)));
   var First := ParseLine(Lines[0]);
@@ -261,8 +257,5 @@ begin
   Assert.AreEqual(0, Integer(Length(Lines)), 'the request was cancelled at shutdown and got no response');
   Assert.IsTrue(FElapsedMs < 3000, 'Run returned after the drain timeout: ' + FElapsedMs.ToString + ' ms');
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TStdioTransportTests);
 
 end.

--- a/tests/MCPServer.Tests.StdioChannel.pas
+++ b/tests/MCPServer.Tests.StdioChannel.pas
@@ -20,6 +20,8 @@ type
     [Test] procedure Reader_DecodesUtf8;
     [Test] procedure Reader_ReportsOverlongLine_AndContinues;
     [Test] procedure Reader_ReportsInvalidUtf8_AndContinues;
+    [Test] procedure Reader_OverlongLineWithoutNewline_EndsStream;
+    [Test] procedure Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
     [Test] procedure Reader_EmptyStream_HasNoLines;
     [Test] procedure Writer_OneLinePerMessage_Utf8_NoBom;
     [Test] procedure Writer_ReplacesEmbeddedNewlines;
@@ -102,6 +104,33 @@ begin
   Assert.AreEqual('short', Lines[1]);
 end;
 
+procedure TStdioChannelTests.Reader_OverlongLineWithoutNewline_EndsStream;
+var
+  Statuses: TArray<TMCPLineStatus>;
+begin
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(StringOfChar('x', 100)), 50, Statuses);
+  Assert.AreEqual(1, Integer(Length(Lines)));
+  Assert.IsTrue(Statuses[0] = TMCPLineStatus.TooLong);
+  Assert.AreEqual('', Lines[0]);
+end;
+
+procedure TStdioChannelTests.Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
+const
+  BEYOND_ONE_CHUNK = 70 * 1024;
+  LIMIT = 1024;
+var
+  Statuses: TArray<TMCPLineStatus>;
+begin
+  var Long := StringOfChar('y', BEYOND_ONE_CHUNK);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Long + #10'after'#10'last'), LIMIT, Statuses);
+  Assert.AreEqual(3, Integer(Length(Lines)));
+  Assert.IsTrue(Statuses[0] = TMCPLineStatus.TooLong);
+  Assert.IsTrue(Statuses[1] = TMCPLineStatus.Ok);
+  Assert.AreEqual('after', Lines[1]);
+  Assert.IsTrue(Statuses[2] = TMCPLineStatus.Ok);
+  Assert.AreEqual('last', Lines[2]);
+end;
+
 procedure TStdioChannelTests.Reader_ReportsInvalidUtf8_AndContinues;
 var
   Statuses: TArray<TMCPLineStatus>;
@@ -131,7 +160,7 @@ begin
 
     var Bytes: TBytes;
     SetLength(Bytes, Stream.Size);
-    Move(Stream.Memory^, Bytes[0], Stream.Size);
+    Move(Stream.Memory^, Bytes[0], Length(Bytes));
     Assert.AreEqual($7B, Integer(Bytes[0]), 'no byte-order mark');
     var Text := TEncoding.UTF8.GetString(Bytes);
     Assert.AreEqual('{"a":"' + Char($00E9) + '"}'#10'{"b":2}'#10, Text);
@@ -149,7 +178,7 @@ begin
     SinkIntf.Send('a'#13#10'b');
     var Bytes: TBytes;
     SetLength(Bytes, Stream.Size);
-    Move(Stream.Memory^, Bytes[0], Stream.Size);
+    Move(Stream.Memory^, Bytes[0], Length(Bytes));
     Assert.AreEqual('a  b'#10, TEncoding.UTF8.GetString(Bytes));
   finally
     Stream.Free;
@@ -183,7 +212,7 @@ begin
 
     var Bytes: TBytes;
     SetLength(Bytes, Stream.Size);
-    Move(Stream.Memory^, Bytes[0], Stream.Size);
+    Move(Stream.Memory^, Bytes[0], Length(Bytes));
     var Lines := TEncoding.UTF8.GetString(Bytes).Split([#10]);
     var Count := 0;
     for var Line in Lines do
@@ -200,8 +229,5 @@ begin
     Stream.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TStdioChannelTests);
 
 end.

--- a/tests/MCPServer.Tests.ToolResult.pas
+++ b/tests/MCPServer.Tests.ToolResult.pas
@@ -152,7 +152,4 @@ begin
   Assert.IsFalse(Encoded.Contains(#13) or Encoded.Contains(#10));
 end;
 
-initialization
-  TDUnitX.RegisterTestFixture(TToolResultTests);
-
 end.

--- a/tests/MCPServer.Tests.ToolsManager.pas
+++ b/tests/MCPServer.Tests.ToolsManager.pas
@@ -25,7 +25,6 @@ type
     property Doubled: Integer read FDoubled write FDoubled;
   end;
 
-  /// A typed tool: structured content plus the text fallback.
   TDoublingTool = class(TMCPToolBase<TStructuredParams, TStructuredOutput>)
   protected
     function ExecuteWithParams(const Params: TStructuredParams): TStructuredOutput; override;
@@ -33,8 +32,6 @@ type
     constructor Create; override;
   end;
 
-  /// A hand-written schema, to exercise TMCPToolBase's own validation
-  /// (nothing goes through TMCPSerializer for this tool).
   THandWrittenTool = class(TMCPToolBase)
   protected
     function BuildSchema: TJSONObject; override;
@@ -331,8 +328,5 @@ begin
     Json.Free;
   end;
 end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TToolsManagerTests);
 
 end.


### PR DESCRIPTION
## Summary

- Resource templates match thread-safely and percent-decode template variables without turning `+` into a space.
- The stdio transport no longer frees shared objects under a worker thread that outlived the drain timeout; overlong stdin lines are discarded chunk by chunk.
- `TMCPLegacySession` is lock-guarded; origin allow-list entries match with or without the default port; JSON string fields reject numbers (`IsJsonString`).
- `completion/complete` answers `-32002` to legacy clients for an unknown resource; the `/info` endpoint derives its version list from the supported versions; leaks in tool result serialisation and the DEBUG output-schema check are closed.
- Sources carry no comments and test fixtures are discovered through RTTI. `coding-rules.md` records the conventions this library keeps on purpose.

## Verification

- DUnitX: 300/300 on Win64 and Win32, no leaks, zero hints and warnings.
- Linux64 build, HTTP goldens, stdio smoke, conformance 2026-07-28 and 2025-11-25 (baselines unchanged), Inspector smoke over all four server modes.