### PR TITLE
Bearer authentication for the HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   request's own stream, only when the request carries
   `_meta.io.modelcontextprotocol/logLevel` and the level is at or above it;
   `TMCPLogLevel` and `MCP_LOG_LEVELS` in `MCPServer.Types`.
+- Authentication (`MCPServer.Authorization`): `IMCPAuthorizer` on
+  `TMCPIdHTTPServer.Authorizer`, `TMCPStaticBearerAuthorizer` (constant-time
+  comparison), the abstract `TMCPOAuthResourceServerAuthorizer` (mandatory
+  audience and expiry checks, `RequiredScopes`) and
+  `TMCPIntrospectionAuthorizer` (RFC 7662). `401`/`403`/`400` with
+  `WWW-Authenticate: Bearer` challenges (`resource_metadata`, `error`,
+  `scope`), the RFC 9728 protected resource metadata document at
+  `/.well-known/oauth-protected-resource[<Endpoint>]`, `[RequiresScope]` on
+  tool classes, `Principal`, `Scopes` and `HasScope` on the request context,
+  and `[Auth] BearerTokens`, `AuthorizationServers`, `ResourceUri` and
+  `ScopesSupported` in `settings.ini`. The stdio transport never
+  authenticates.
 - `subscriptions/listen` (`MCPServer.SubscriptionsManager`): long-lived
   change notification streams with the acknowledgement first, the honoured
   filter, `_meta.io.modelcontextprotocol/subscriptionId` on every message,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -162,6 +162,25 @@ at startup. `RequestStateTtlSeconds` bounds the replay window (600 s).
 nine new example tools plus one example prompt ship with the executable;
 they are only registered when their units are in the project.
 
+## Authentication
+
+**Opt-in, and only over HTTP.** Nothing changes until `[Auth] BearerTokens`
+is set or a library assigns `TMCPIdHTTPServer.Authorizer`. From then on every
+request to the endpoint needs `Authorization: Bearer <token>`; `OPTIONS` and
+`GET /.well-known/oauth-protected-resource[<Endpoint>]` stay open. Legacy and
+modern clients get the same `401`/`403`/`400` answers with a
+`WWW-Authenticate: Bearer` challenge and an id-less JSON-RPC error body.
+
+**`[RequiresScope]` tools answer `403` without the scope**, also to legacy
+clients (their JSON-RPC errors otherwise travel in `200`). The response carries
+`WWW-Authenticate: Bearer error="insufficient_scope", scope="..."` and
+`error.data.requiredScope`.
+
+**`TMCPRequestContext.Create` and `TMCPTransportHints` gained `Principal` and
+`Scopes`.** The request state sealer binds `requestState` tokens to the
+principal now, so a token obtained by one authenticated caller is rejected
+when another caller presents it.
+
 ## Subscriptions
 
 **`subscriptions/listen` replaces `resources/subscribe` and the GET stream.**

--- a/README.md
+++ b/README.md
@@ -802,6 +802,54 @@ The server provides six resources and two resource templates, accessible via URI
 
 The server supports configuration through `settings.ini` files. A default `settings.ini.example` is provided in the repository.
 
+### Authentication
+
+The HTTP endpoint is open by default, which is fine for a loopback-only
+server. A server that other machines can reach should require a token:
+
+- `[Auth] BearerTokens`: comma-separated pre-shared tokens. With this set the
+  executable installs `TMCPStaticBearerAuthorizer`; every request except
+  `OPTIONS` and the protected resource metadata must carry
+  `Authorization: Bearer <token>`. A missing token is `401` with a
+  `WWW-Authenticate: Bearer` challenge, an unknown token `401` with
+  `error="invalid_token"`, another scheme `400` with `error="invalid_request"`.
+  Tokens are compared in constant time and never logged.
+- `[Auth] AuthorizationServers`: issuer URLs of the OAuth 2.1 authorization
+  servers, published in `GET /.well-known/oauth-protected-resource` and
+  `/.well-known/oauth-protected-resource<Endpoint>` (RFC 9728) and referenced
+  by the `resource_metadata` parameter of every challenge, so clients can
+  discover where to obtain a token. `ResourceUri` is the canonical URI of this
+  server that the tokens must name as their audience (default
+  `<Protocol>://<Host>:<Port><Endpoint>`); `ScopesSupported` lists the scopes
+  clients may request (`offline_access` is never advertised).
+
+A library that hosts `TMCPIdHTTPServer` assigns its own `Authorizer`
+(`MCPServer.Authorization`):
+
+- `TMCPStaticBearerAuthorizer.Create(Tokens, Scopes)`: the pre-shared tokens,
+  optionally limited to a set of scopes (all scopes by default).
+- `TMCPOAuthResourceServerAuthorizer`: the base for token validation against
+  an authorization server. Override `ValidateToken(Token, out Claims)`; the
+  base class then requires the `aud` claim to name `ExpectedAudience`, the
+  `exp` claim to lie in the future, and the `RequiredScopes` to be present in
+  `scope` or `scp`, answering `401 invalid_token` or `403 insufficient_scope`
+  otherwise. `TMCPIntrospectionAuthorizer` implements `ValidateToken` with an
+  RFC 7662 token introspection request (client credentials over HTTP basic
+  authentication). Signed-JWT validation is not built in: the RTL has no JOSE
+  library, so a deployment that validates JWTs locally supplies its own
+  `ValidateToken` on top of its JWT library of choice.
+- `[RequiresScope('name')]` on a tool class makes `tools/call` answer `403`
+  with `WWW-Authenticate: Bearer error="insufficient_scope", scope="name"`
+  unless the caller's token grants that scope. On an open server, and over
+  stdio, nobody holds a scope, so such a tool is unusable there.
+
+Tools see the authenticated caller as `Context.Principal` and
+`Context.HasScope`. The inbound token is bound to this server: a tool that
+calls an upstream API must obtain its own credentials and must never forward
+the `Authorization` header it was called with. Authentication is an HTTP
+concern; the stdio transport trusts the process that spawned it and never
+consults an authorizer.
+
 ### Network and Security
 
 - `[Server] BindAddress`: the interface to listen on. Empty (default) derives it from `Host`: a loopback `Host` binds `127.0.0.1` and `::1`, any other `Host` binds every interface. Set `0.0.0.0` to listen everywhere explicitly.

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -42,6 +42,22 @@ RequestStateKey=
 ; Seconds a requestState token stays valid
 RequestStateTtlSeconds=600
 
+[Auth]
+; Pre-shared bearer tokens for the HTTP endpoint, comma-separated. Empty = no
+; authentication (the default for a loopback-only server). With tokens set,
+; every request except OPTIONS and the protected resource metadata must carry
+; "Authorization: Bearer <token>"; otherwise it gets 401.
+BearerTokens=
+; OAuth 2.1 authorization server issuer URLs, comma-separated, published in
+; /.well-known/oauth-protected-resource so clients can discover where to get a
+; token. Leave empty for pre-shared tokens only.
+AuthorizationServers=
+; Canonical URI of this server as bound into token audiences (RFC 8707).
+; Empty = <Protocol>://<Host>:<Port><Endpoint>
+ResourceUri=
+; Scopes clients may ask for, comma-separated, published in the metadata
+ScopesSupported=
+
 [Protocol]
 ; Boolean values: use 1 (true) or 0 (false)
 ; Answer ping for MCP 2026-07-28 requests although that revision removed it

--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -1,0 +1,440 @@
+unit MCPServer.Authorization;
+
+interface
+
+uses
+  System.SysUtils,
+  System.JSON,
+  MCPServer.Types;
+
+type
+  TMCPAuthDecision = (Allow, Unauthorized, Forbidden, BadRequest);
+
+  TMCPPrincipal = record
+    Subject: string;
+    Scopes: TArray<string>;
+    function HasScope(const Scope: string): Boolean;
+    class function None: TMCPPrincipal; static;
+  end;
+
+  TMCPAuthChallenge = record
+    Error: string;
+    ErrorDescription: string;
+    Scope: string;
+    class function None: TMCPAuthChallenge; static;
+    class function InvalidToken(const Description: string): TMCPAuthChallenge; static;
+    class function InvalidRequest(const Description: string): TMCPAuthChallenge; static;
+    class function InsufficientScope(const Scope: string): TMCPAuthChallenge; static;
+  end;
+
+  IMCPAuthorizer = interface
+    ['{7B3D5F1A-9C2E-4A8B-B6D0-1E3F5A7C9B2D}']
+    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
+      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+  end;
+
+  RequiresScopeAttribute = class(TCustomAttribute)
+  private
+    FScope: string;
+  public
+    constructor Create(const AScope: string);
+    property Scope: string read FScope;
+  end;
+
+  TMCPBearerChallenge = record
+    const SCHEME = 'Bearer';
+    const ERROR_INVALID_TOKEN = 'invalid_token';
+    const ERROR_INVALID_REQUEST = 'invalid_request';
+    const ERROR_INSUFFICIENT_SCOPE = 'insufficient_scope';
+    class function Build(const ResourceMetadataUrl: string; const Challenge: TMCPAuthChallenge): string; static;
+    class function Quote(const Value: string): string; static;
+  end;
+
+  TMCPProtectedResourceMetadata = record
+    const WELL_KNOWN_PATH = '/.well-known/oauth-protected-resource';
+    class function Build(const ResourceUri, ResourceName: string;
+      const AuthorizationServers, ScopesSupported: TArray<string>): TJSONObject; static;
+    class function WithoutOfflineAccess(const Scopes: TArray<string>): TArray<string>; static;
+  end;
+
+  TMCPStaticBearerAuthorizer = class(TInterfacedObject, IMCPAuthorizer)
+  strict private
+    FTokens: TArray<TBytes>;
+    FScopes: TArray<string>;
+  public
+    constructor Create(const Tokens: TArray<string>; const Scopes: TArray<string> = nil);
+    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
+      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    class function SameToken(const Presented, Expected: TBytes): Boolean; static;
+  end;
+
+  TMCPOAuthResourceServerAuthorizer = class abstract(TInterfacedObject, IMCPAuthorizer)
+  strict private
+    FExpectedAudience: string;
+    FRequiredScopes: TArray<string>;
+  protected
+    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; virtual; abstract;
+    function AudienceMatches(const Claims: TJSONObject): Boolean; virtual;
+    function IsExpired(const Claims: TJSONObject): Boolean; virtual;
+    function ScopesOf(const Claims: TJSONObject): TArray<string>; virtual;
+  public
+    constructor Create(const ExpectedAudience: string);
+    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
+      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    property ExpectedAudience: string read FExpectedAudience;
+    property RequiredScopes: TArray<string> read FRequiredScopes write FRequiredScopes;
+  end;
+
+  TMCPIntrospectionAuthorizer = class(TMCPOAuthResourceServerAuthorizer)
+  strict private
+    FIntrospectionUrl: string;
+    FClientId: string;
+    FClientSecret: string;
+    FTimeoutMs: Integer;
+  protected
+    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
+  public
+    const DEFAULT_TIMEOUT_MS = 5000;
+    constructor Create(const ExpectedAudience, IntrospectionUrl, ClientId, ClientSecret: string);
+    property IntrospectionUrl: string read FIntrospectionUrl;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs;
+  end;
+
+  EMCPAuthorizationConfiguration = class(Exception)
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  System.DateUtils,
+  System.NetEncoding,
+  System.Net.HttpClient,
+  System.Net.URLClient,
+  System.NetConsts,
+  MCPServer.Logger;
+
+const
+  CLAIM_SUBJECT = 'sub';
+  CLAIM_AUDIENCE = 'aud';
+  CLAIM_EXPIRY = 'exp';
+  CLAIM_SCOPE = 'scope';
+  CLAIM_SCOPE_ARRAY = 'scp';
+  CLAIM_ACTIVE = 'active';
+  SCOPE_ANY = '*';
+  SCOPE_OFFLINE_ACCESS = 'offline_access';
+  SCOPE_SEPARATOR = ' ';
+  STATIC_SUBJECT_FORMAT = 'token-%d';
+  MEDIA_TYPE_FORM = 'application/x-www-form-urlencoded';
+
+{ TMCPPrincipal }
+
+class function TMCPPrincipal.None: TMCPPrincipal;
+begin
+  Result := Default(TMCPPrincipal);
+end;
+
+function TMCPPrincipal.HasScope(const Scope: string): Boolean;
+begin
+  for var Granted in Scopes do
+  begin
+    if (Granted = Scope) or (Granted = SCOPE_ANY) then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
+{ TMCPAuthChallenge }
+
+class function TMCPAuthChallenge.None: TMCPAuthChallenge;
+begin
+  Result := Default(TMCPAuthChallenge);
+end;
+
+class function TMCPAuthChallenge.InvalidToken(const Description: string): TMCPAuthChallenge;
+begin
+  Result := Default(TMCPAuthChallenge);
+  Result.Error := TMCPBearerChallenge.ERROR_INVALID_TOKEN;
+  Result.ErrorDescription := Description;
+end;
+
+class function TMCPAuthChallenge.InvalidRequest(const Description: string): TMCPAuthChallenge;
+begin
+  Result := Default(TMCPAuthChallenge);
+  Result.Error := TMCPBearerChallenge.ERROR_INVALID_REQUEST;
+  Result.ErrorDescription := Description;
+end;
+
+class function TMCPAuthChallenge.InsufficientScope(const Scope: string): TMCPAuthChallenge;
+begin
+  Result := Default(TMCPAuthChallenge);
+  Result.Error := TMCPBearerChallenge.ERROR_INSUFFICIENT_SCOPE;
+  Result.Scope := Scope;
+end;
+
+{ RequiresScopeAttribute }
+
+constructor RequiresScopeAttribute.Create(const AScope: string);
+begin
+  inherited Create;
+  FScope := AScope;
+end;
+
+{ TMCPBearerChallenge }
+
+class function TMCPBearerChallenge.Quote(const Value: string): string;
+begin
+  var Clean := Value.Replace(#13, ' ').Replace(#10, ' ');
+  Result := '"' + Clean.Replace('\', '\\').Replace('"', '\"') + '"';
+end;
+
+class function TMCPBearerChallenge.Build(const ResourceMetadataUrl: string; const Challenge: TMCPAuthChallenge): string;
+begin
+  var Parameters: TArray<string> := nil;
+  if ResourceMetadataUrl <> '' then
+    Parameters := Parameters + ['resource_metadata=' + Quote(ResourceMetadataUrl)];
+  if Challenge.Error <> '' then
+    Parameters := Parameters + ['error=' + Quote(Challenge.Error)];
+  if Challenge.ErrorDescription <> '' then
+    Parameters := Parameters + ['error_description=' + Quote(Challenge.ErrorDescription)];
+  if Challenge.Scope <> '' then
+    Parameters := Parameters + ['scope=' + Quote(Challenge.Scope)];
+
+  Result := SCHEME;
+  if Length(Parameters) > 0 then
+    Result := Result + ' ' + string.Join(', ', Parameters);
+end;
+
+{ TMCPProtectedResourceMetadata }
+
+class function TMCPProtectedResourceMetadata.WithoutOfflineAccess(const Scopes: TArray<string>): TArray<string>;
+begin
+  Result := nil;
+  for var Scope in Scopes do
+  begin
+    if Scope = SCOPE_OFFLINE_ACCESS then
+      TLogger.Warning('offline_access is not advertised: refresh tokens are not a resource requirement')
+    else if Scope <> '' then
+      Result := Result + [Scope];
+  end;
+end;
+
+class function TMCPProtectedResourceMetadata.Build(const ResourceUri, ResourceName: string;
+  const AuthorizationServers, ScopesSupported: TArray<string>): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  Result.AddPair('resource', ResourceUri);
+  var Servers := TJSONArray.Create;
+  Result.AddPair('authorization_servers', Servers);
+  for var Server in AuthorizationServers do
+  begin
+    Servers.Add(Server);
+  end;
+  var Scopes := WithoutOfflineAccess(ScopesSupported);
+  if Length(Scopes) > 0 then
+  begin
+    var ScopesArray := TJSONArray.Create;
+    Result.AddPair('scopes_supported', ScopesArray);
+    for var Scope in Scopes do
+    begin
+      ScopesArray.Add(Scope);
+    end;
+  end;
+  var Methods := TJSONArray.Create;
+  Methods.Add('header');
+  Result.AddPair('bearer_methods_supported', Methods);
+  if ResourceName <> '' then
+    Result.AddPair('resource_name', ResourceName);
+end;
+
+{ TMCPStaticBearerAuthorizer }
+
+constructor TMCPStaticBearerAuthorizer.Create(const Tokens: TArray<string>; const Scopes: TArray<string>);
+begin
+  inherited Create;
+  for var Token in Tokens do
+  begin
+    if Token.Trim <> '' then
+      FTokens := FTokens + [TEncoding.UTF8.GetBytes(Token.Trim)];
+  end;
+  if Length(FTokens) = 0 then
+    raise EMCPAuthorizationConfiguration.Create('A static bearer authorizer needs at least one token');
+  FScopes := Scopes;
+  if Length(FScopes) = 0 then
+    FScopes := [SCOPE_ANY];
+end;
+
+class function TMCPStaticBearerAuthorizer.SameToken(const Presented, Expected: TBytes): Boolean;
+begin
+  Result := TMCPConstantTime.SameBytes(Presented, Expected);
+end;
+
+function TMCPStaticBearerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string;
+  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+begin
+  Principal := TMCPPrincipal.None;
+  Challenge := TMCPAuthChallenge.None;
+  var Presented := TEncoding.UTF8.GetBytes(BearerToken);
+  var Matched: Integer := -1;
+  for var I := 0 to High(FTokens) do
+  begin
+    if SameToken(Presented, FTokens[I]) then
+      Matched := Integer(I);
+  end;
+
+  if Matched < 0 then
+  begin
+    Challenge := TMCPAuthChallenge.InvalidToken('The bearer token is not recognised');
+    Exit(TMCPAuthDecision.Unauthorized);
+  end;
+  Principal.Subject := Format(STATIC_SUBJECT_FORMAT, [Matched + 1]);
+  Principal.Scopes := FScopes;
+  Result := TMCPAuthDecision.Allow;
+end;
+
+{ TMCPOAuthResourceServerAuthorizer }
+
+constructor TMCPOAuthResourceServerAuthorizer.Create(const ExpectedAudience: string);
+begin
+  inherited Create;
+  if ExpectedAudience.Trim = '' then
+    raise EMCPAuthorizationConfiguration.Create('An OAuth resource server authorizer needs the expected audience');
+  FExpectedAudience := ExpectedAudience.Trim;
+end;
+
+function TMCPOAuthResourceServerAuthorizer.AudienceMatches(const Claims: TJSONObject): Boolean;
+begin
+  var Audience := Claims.GetValue(CLAIM_AUDIENCE);
+  if IsJsonString(Audience) then
+    Exit(SameText(TJSONString(Audience).Value, FExpectedAudience));
+  if Audience is TJSONArray then
+  begin
+    for var Item in TJSONArray(Audience) do
+    begin
+      if IsJsonString(Item) and SameText(TJSONString(Item).Value, FExpectedAudience) then
+        Exit(True);
+    end;
+  end;
+  Result := False;
+end;
+
+function TMCPOAuthResourceServerAuthorizer.IsExpired(const Claims: TJSONObject): Boolean;
+begin
+  var Expiry := Claims.GetValue(CLAIM_EXPIRY);
+  if not (Expiry is TJSONNumber) then
+    Exit(True);
+  Result := TJSONNumber(Expiry).AsInt64 <= DateTimeToUnix(Now, False);
+end;
+
+function TMCPOAuthResourceServerAuthorizer.ScopesOf(const Claims: TJSONObject): TArray<string>;
+begin
+  Result := nil;
+  var Scope := Claims.GetValue(CLAIM_SCOPE);
+  if IsJsonString(Scope) then
+    Exit(TJSONString(Scope).Value.Split([SCOPE_SEPARATOR], TStringSplitOptions.ExcludeEmpty));
+
+  var ScopeArray := Claims.GetValue(CLAIM_SCOPE_ARRAY);
+  if ScopeArray is TJSONArray then
+  begin
+    for var Item in TJSONArray(ScopeArray) do
+    begin
+      if IsJsonString(Item) then
+        Result := Result + [TJSONString(Item).Value];
+    end;
+  end;
+end;
+
+function TMCPOAuthResourceServerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string;
+  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+var
+  Claims: TJSONObject;
+begin
+  Principal := TMCPPrincipal.None;
+  Challenge := TMCPAuthChallenge.None;
+  if not ValidateToken(BearerToken, Claims) then
+  begin
+    Challenge := TMCPAuthChallenge.InvalidToken('The access token is not valid');
+    Exit(TMCPAuthDecision.Unauthorized);
+  end;
+
+  try
+    if not AudienceMatches(Claims) then
+    begin
+      Challenge := TMCPAuthChallenge.InvalidToken('The access token was not issued for this server');
+      Exit(TMCPAuthDecision.Unauthorized);
+    end;
+    if IsExpired(Claims) then
+    begin
+      Challenge := TMCPAuthChallenge.InvalidToken('The access token has expired');
+      Exit(TMCPAuthDecision.Unauthorized);
+    end;
+
+    Principal.Subject := Claims.GetValue<string>(CLAIM_SUBJECT, '');
+    Principal.Scopes := ScopesOf(Claims);
+    for var Required in FRequiredScopes do
+    begin
+      if not Principal.HasScope(Required) then
+      begin
+        Challenge := TMCPAuthChallenge.InsufficientScope(string.Join(SCOPE_SEPARATOR, FRequiredScopes));
+        Exit(TMCPAuthDecision.Forbidden);
+      end;
+    end;
+    Result := TMCPAuthDecision.Allow;
+  finally
+    Claims.Free;
+  end;
+end;
+
+{ TMCPIntrospectionAuthorizer }
+
+constructor TMCPIntrospectionAuthorizer.Create(const ExpectedAudience, IntrospectionUrl, ClientId, ClientSecret: string);
+begin
+  inherited Create(ExpectedAudience);
+  if IntrospectionUrl.Trim = '' then
+    raise EMCPAuthorizationConfiguration.Create('An introspection authorizer needs the introspection endpoint URL');
+  FIntrospectionUrl := IntrospectionUrl.Trim;
+  FClientId := ClientId;
+  FClientSecret := ClientSecret;
+  FTimeoutMs := DEFAULT_TIMEOUT_MS;
+end;
+
+function TMCPIntrospectionAuthorizer.ValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
+begin
+  Claims := nil;
+  var Client := THTTPClient.Create;
+  var Form := TStringStream.Create('token=' + TNetEncoding.URL.EncodeForm(Token), TEncoding.UTF8);
+  try
+    Client.ConnectionTimeout := FTimeoutMs;
+    Client.ResponseTimeout := FTimeoutMs;
+    Client.ContentType := MEDIA_TYPE_FORM;
+    var Headers: TArray<TNetHeader> := [TNetHeader.Create('Accept', 'application/json')];
+    if FClientId <> '' then
+      Headers := Headers + [TNetHeader.Create('Authorization', 'Basic ' + TNetEncoding.Base64.Encode(FClientId + ':' + FClientSecret))];
+
+    var Response := Client.Post(FIntrospectionUrl, Form, nil, Headers);
+    if Response.StatusCode <> 200 then
+    begin
+      TLogger.Warning(Format('Token introspection answered HTTP %d', [Response.StatusCode]));
+      Exit(False);
+    end;
+
+    var Parsed := TJSONObject.ParseJSONValue(Response.ContentAsString(TEncoding.UTF8));
+    if not (Parsed is TJSONObject) then
+    begin
+      Parsed.Free;
+      Exit(False);
+    end;
+    if not (TJSONObject(Parsed).GetValue(CLAIM_ACTIVE) is TJSONTrue) then
+    begin
+      Parsed.Free;
+      Exit(False);
+    end;
+    Claims := TJSONObject(Parsed);
+    Result := True;
+  finally
+    Form.Free;
+    Client.Free;
+  end;
+end;
+
+end.

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -38,7 +38,12 @@ type
     FSecurityAllowedOrigins: string;
     FRequestStateKey: string;
     FRequestStateTtlSeconds: Integer;
+    FBearerTokens: string;
+    FAuthorizationServers: string;
+    FResourceUri: string;
+    FScopesSupported: string;
     function GetProtocol: string;
+    function SplitList(const Value: string): TArray<string>;
     function GetAllowedOrigins: string;
 
     procedure LoadDefaults;
@@ -83,6 +88,13 @@ type
     property AllowedOrigins: string read GetAllowedOrigins;
     property RequestStateKey: string read FRequestStateKey write FRequestStateKey;
     property RequestStateTtlSeconds: Integer read FRequestStateTtlSeconds write FRequestStateTtlSeconds;
+    property BearerTokens: string read FBearerTokens write FBearerTokens;
+    property AuthorizationServers: string read FAuthorizationServers write FAuthorizationServers;
+    property ResourceUri: string read FResourceUri write FResourceUri;
+    property ScopesSupported: string read FScopesSupported write FScopesSupported;
+    function BearerTokenList: TArray<string>;
+    function AuthorizationServerList: TArray<string>;
+    function ScopesSupportedList: TArray<string>;
 
     const DEFAULT_MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
     const DEFAULT_MAX_JSON_DEPTH = 64;
@@ -151,6 +163,35 @@ begin
   FSecurityAllowedOrigins := '';
   FRequestStateKey := '';
   FRequestStateTtlSeconds := DEFAULT_REQUEST_STATE_TTL_SECONDS;
+  FBearerTokens := '';
+  FAuthorizationServers := '';
+  FResourceUri := '';
+  FScopesSupported := '';
+end;
+
+function TMCPSettings.SplitList(const Value: string): TArray<string>;
+begin
+  Result := nil;
+  for var Item in Value.Split([',']) do
+  begin
+    if Item.Trim <> '' then
+      Result := Result + [Item.Trim];
+  end;
+end;
+
+function TMCPSettings.BearerTokenList: TArray<string>;
+begin
+  Result := SplitList(FBearerTokens);
+end;
+
+function TMCPSettings.AuthorizationServerList: TArray<string>;
+begin
+  Result := SplitList(FAuthorizationServers);
+end;
+
+function TMCPSettings.ScopesSupportedList: TArray<string>;
+begin
+  Result := SplitList(FScopesSupported);
 end;
 
 function TMCPSettings.GetAllowedOrigins: string;
@@ -200,6 +241,13 @@ begin
     IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
     IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 
+    IniFile.WriteString('Auth', '; Bearer tokens accepted on the HTTP endpoint (comma-separated; empty = open server)', '');
+    IniFile.WriteString('Auth', 'BearerTokens', FBearerTokens);
+    IniFile.WriteString('Auth', '; OAuth authorization servers published in the protected resource metadata', '');
+    IniFile.WriteString('Auth', 'AuthorizationServers', FAuthorizationServers);
+    IniFile.WriteString('Auth', 'ResourceUri', FResourceUri);
+    IniFile.WriteString('Auth', 'ScopesSupported', FScopesSupported);
+
     IniFile.WriteString('Protocol', '; Protocol options (1 = on, 0 = off)', '');
     IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
     IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
@@ -248,6 +296,11 @@ begin
     FSecurityAllowedOrigins := IniFile.ReadString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
     FRequestStateKey := IniFile.ReadString('Security', 'RequestStateKey', FRequestStateKey);
     FRequestStateTtlSeconds := IniFile.ReadInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
+
+    FBearerTokens := IniFile.ReadString('Auth', 'BearerTokens', FBearerTokens);
+    FAuthorizationServers := IniFile.ReadString('Auth', 'AuthorizationServers', FAuthorizationServers);
+    FResourceUri := IniFile.ReadString('Auth', 'ResourceUri', FResourceUri);
+    FScopesSupported := IniFile.ReadString('Auth', 'ScopesSupported', FScopesSupported);
 
     FLenientModernPing := IniFile.ReadBool('Protocol', 'LenientModernPing', FLenientModernPing);
     FDiscoverListsLegacyVersions := IniFile.ReadBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
@@ -302,6 +355,11 @@ begin
     IniFile.WriteString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
     IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
     IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
+
+    IniFile.WriteString('Auth', 'BearerTokens', FBearerTokens);
+    IniFile.WriteString('Auth', 'AuthorizationServers', FAuthorizationServers);
+    IniFile.WriteString('Auth', 'ResourceUri', FResourceUri);
+    IniFile.WriteString('Auth', 'ScopesSupported', FScopesSupported);
 
     IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
     IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -23,6 +23,7 @@ uses
   MCPServer.ContentBlocks in 'Protocol\MCPServer.ContentBlocks.pas',
   MCPServer.Logger in 'Core\MCPServer.Logger.pas',
   MCPServer.Settings in 'Core\MCPServer.Settings.pas',
+  MCPServer.Authorization in 'Core\MCPServer.Authorization.pas',
   MCPServer.Registration in 'Core\MCPServer.Registration.pas',
   MCPServer.ManagerRegistry in 'Core\MCPServer.ManagerRegistry.pas',
   MCPServer.Tool.Base in 'Tools\MCPServer.Tool.Base.pas',
@@ -126,6 +127,8 @@ begin
     Server.Settings := Settings;
     Server.ManagerRegistry := ManagerRegistry;
     Server.CoreManager := CoreManager;
+    if Length(Settings.BearerTokenList) > 0 then
+      Server.Authorizer := TMCPStaticBearerAuthorizer.Create(Settings.BearerTokenList);
 
     Server.Start;
 

--- a/src/MCPServer.dproj
+++ b/src/MCPServer.dproj
@@ -140,6 +140,7 @@
         <DCCReference Include="Protocol\MCPServer.ContentBlocks.pas"/>
         <DCCReference Include="Core\MCPServer.Logger.pas"/>
         <DCCReference Include="Core\MCPServer.Settings.pas"/>
+        <DCCReference Include="Core\MCPServer.Authorization.pas"/>
         <DCCReference Include="Core\MCPServer.Registration.pas"/>
         <DCCReference Include="Core\MCPServer.ManagerRegistry.pas"/>
         <DCCReference Include="Tools\MCPServer.Tool.Base.pas"/>

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -31,6 +31,7 @@ type
     function CreateToolJSON(const Tool: IMCPTool): TJSONObject;
     procedure CheckCursor(const Params: TJSONObject);
     procedure ValidateToolName(const Name: string);
+    procedure CheckRequiredScopes(const Tool: IMCPTool);
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
   private
     procedure RegisterTool(const Tool: IMCPTool);
@@ -66,6 +67,7 @@ uses
   System.RegularExpressions,
   MCPServer.Registration,
   MCPServer.RequestContext,
+  MCPServer.Authorization,
   MCPServer.Errors,
   MCPServer.Mrtr,
   MCPServer.Tool.Result,
@@ -154,6 +156,26 @@ begin
     Result := CallTool(Params, EraOf(Context))
   else
     raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+end;
+
+procedure TMCPToolsManager.CheckRequiredScopes(const Tool: IMCPTool);
+begin
+  var Context := TMCPRequestContext.Current;
+  var RttiContext := TRttiContext.Create;
+  try
+    var ToolType := RttiContext.GetType((Tool as TObject).ClassType);
+    for var Attribute in ToolType.GetAttributes do
+    begin
+      if not (Attribute is RequiresScopeAttribute) then
+        Continue;
+      var Scope := RequiresScopeAttribute(Attribute).Scope;
+      var Granted := Assigned(Context) and Context.HasScope(Scope);
+      if not Granted then
+        raise EMCPError.InsufficientScope(Scope);
+    end;
+  finally
+    RttiContext.Free;
+  end;
 end;
 
 procedure TMCPToolsManager.ValidateToolName(const Name: string);
@@ -410,6 +432,7 @@ begin
 
   if not TryGetTool(ToolName, Tool) then
     raise EMCPError.UnknownTool(ToolName);
+  CheckRequiredScopes(Tool);
 
   TLogger.Info('MCP CallTool called for tool: ' + ToolName);
   Result := TValue.From<TJSONObject>(ExecuteTool(Tool, Arguments, Era));

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -31,6 +31,8 @@ type
     class function UnknownTool(const Name: string): EMCPError;
     class function UnknownPrompt(const Name: string): EMCPError;
     class function ResourceNotFound(const Uri: string; Era: TMCPProtocolEra): EMCPError;
+    class function InsufficientScope(const Scope: string): EMCPError;
+    function RequiredScope: string;
 
     property Code: Integer read FCode;
     property Data: TJSONValue read FData;
@@ -46,6 +48,7 @@ type
 
 const
   HTTP_STATUS_OK = 200;
+  HTTP_STATUS_FORBIDDEN = 403;
   HTTP_STATUS_ACCEPTED = 202;
   HTTP_STATUS_BAD_REQUEST = 400;
   HTTP_STATUS_NOT_FOUND = 404;
@@ -139,6 +142,20 @@ begin
   var Data := TJSONObject.Create;
   Data.AddPair('name', Name);
   Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, 'Unknown prompt: ' + Name, Data);
+end;
+
+function EMCPError.RequiredScope: string;
+begin
+  Result := '';
+  if Data is TJSONObject then
+    Result := TJSONObject(Data).GetValue<string>('requiredScope', '');
+end;
+
+class function EMCPError.InsufficientScope(const Scope: string): EMCPError;
+begin
+  var Data := TJSONObject.Create;
+  Data.AddPair('requiredScope', Scope);
+  Result := EMCPError.Create(JSONRPC_INVALID_REQUEST, Format('The %s scope is required', [Scope]), Data, HTTP_STATUS_FORBIDDEN);
 end;
 
 class function EMCPError.ResourceNotFound(const Uri: string; Era: TMCPProtocolEra): EMCPError;

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -22,6 +22,7 @@ type
     Era: TMCPProtocolEra;
     IsNotification: Boolean;
     Cancelled: Boolean;
+    RequiredScope: string;
   end;
 
   TMCPJsonRpcProcessor = class
@@ -40,6 +41,9 @@ type
     function ClientInputResponses(const Params: TJSONObject): TJSONObject;
     function OpenClientRequestState(const Method: string; const Params: TJSONObject;
       const Hints: TMCPTransportHints): TJSONObject;
+    function NewContext(Era: TMCPProtocolEra; const Version, Method: string; const RequestId: TMCPRequestId;
+      const Meta: TJSONObject; const Hints: TMCPTransportHints; const InputResponses: TJSONObject = nil;
+      const RequestState: TJSONObject = nil): IMCPRequestContext;
     function InputRequiredResult(const Context: IMCPRequestContext; const Params: TJSONObject;
       const Hints: TMCPTransportHints; const Required: EMCPInputRequired): TMCPProcessResult;
     function EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
@@ -319,6 +323,14 @@ begin
       [Decoded, BodyValue]));
 end;
 
+function TMCPJsonRpcProcessor.NewContext(Era: TMCPProtocolEra; const Version, Method: string;
+  const RequestId: TMCPRequestId; const Meta: TJSONObject; const Hints: TMCPTransportHints;
+  const InputResponses: TJSONObject; const RequestState: TJSONObject): IMCPRequestContext;
+begin
+  Result := TMCPRequestContext.Create(Era, Version, Method, RequestId, Meta, Hints.LegacySession, FManagerRegistry,
+    Hints.Sink, InputResponses, RequestState, Hints.Principal, Hints.Scopes);
+end;
+
 function TMCPJsonRpcProcessor.BuildRequestContext(const Method: string; const Params: TJSONObject;
   const RequestId: TMCPRequestId; const Hints: TMCPTransportHints): IMCPRequestContext;
 var
@@ -366,8 +378,7 @@ begin
       InputResponses := ClientInputResponses(Params);
       RequestState := OpenClientRequestState(Method, Params, Hints);
     end;
-    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta,
-      Hints.LegacySession, FManagerRegistry, Hints.Sink, InputResponses, RequestState));
+    Exit(NewContext(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta, Hints, InputResponses, RequestState));
   end;
 
   if Method = 'initialize' then
@@ -379,8 +390,7 @@ begin
       if IsJsonString(RequestedValue) then
         Requested := TJSONString(RequestedValue).Value;
     end;
-    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Legacy, NegotiateLegacyProtocolVersion(Requested),
-      Method, RequestId, Meta, Hints.LegacySession, FManagerRegistry, Hints.Sink));
+    Exit(NewContext(TMCPProtocolEra.Legacy, NegotiateLegacyProtocolVersion(Requested), Method, RequestId, Meta, Hints));
   end;
 
   if IsModernOnlyMethod(Method) then
@@ -398,8 +408,7 @@ begin
       raise EMCPError.Create(JSONRPC_INVALID_REQUEST,
         'Unsupported MCP-Protocol-Version header: ' + Header, nil, HTTP_STATUS_BAD_REQUEST);
 
-    Exit(TMCPRequestContext.Create(TMCPProtocolEra.Legacy, Header, Method, RequestId, Meta,
-      Hints.LegacySession, FManagerRegistry, Hints.Sink));
+    Exit(NewContext(TMCPProtocolEra.Legacy, Header, Method, RequestId, Meta, Hints));
   end;
 
   Version := '';
@@ -408,8 +417,7 @@ begin
   if Version = '' then
     Version := MCP_LATEST_LEGACY_PROTOCOL_VERSION;
 
-  Result := TMCPRequestContext.Create(TMCPProtocolEra.Legacy, Version, Method, RequestId, Meta,
-    Hints.LegacySession, FManagerRegistry, Hints.Sink);
+  Result := NewContext(TMCPProtocolEra.Legacy, Version, Method, RequestId, Meta, Hints);
 end;
 
 function TMCPJsonRpcProcessor.ProcessNotification(const Method: string; const Params: TJSONObject;
@@ -607,8 +615,8 @@ function TMCPJsonRpcProcessor.StatusForError(Era: TMCPProtocolEra; const Error: 
 begin
   if Era = TMCPProtocolEra.Legacy then
   begin
-    if Error.HttpStatus = HTTP_STATUS_BAD_REQUEST then
-      Exit(HTTP_STATUS_BAD_REQUEST);
+    if (Error.HttpStatus = HTTP_STATUS_BAD_REQUEST) or (Error.HttpStatus = HTTP_STATUS_FORBIDDEN) then
+      Exit(Error.HttpStatus);
     Exit(HTTP_STATUS_OK);
   end;
 
@@ -631,6 +639,9 @@ function TMCPJsonRpcProcessor.ErrorResult(Era: TMCPProtocolEra; const RequestId:
   const Error: EMCPError): TMCPProcessResult;
 begin
   TLogger.Error('Error processing request: ' + Error.Message);
+  var RequiredScope := '';
+  if Error.HttpStatus = HTTP_STATUS_FORBIDDEN then
+    RequiredScope := Error.RequiredScope;
 
   var Response := TJSONObject.Create;
   try
@@ -652,6 +663,8 @@ begin
   Result.HttpStatus := StatusForError(Era, Error);
   Result.Era := Era;
   Result.IsNotification := False;
+  Result.Cancelled := False;
+  Result.RequiredScope := RequiredScope;
 end;
 
 function TMCPJsonRpcProcessor.ExceptionToError(Era: TMCPProtocolEra; const E: Exception): EMCPError;

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -22,6 +22,7 @@ type
     NameHeader: string;
     RemoteAddress: string;
     Principal: string;
+    Scopes: TArray<string>;
     LegacySession: TMCPLegacySession;
     Sink: IMCPMessageSink;
     Tracker: IMCPRequestTracker;
@@ -45,6 +46,8 @@ type
     FSink: IMCPMessageSink;
     FInputResponses: TJSONObject;
     FRequestState: TJSONObject;
+    FPrincipal: string;
+    FScopes: TArray<string>;
     FCancelled: Integer;
     FProgressSent: Boolean;
     FLastProgress: Double;
@@ -55,7 +58,8 @@ type
       const RequestId: TMCPRequestId; const Meta: TJSONObject;
       const LegacySession: TMCPLegacySession; const ManagerRegistry: IMCPManagerRegistry;
       const Sink: IMCPMessageSink = nil; const InputResponses: TJSONObject = nil;
-      const RequestState: TJSONObject = nil);
+      const RequestState: TJSONObject = nil; const Principal: string = '';
+      const Scopes: TArray<string> = nil);
     destructor Destroy; override;
 
     function GetEra: TMCPProtocolEra;
@@ -72,7 +76,10 @@ type
     function GetInputResponses: TJSONObject;
     function GetRequestState: TJSONObject;
     function GetSink: IMCPMessageSink;
+    function GetPrincipal: string;
+    function GetScopes: TArray<string>;
     function HasClientCapability(const Path: string): Boolean;
+    function HasScope(const Scope: string): Boolean;
     procedure RequireClientCapability(const Path: string);
     function IsCancelled: Boolean;
     procedure CheckCancelled;
@@ -129,7 +136,7 @@ end;
 constructor TMCPRequestContext.Create(Era: TMCPProtocolEra; const ProtocolVersion, Method: string;
   const RequestId: TMCPRequestId; const Meta: TJSONObject; const LegacySession: TMCPLegacySession;
   const ManagerRegistry: IMCPManagerRegistry; const Sink: IMCPMessageSink; const InputResponses: TJSONObject;
-  const RequestState: TJSONObject);
+  const RequestState: TJSONObject; const Principal: string; const Scopes: TArray<string>);
 begin
   inherited Create;
   FEra := Era;
@@ -144,6 +151,8 @@ begin
   if Assigned(InputResponses) then
     FInputResponses := TJSONObject(InputResponses.Clone);
   FRequestState := RequestState;
+  FPrincipal := Principal;
+  FScopes := Scopes;
 end;
 
 destructor TMCPRequestContext.Destroy;
@@ -241,6 +250,26 @@ end;
 function TMCPRequestContext.GetSink: IMCPMessageSink;
 begin
   Result := FSink;
+end;
+
+function TMCPRequestContext.GetPrincipal: string;
+begin
+  Result := FPrincipal;
+end;
+
+function TMCPRequestContext.GetScopes: TArray<string>;
+begin
+  Result := FScopes;
+end;
+
+function TMCPRequestContext.HasScope(const Scope: string): Boolean;
+begin
+  for var Granted in FScopes do
+  begin
+    if (Granted = Scope) or (Granted = MCP_SCOPE_ANY) then
+      Exit(True);
+  end;
+  Result := False;
 end;
 
 function TMCPRequestContext.TryGetInputResponse(const Key: string; out Response: TJSONObject): Boolean;

--- a/src/Protocol/MCPServer.RequestState.pas
+++ b/src/Protocol/MCPServer.RequestState.pas
@@ -18,7 +18,6 @@ type
     function Signature(const Payload: TBytes): TBytes;
     class function Base64Url(const Bytes: TBytes): string; static;
     class function TryFromBase64Url(const Text: string; out Bytes: TBytes): Boolean; static;
-    class function SameBytes(const A, B: TBytes): Boolean; static;
     class function CanonicalJson(const Value: TJSONValue): string; static;
   public
     constructor Create(const Key: string; TtlSeconds: Integer = DEFAULT_TTL_SECONDS);
@@ -41,6 +40,7 @@ uses
   System.NetEncoding,
   System.Generics.Collections,
   System.Generics.Defaults,
+  MCPServer.Types,
   MCPServer.Errors,
   MCPServer.Logger;
 
@@ -108,25 +108,6 @@ begin
   except
     Result := False;
   end;
-end;
-
-class function TMCPRequestStateSealer.SameBytes(const A, B: TBytes): Boolean;
-begin
-  var Difference := Length(A) xor Length(B);
-  var Longest := Length(A);
-  if Length(B) > Longest then
-    Longest := Length(B);
-  for var I := 0 to Longest - 1 do
-  begin
-    var Left := 0;
-    var Right := 0;
-    if I < Length(A) then
-      Left := A[I];
-    if I < Length(B) then
-      Right := B[I];
-    Difference := Difference or (Left xor Right);
-  end;
-  Result := Difference = 0;
 end;
 
 class function TMCPRequestStateSealer.CanonicalJson(const Value: TJSONValue): string;
@@ -233,7 +214,7 @@ begin
   var Separator := Token.LastIndexOf(TOKEN_SEPARATOR);
   if (Separator <= 0) or not TryFromBase64Url(Token.Substring(0, Separator), PayloadBytes)
     or not TryFromBase64Url(Token.Substring(Separator + 1), SignatureBytes)
-    or not SameBytes(SignatureBytes, Signature(PayloadBytes)) then
+    or not TMCPConstantTime.SameBytes(SignatureBytes, Signature(PayloadBytes)) then
     raise EMCPError.InvalidParams('requestState failed integrity verification');
 
   var Payload := TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes)) as TJSONObject;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -62,6 +62,7 @@ const
   );
 
   MCP_METHOD_NOTIFICATIONS_MESSAGE = 'notifications/message';
+  MCP_SCOPE_ANY = '*';
   MCP_METHOD_SUBSCRIPTIONS_LISTEN = 'subscriptions/listen';
   MCP_METHOD_NOTIFICATIONS_SUBSCRIPTIONS_ACKNOWLEDGED = 'notifications/subscriptions/acknowledged';
   MCP_METHOD_NOTIFICATIONS_TOOLS_LIST_CHANGED = 'notifications/tools/list_changed';
@@ -79,6 +80,10 @@ type
   TMCPLogLevel = record
     class function Rank(const Level: string): Integer; static;
     class function IsKnown(const Level: string): Boolean; static;
+  end;
+
+  TMCPConstantTime = record
+    class function SameBytes(const A, B: TBytes): Boolean; static;
   end;
 
   OptionalAttribute = class(TCustomAttribute)
@@ -283,8 +288,11 @@ type
     function GetInputResponses: TJSONObject;
     function GetRequestState: TJSONObject;
     function GetSink: IMCPMessageSink;
+    function GetPrincipal: string;
+    function GetScopes: TArray<string>;
 
     function HasClientCapability(const Path: string): Boolean;
+    function HasScope(const Scope: string): Boolean;
     procedure RequireClientCapability(const Path: string);
     function IsCancelled: Boolean;
     procedure CheckCancelled;
@@ -309,6 +317,8 @@ type
     property InputResponses: TJSONObject read GetInputResponses;
     property RequestState: TJSONObject read GetRequestState;
     property Sink: IMCPMessageSink read GetSink;
+    property Principal: string read GetPrincipal;
+    property Scopes: TArray<string> read GetScopes;
   end;
 
   IMCPRequestTracker = interface
@@ -457,6 +467,25 @@ end;
 class function TMCPLogLevel.IsKnown(const Level: string): Boolean;
 begin
   Result := Rank(Level) >= 0;
+end;
+
+class function TMCPConstantTime.SameBytes(const A, B: TBytes): Boolean;
+begin
+  var Difference := Length(A) xor Length(B);
+  var Longest := Length(A);
+  if Length(B) > Longest then
+    Longest := Length(B);
+  for var I := 0 to Longest - 1 do
+  begin
+    var Left := 0;
+    var Right := 0;
+    if I < Length(A) then
+      Left := A[I];
+    if I < Length(B) then
+      Right := B[I];
+    Difference := Difference or (Left xor Right);
+  end;
+  Result := Difference = 0;
 end;
 
 function IsJsonString(const Value: TJSONValue): Boolean;

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -26,6 +26,7 @@ uses
   IdServerIOHandler,
   MCPServer.Types,
   MCPServer.Settings,
+  MCPServer.Authorization,
   MCPServer.RequestContext,
   MCPServer.JsonRpcProcessor;
 
@@ -44,16 +45,28 @@ type
     FPort: Word;
     FActive: Boolean;
     FSettings: TMCPSettings;
+    FAuthorizer: IMCPAuthorizer;
     procedure ConfigureSSL;
     procedure ConfigureBindings;
     procedure AddBinding(const IP: string; IPVersion: TIdIPVersion);
     procedure HandleQuerySSLPort(APort: Word; var VUseSSL: Boolean);
+    procedure HandleParseAuthentication(Context: TIdContext; const AuthType, AuthData: string;
+      var VUsername, VPassword: string; var VHandled: Boolean);
     procedure HandleHTTPRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
     function AllowedOrigins: TArray<string>;
     function ValidateOrigin(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo): Boolean;
     procedure ApplyCorsHeaders(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
     procedure HandleEndpointInfo(ResponseInfo: TIdHTTPResponseInfo);
-    procedure HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
+    function IsProtectedResourceMetadataPath(const Document: string): Boolean;
+    function ResourceUri: string;
+    function ResourceMetadataUrl: string;
+    procedure HandleProtectedResourceMetadata(ResponseInfo: TIdHTTPResponseInfo);
+    function Authenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+      out Principal: TMCPPrincipal): Boolean;
+    procedure SendChallenge(ResponseInfo: TIdHTTPResponseInfo; Status: Integer; const Challenge: TMCPAuthChallenge;
+      const Message: string);
+    procedure HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+      const Principal: TMCPPrincipal);
     function BuildTransportHints(RequestInfo: TIdHTTPRequestInfo): TMCPTransportHints;
     procedure EchoLegacySessionId(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
     procedure SendEmpty(ResponseInfo: TIdHTTPResponseInfo; Status: Integer);
@@ -75,6 +88,7 @@ type
     property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry write FManagerRegistry;
     property CoreManager: IMCPCapabilityManager read FCoreManager write FCoreManager;
     property Settings: TMCPSettings read FSettings write FSettings;
+    property Authorizer: IMCPAuthorizer read FAuthorizer write FAuthorizer;
   end;
 
 implementation
@@ -90,6 +104,7 @@ const
   DEFAULT_MCP_PORT = 3000;
 
   HTTP_NO_CONTENT = 204;
+  HTTP_UNAUTHORIZED = 401;
   HTTP_FORBIDDEN = 403;
   HTTP_METHOD_NOT_ALLOWED = 405;
   HTTP_PAYLOAD_TOO_LARGE = 413;
@@ -104,6 +119,10 @@ const
   ALLOW_HEADER = 'POST, OPTIONS';
 
   HEADER_ORIGIN = 'Origin';
+  HEADER_AUTHORIZATION = 'Authorization';
+  HEADER_WWW_AUTHENTICATE = 'WWW-Authenticate';
+  BEARER_PREFIX = 'Bearer ';
+  METADATA_CACHE_CONTROL = 'max-age=3600';
   HEADER_ACCEPT = 'Accept';
   HEADER_SESSION_ID = 'Mcp-Session-Id';
   HEADER_PROTOCOL_VERSION = 'MCP-Protocol-Version';
@@ -132,6 +151,7 @@ begin
   FHTTPServer.OnCommandGet := HandleHTTPRequest;
   FHTTPServer.OnCommandOther := HandleHTTPRequest;
   FHTTPServer.OnQuerySSLPort := HandleQuerySSLPort;
+  FHTTPServer.OnParseAuthentication := HandleParseAuthentication;
   FSSLHandler := nil;
 end;
 
@@ -165,6 +185,9 @@ begin
     if FSettings.SSLEnabled then
       ConfigureSSL;
   end;
+
+  if Assigned(FAuthorizer) and (not Assigned(FSettings) or (Length(FSettings.AuthorizationServerList) = 0)) then
+    TLogger.Warning('An authorizer is configured without [Auth] AuthorizationServers: clients cannot discover an authorization server, only pre-shared tokens work');
 
   FHTTPServer.DefaultPort := FPort;
   ConfigureBindings;
@@ -304,6 +327,14 @@ begin
     TLogger.Info('Root Certificate: ' + FSettings.SSLRootCertFile);
 end;
 
+procedure TMCPIdHTTPServer.HandleParseAuthentication(Context: TIdContext; const AuthType, AuthData: string;
+  var VUsername, VPassword: string; var VHandled: Boolean);
+begin
+  VUsername := '';
+  VPassword := '';
+  VHandled := True;
+end;
+
 procedure TMCPIdHTTPServer.HandleQuerySSLPort(APort: Word; var VUseSSL: Boolean);
 begin
   VUseSSL := Assigned(FSettings) and FSettings.SSLEnabled and (APort = FPort);
@@ -345,6 +376,13 @@ begin
       Exit;
     end;
 
+    if Assigned(FAuthorizer) and (RequestInfo.CommandType = hcGET)
+      and IsProtectedResourceMetadataPath(RequestInfo.Document) then
+    begin
+      HandleProtectedResourceMetadata(ResponseInfo);
+      Exit;
+    end;
+
     if RequestInfo.Document <> Endpoint then
     begin
       SendEmpty(ResponseInfo, HTTP_STATUS_NOT_FOUND);
@@ -352,9 +390,17 @@ begin
     end;
 
     if RequestInfo.Command = 'OPTIONS' then
-      SendEmpty(ResponseInfo, HTTP_NO_CONTENT)
-    else if RequestInfo.CommandType = hcPOST then
-      HandlePostRequest(Context, RequestInfo, ResponseInfo)
+    begin
+      SendEmpty(ResponseInfo, HTTP_NO_CONTENT);
+      Exit;
+    end;
+
+    var Principal := TMCPPrincipal.None;
+    if Assigned(FAuthorizer) and not Authenticate(RequestInfo, ResponseInfo, Principal) then
+      Exit;
+
+    if RequestInfo.CommandType = hcPOST then
+      HandlePostRequest(Context, RequestInfo, ResponseInfo, Principal)
     else
       SendMethodNotAllowed(ResponseInfo);
   finally
@@ -441,6 +487,90 @@ begin
   end;
 end;
 
+function TMCPIdHTTPServer.IsProtectedResourceMetadataPath(const Document: string): Boolean;
+begin
+  var Endpoint := '/mcp';
+  if Assigned(FSettings) then
+    Endpoint := FSettings.Endpoint;
+  Result := (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH)
+    or (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH + Endpoint);
+end;
+
+function TMCPIdHTTPServer.ResourceUri: string;
+begin
+  Result := '';
+  if Assigned(FSettings) then
+    Result := FSettings.ResourceUri.Trim;
+  if Result <> '' then
+    Exit;
+
+  Result := Format('%s://%s:%d%s', [FSettings.Protocol.ToLower, FSettings.Host.ToLower, FPort, FSettings.Endpoint]);
+end;
+
+function TMCPIdHTTPServer.ResourceMetadataUrl: string;
+begin
+  Result := '';
+  if not Assigned(FSettings) or (Length(FSettings.AuthorizationServerList) = 0) then
+    Exit;
+  Result := Format('%s://%s:%d%s%s', [FSettings.Protocol.ToLower, FSettings.Host.ToLower, FPort,
+    TMCPProtectedResourceMetadata.WELL_KNOWN_PATH, FSettings.Endpoint]);
+end;
+
+procedure TMCPIdHTTPServer.HandleProtectedResourceMetadata(ResponseInfo: TIdHTTPResponseInfo);
+begin
+  var Metadata := TMCPProtectedResourceMetadata.Build(ResourceUri, FSettings.ServerName,
+    FSettings.AuthorizationServerList, FSettings.ScopesSupportedList);
+  try
+    ResponseInfo.CustomHeaders.Values['Cache-Control'] := METADATA_CACHE_CONTROL;
+    SendJson(ResponseInfo, HTTP_STATUS_OK, Metadata.ToJSON);
+  finally
+    Metadata.Free;
+  end;
+end;
+
+procedure TMCPIdHTTPServer.SendChallenge(ResponseInfo: TIdHTTPResponseInfo; Status: Integer;
+  const Challenge: TMCPAuthChallenge; const Message: string);
+begin
+  ResponseInfo.CustomHeaders.Values[HEADER_WWW_AUTHENTICATE] := TMCPBearerChallenge.Build(ResourceMetadataUrl, Challenge);
+  SendJsonRpcError(ResponseInfo, Status, JSONRPC_INVALID_REQUEST, Message);
+end;
+
+function TMCPIdHTTPServer.Authenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+  out Principal: TMCPPrincipal): Boolean;
+var
+  Challenge: TMCPAuthChallenge;
+begin
+  Principal := TMCPPrincipal.None;
+  Result := False;
+
+  var Header := HeaderValue(RequestInfo, HEADER_AUTHORIZATION);
+  if Header = '' then
+  begin
+    SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, TMCPAuthChallenge.None, 'Authorization required');
+    Exit;
+  end;
+  if not Header.StartsWith(BEARER_PREFIX, True) or (Header.Length <= BEARER_PREFIX.Length) then
+  begin
+    SendChallenge(ResponseInfo, HTTP_STATUS_BAD_REQUEST,
+      TMCPAuthChallenge.InvalidRequest('Only the Bearer scheme is supported'), 'Malformed Authorization header');
+    Exit;
+  end;
+
+  var Token := Header.Substring(BEARER_PREFIX.Length).Trim;
+  case FAuthorizer.Authorize(Token, RequestInfo.Command, RequestInfo.Document, Principal, Challenge) of
+    TMCPAuthDecision.Allow:
+      Result := True;
+    TMCPAuthDecision.Unauthorized:
+      SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Challenge, 'Unauthorized');
+    TMCPAuthDecision.Forbidden:
+      SendChallenge(ResponseInfo, HTTP_FORBIDDEN, Challenge, 'Forbidden');
+    TMCPAuthDecision.BadRequest:
+      SendChallenge(ResponseInfo, HTTP_STATUS_BAD_REQUEST, Challenge, 'Malformed authorization request');
+  else
+    SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Challenge, 'Unauthorized');
+  end;
+end;
+
 function TMCPIdHTTPServer.BuildTransportHints(RequestInfo: TIdHTTPRequestInfo): TMCPTransportHints;
 begin
   Result := TMCPTransportHints.ForHttp(
@@ -460,7 +590,7 @@ begin
 end;
 
 procedure TMCPIdHTTPServer.HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo;
-  ResponseInfo: TIdHTTPResponseInfo);
+  ResponseInfo: TIdHTTPResponseInfo; const Principal: TMCPPrincipal);
 begin
   var MaxBodyBytes: Integer := TMCPSettings.DEFAULT_MAX_REQUEST_BODY_BYTES;
   var MaxDepth: Integer := TMCPSettings.DEFAULT_MAX_JSON_DEPTH;
@@ -495,6 +625,8 @@ begin
 
   var AcceptsEventStream := TMCPAcceptHeader.Accepts(HeaderValue(RequestInfo, HEADER_ACCEPT), MEDIA_TYPE_EVENT_STREAM);
   var Hints := BuildTransportHints(RequestInfo);
+  Hints.Principal := Principal.Subject;
+  Hints.Scopes := Principal.Scopes;
   var Stream: TMCPHttpResponseStream := nil;
   var StreamRef: IMCPMessageSink := nil;
   if AcceptsEventStream then
@@ -522,6 +654,9 @@ begin
 
   if Outcome.Era = TMCPProtocolEra.Legacy then
     EchoLegacySessionId(RequestInfo, ResponseInfo);
+  if Outcome.RequiredScope <> '' then
+    ResponseInfo.CustomHeaders.Values[HEADER_WWW_AUTHENTICATE] :=
+      TMCPBearerChallenge.Build(ResourceMetadataUrl, TMCPAuthChallenge.InsufficientScope(Outcome.RequiredScope));
 
   if Outcome.Body = '' then
   begin

--- a/tests/MCPServer.Tests.Authorization.pas
+++ b/tests/MCPServer.Tests.Authorization.pas
@@ -1,0 +1,273 @@
+unit MCPServer.Tests.Authorization;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.SysUtils,
+  System.Classes,
+  System.JSON,
+  IdHTTPServer,
+  IdContext,
+  IdCustomHTTPServer,
+  MCPServer.Types,
+  MCPServer.Authorization;
+
+type
+  TClaimsAuthorizer = class(TMCPOAuthResourceServerAuthorizer)
+  strict private
+    FClaimsJson: string;
+  protected
+    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
+  public
+    constructor Create(const ExpectedAudience, ClaimsJson: string);
+  end;
+
+  [TestFixture]
+  TAuthorizationTests = class
+  private
+    FIntrospection: TIdHTTPServer;
+    FSeenAuthorization: string;
+    FSeenBody: string;
+    procedure HandleIntrospection(Context: TIdContext; Request: TIdHTTPRequestInfo; Response: TIdHTTPResponseInfo);
+    function Decide(const Authorizer: IMCPAuthorizer; const Token: string; out Principal: TMCPPrincipal;
+      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+  public
+    [TearDown]
+    procedure TearDown;
+
+    [Test] procedure StaticBearer_AcceptsListedTokens_RejectsOthers;
+    [Test] procedure StaticBearer_NeedsAToken;
+    [Test] procedure ConstantTime_ComparesWholeToken;
+    [Test] procedure Principal_HasScope_HonoursWildcard;
+    [Test] procedure OAuth_RejectsWrongAudience_Expiry_AndScope;
+    [Test] procedure OAuth_AcceptsAudienceArray_AndScopeArray;
+    [Test] procedure OAuth_NeedsAnAudience;
+    [Test] procedure Challenge_Build_QuotesParameters;
+    [Test] procedure Metadata_Build_DropsOfflineAccess;
+    [Test] procedure Introspection_PostsTokenWithClientCredentials;
+  end;
+
+implementation
+
+uses
+  System.DateUtils;
+
+const
+  AUDIENCE = 'https://mcp.example/mcp';
+
+{ TClaimsAuthorizer }
+
+constructor TClaimsAuthorizer.Create(const ExpectedAudience, ClaimsJson: string);
+begin
+  inherited Create(ExpectedAudience);
+  FClaimsJson := ClaimsJson;
+end;
+
+function TClaimsAuthorizer.ValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
+begin
+  Claims := nil;
+  if Token <> 'valid' then
+    Exit(False);
+  Claims := TJSONObject.ParseJSONValue(FClaimsJson) as TJSONObject;
+  Result := True;
+end;
+
+{ TAuthorizationTests }
+
+procedure TAuthorizationTests.TearDown;
+begin
+  FIntrospection.Free;
+  FIntrospection := nil;
+end;
+
+function TAuthorizationTests.Decide(const Authorizer: IMCPAuthorizer; const Token: string;
+  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+begin
+  Result := Authorizer.Authorize(Token, 'POST', '/mcp', Principal, Challenge);
+end;
+
+procedure TAuthorizationTests.StaticBearer_AcceptsListedTokens_RejectsOthers;
+var
+  Principal: TMCPPrincipal;
+  Challenge: TMCPAuthChallenge;
+begin
+  var Authorizer: IMCPAuthorizer := TMCPStaticBearerAuthorizer.Create(['alpha', ' beta ']);
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'alpha', Principal, Challenge));
+  Assert.AreEqual('token-1', Principal.Subject);
+  Assert.IsTrue(Principal.HasScope('anything'), 'pre-shared tokens grant every scope');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'beta', Principal, Challenge));
+  Assert.AreEqual('token-2', Principal.Subject);
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, 'alph', Principal, Challenge));
+  Assert.AreEqual('invalid_token', Challenge.Error);
+  Assert.AreEqual('', Principal.Subject);
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, '', Principal, Challenge));
+
+  var Scoped: IMCPAuthorizer := TMCPStaticBearerAuthorizer.Create(['alpha'], ['read']);
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Scoped, 'alpha', Principal, Challenge));
+  Assert.IsTrue(Principal.HasScope('read'));
+  Assert.IsFalse(Principal.HasScope('write'));
+end;
+
+procedure TAuthorizationTests.StaticBearer_NeedsAToken;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      TMCPStaticBearerAuthorizer.Create(['', '  ']).Free;
+    end, EMCPAuthorizationConfiguration);
+end;
+
+procedure TAuthorizationTests.ConstantTime_ComparesWholeToken;
+begin
+  Assert.IsTrue(TMCPConstantTime.SameBytes(TEncoding.UTF8.GetBytes('secret'), TEncoding.UTF8.GetBytes('secret')));
+  Assert.IsFalse(TMCPConstantTime.SameBytes(TEncoding.UTF8.GetBytes('secret'), TEncoding.UTF8.GetBytes('secret2')));
+  Assert.IsFalse(TMCPConstantTime.SameBytes(TEncoding.UTF8.GetBytes('secret'), TEncoding.UTF8.GetBytes('secreT')));
+  Assert.IsFalse(TMCPConstantTime.SameBytes(nil, TEncoding.UTF8.GetBytes('x')));
+  Assert.IsTrue(TMCPConstantTime.SameBytes(nil, nil));
+end;
+
+procedure TAuthorizationTests.Principal_HasScope_HonoursWildcard;
+begin
+  var Principal := TMCPPrincipal.None;
+  Assert.IsFalse(Principal.HasScope('read'));
+  Principal.Scopes := ['read', 'files:write'];
+  Assert.IsTrue(Principal.HasScope('files:write'));
+  Assert.IsFalse(Principal.HasScope('admin'));
+  Principal.Scopes := ['*'];
+  Assert.IsTrue(Principal.HasScope('admin'));
+end;
+
+procedure TAuthorizationTests.OAuth_RejectsWrongAudience_Expiry_AndScope;
+var
+  Principal: TMCPPrincipal;
+  Challenge: TMCPAuthChallenge;
+begin
+  var Future := System.DateUtils.DateTimeToUnix(Now, False) + 600;
+  var Past := System.DateUtils.DateTimeToUnix(Now, False) - 600;
+
+  var Invalid: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d}', [AUDIENCE, Future]));
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Invalid, 'nope', Principal, Challenge));
+  Assert.AreEqual('invalid_token', Challenge.Error);
+
+  var WrongAudience: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"https://other","exp":%d}', [Future]));
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(WrongAudience, 'valid', Principal, Challenge));
+  Assert.IsTrue(Challenge.ErrorDescription.Contains('not issued for this server'), Challenge.ErrorDescription);
+
+  var Expired: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d}', [AUDIENCE, Past]));
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Expired, 'valid', Principal, Challenge));
+  Assert.IsTrue(Challenge.ErrorDescription.Contains('expired'), Challenge.ErrorDescription);
+
+  var NoExpiry: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s"}', [AUDIENCE]));
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(NoExpiry, 'valid', Principal, Challenge), 'exp is mandatory');
+
+  var Scoped := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d,"scope":"read"}', [AUDIENCE, Future]));
+  var ScopedRef: IMCPAuthorizer := Scoped;
+  Scoped.RequiredScopes := ['read', 'write'];
+  Assert.AreEqual(TMCPAuthDecision.Forbidden, Decide(ScopedRef, 'valid', Principal, Challenge));
+  Assert.AreEqual('insufficient_scope', Challenge.Error);
+  Assert.AreEqual('read write', Challenge.Scope);
+
+  Scoped.RequiredScopes := ['read'];
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(ScopedRef, 'valid', Principal, Challenge));
+  Assert.AreEqual('u', Principal.Subject);
+  Assert.IsTrue(Principal.HasScope('read'));
+  Assert.IsFalse(Principal.HasScope('write'));
+end;
+
+procedure TAuthorizationTests.OAuth_AcceptsAudienceArray_AndScopeArray;
+var
+  Principal: TMCPPrincipal;
+  Challenge: TMCPAuthChallenge;
+begin
+  var Future := System.DateUtils.DateTimeToUnix(Now, False) + 600;
+  var Authorizer: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE,
+    Format('{"sub":"u","aud":["https://other","%s"],"exp":%d,"scp":["a","b"]}', [AUDIENCE.ToUpper, Future]));
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'valid', Principal, Challenge));
+  Assert.IsTrue(Principal.HasScope('a'));
+  Assert.IsTrue(Principal.HasScope('b'));
+  Assert.IsFalse(Principal.HasScope('c'));
+end;
+
+procedure TAuthorizationTests.OAuth_NeedsAnAudience;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      TClaimsAuthorizer.Create(' ', '{}').Free;
+    end, EMCPAuthorizationConfiguration);
+end;
+
+procedure TAuthorizationTests.Challenge_Build_QuotesParameters;
+begin
+  Assert.AreEqual('Bearer', TMCPBearerChallenge.Build('', TMCPAuthChallenge.None));
+  Assert.AreEqual('Bearer resource_metadata="https://s/.well-known/oauth-protected-resource/mcp"',
+    TMCPBearerChallenge.Build('https://s/.well-known/oauth-protected-resource/mcp', TMCPAuthChallenge.None));
+  Assert.AreEqual('Bearer error="invalid_token", error_description="say \"hi\""',
+    TMCPBearerChallenge.Build('', TMCPAuthChallenge.InvalidToken('say "hi"')));
+  Assert.AreEqual('Bearer resource_metadata="https://s/m", error="insufficient_scope", scope="read write"',
+    TMCPBearerChallenge.Build('https://s/m', TMCPAuthChallenge.InsufficientScope('read write')));
+  Assert.IsFalse(TMCPBearerChallenge.Build('', TMCPAuthChallenge.InvalidRequest('a'#13#10'b')).Contains(#10));
+end;
+
+procedure TAuthorizationTests.Metadata_Build_DropsOfflineAccess;
+begin
+  var Metadata := TMCPProtectedResourceMetadata.Build('https://mcp.example/mcp', 'demo',
+    ['https://auth.example'], ['read', 'offline_access', 'write']);
+  try
+    Assert.AreEqual('https://mcp.example/mcp', Metadata.GetValue<string>('resource'));
+    Assert.AreEqual('https://auth.example', Metadata.GetValue<string>('authorization_servers[0]'));
+    Assert.AreEqual(2, (Metadata.GetValue('scopes_supported') as TJSONArray).Count);
+    Assert.AreEqual('header', Metadata.GetValue<string>('bearer_methods_supported[0]'));
+    Assert.AreEqual('demo', Metadata.GetValue<string>('resource_name'));
+  finally
+    Metadata.Free;
+  end;
+
+  var Bare := TMCPProtectedResourceMetadata.Build('https://mcp.example/mcp', '', nil, nil);
+  try
+    Assert.AreEqual(0, (Bare.GetValue('authorization_servers') as TJSONArray).Count);
+    Assert.IsNull(Bare.GetValue('scopes_supported'));
+    Assert.IsNull(Bare.GetValue('resource_name'));
+  finally
+    Bare.Free;
+  end;
+end;
+
+procedure TAuthorizationTests.HandleIntrospection(Context: TIdContext; Request: TIdHTTPRequestInfo;
+  Response: TIdHTTPResponseInfo);
+begin
+  FSeenAuthorization := Request.RawHeaders.Values['Authorization'];
+  FSeenBody := Request.FormParams;
+  Response.ContentType := 'application/json';
+  if FSeenBody.Contains('token=good') then
+    Response.ContentText := Format('{"active":true,"sub":"alice","aud":"%s","exp":%d,"scope":"read"}',
+      [AUDIENCE, System.DateUtils.DateTimeToUnix(Now, False) + 600])
+  else
+    Response.ContentText := '{"active":false}';
+end;
+
+procedure TAuthorizationTests.Introspection_PostsTokenWithClientCredentials;
+var
+  Principal: TMCPPrincipal;
+  Challenge: TMCPAuthChallenge;
+begin
+  FIntrospection := TIdHTTPServer.Create(nil);
+  FIntrospection.Bindings.Add.IP := '127.0.0.1';
+  FIntrospection.Bindings[0].Port := 0;
+  FIntrospection.OnCommandGet := HandleIntrospection;
+  FIntrospection.Active := True;
+  var Url := Format('http://127.0.0.1:%d/introspect', [FIntrospection.Bindings[0].Port]);
+
+  var Authorizer: IMCPAuthorizer := TMCPIntrospectionAuthorizer.Create(AUDIENCE, Url, 'mcp', 's3cret');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'good', Principal, Challenge));
+  Assert.AreEqual('alice', Principal.Subject);
+  Assert.IsTrue(Principal.HasScope('read'));
+  Assert.AreEqual('token=good', FSeenBody);
+  Assert.IsTrue(FSeenAuthorization.StartsWith('Basic '), FSeenAuthorization);
+
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, 'stale', Principal, Challenge));
+  Assert.AreEqual('invalid_token', Challenge.Error);
+end;
+
+end.

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -8,8 +8,12 @@ uses
   System.Classes,
   System.JSON,
   IdHTTP,
+  MCPServer.Types,
   MCPServer.Settings,
+  MCPServer.Authorization,
   MCPServer.IdHTTPServer,
+  MCPServer.Tool.Base,
+  MCPServer.Tool.ContentSamples,
   MCPServer.Tests.Harness;
 
 type
@@ -20,6 +24,12 @@ type
     RawHeaders: string;
     function Header(const Name: string): string;
     function Json: TJSONObject;
+  end;
+
+  [RequiresScope('admin')]
+  TScopedTool = class(TSimpleTextTool)
+  public
+    constructor Create; override;
   end;
 
   [TestFixture]
@@ -73,13 +83,19 @@ type
     [Test] procedure StreamedError_IsFinalEvent;
     [Test] procedure Listen_StreamsAckAndChanges_UntilStopped;
     [Test] procedure Listen_WithoutEventStreamAccept_IsInvalidRequest;
+    [Test] procedure Auth_MissingToken_Is401WithChallenge;
+    [Test] procedure Auth_WrongToken_Is401_InvalidToken;
+    [Test] procedure Auth_MalformedHeader_Is400;
+    [Test] procedure Auth_ValidToken_IsServed;
+    [Test] procedure Auth_PreflightAndMetadata_NeedNoToken;
+    [Test] procedure Auth_ScopedTool_Is403_WithInsufficientScope;
+    [Test] procedure Auth_ScopedTool_OnOpenServer_Is403;
   end;
 
 implementation
 
 uses
-  System.Threading,
-  MCPServer.Types;
+  System.Threading;
 
 const
   MODERN_VERSION_HEADER = 'MCP-Protocol-Version: 2026-07-28';
@@ -104,6 +120,14 @@ function THttpReply.Json: TJSONObject;
 begin
   Result := TJSONObject.ParseJSONValue(Body) as TJSONObject;
   Assert.IsNotNull(Result, 'body is not a JSON object: ' + Body);
+end;
+
+{ TScopedTool }
+
+constructor TScopedTool.Create;
+begin
+  inherited;
+  FName := 'test_scoped';
 end;
 
 { THttpTransportTests }
@@ -145,7 +169,8 @@ begin
   var Request := TStringStream.Create(Body, TEncoding.UTF8);
   var Response := TMemoryStream.Create;
   try
-    Http.HTTPOptions := Http.HTTPOptions + [hoNoProtocolErrorException, hoWantProtocolErrorContent];
+    Http.HTTPOptions := Http.HTTPOptions + [hoNoProtocolErrorException, hoWantProtocolErrorContent] - [hoInProcessAuth];
+    Http.MaxAuthRetries := 0;
     Http.Request.ContentType := 'application/json';
     Http.Request.Accept := 'application/json';
     for var Header in Headers do
@@ -599,6 +624,107 @@ begin
     [MODERN_VERSION_HEADER, 'Mcp-Method: subscriptions/listen']);
   Assert.AreEqual(400, Reply.Status);
   Assert.IsTrue(Reply.Body.Contains('-32600'), Reply.Body);
+end;
+
+procedure THttpTransportTests.Auth_MissingToken_Is401WithChallenge;
+begin
+  FSettings.AuthorizationServers := 'https://auth.example';
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['s3cret']);
+  var Reply := Post(LEGACY_PING, []);
+  Assert.AreEqual(401, Reply.Status);
+  Assert.AreEqual(Format('Bearer resource_metadata="http://localhost:%d/.well-known/oauth-protected-resource/mcp"', [FServer.Port]),
+    Reply.Header('WWW-Authenticate'));
+  Assert.IsTrue(Reply.Body.Contains('-32600'), Reply.Body);
+  Assert.IsFalse(Reply.Body.Contains('"id"'), 'the challenge body carries no id');
+end;
+
+procedure THttpTransportTests.Auth_WrongToken_Is401_InvalidToken;
+begin
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['s3cret']);
+  var Reply := Post(LEGACY_PING, ['Authorization: Bearer nope']);
+  Assert.AreEqual(401, Reply.Status);
+  Assert.AreEqual('Bearer error="invalid_token", error_description="The bearer token is not recognised"',
+    Reply.Header('WWW-Authenticate'));
+end;
+
+procedure THttpTransportTests.Auth_MalformedHeader_Is400;
+begin
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['s3cret']);
+  var Reply := Post(LEGACY_PING, ['Authorization: Basic abc']);
+  Assert.AreEqual(400, Reply.Status);
+  Assert.IsTrue(Reply.Header('WWW-Authenticate').Contains('error="invalid_request"'), Reply.Header('WWW-Authenticate'));
+  var Empty := Post(LEGACY_PING, ['Authorization: Bearer']);
+  Assert.AreEqual(400, Empty.Status);
+end;
+
+procedure THttpTransportTests.Auth_ValidToken_IsServed;
+begin
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['s3cret']);
+  var Reply := Post(LEGACY_PING, ['Authorization: bearer s3cret']);
+  Assert.AreEqual(200, Reply.Status);
+  Assert.AreEqual('', Reply.Header('WWW-Authenticate'));
+  var Modern := Post('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{' + MODERN_META + '}}',
+    [MODERN_VERSION_HEADER, 'Mcp-Method: tools/list', 'Authorization: Bearer s3cret']);
+  Assert.AreEqual(200, Modern.Status);
+end;
+
+procedure THttpTransportTests.Auth_PreflightAndMetadata_NeedNoToken;
+begin
+  FSettings.CorsEnabled := True;
+  FSettings.AuthorizationServers := 'https://auth.example, https://auth2.example';
+  FSettings.ScopesSupported := 'read,offline_access';
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['s3cret']);
+  Assert.AreEqual(204, Send('OPTIONS', '/mcp', '', ['Origin: http://localhost:5173']).Status);
+
+  for var Path in ['/.well-known/oauth-protected-resource', '/.well-known/oauth-protected-resource/mcp'] do
+  begin
+    var Reply := Send('GET', Path, '', []);
+    Assert.AreEqual(200, Reply.Status, Path);
+    Assert.AreEqual('max-age=3600', Reply.Header('Cache-Control'));
+    var Json := Reply.Json;
+    try
+      Assert.AreEqual(Format('http://localhost:%d/mcp', [FServer.Port]), Json.GetValue<string>('resource'));
+      Assert.AreEqual('https://auth2.example', Json.GetValue<string>('authorization_servers[1]'));
+      Assert.AreEqual(1, (Json.GetValue('scopes_supported') as TJSONArray).Count, 'offline_access is dropped');
+      Assert.AreEqual('header', Json.GetValue<string>('bearer_methods_supported[0]'));
+    finally
+      Json.Free;
+    end;
+  end;
+
+  Assert.AreEqual(404, Send('GET', '/.well-known/other', '', []).Status);
+  Assert.AreEqual(401, Send('GET', '/mcp', '', []).Status, 'GET on the endpoint is authenticated before 405');
+end;
+
+procedure THttpTransportTests.Auth_ScopedTool_Is403_WithInsufficientScope;
+const
+  CALL = '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test_scoped","arguments":{}}}';
+begin
+  FHarness.ToolsManager.AddTool(TScopedTool.Create);
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['reader'], ['read']);
+  var Denied := Post(CALL, ['Authorization: Bearer reader']);
+  Assert.AreEqual(403, Denied.Status);
+  Assert.AreEqual('Bearer error="insufficient_scope", scope="admin"', Denied.Header('WWW-Authenticate'));
+  var Json := Denied.Json;
+  try
+    Assert.AreEqual(4, Json.GetValue<Integer>('id'));
+    Assert.AreEqual(-32600, Json.GetValue<Integer>('error.code'));
+    Assert.AreEqual('admin', Json.GetValue<string>('error.data.requiredScope'));
+  finally
+    Json.Free;
+  end;
+
+  FServer.Authorizer := TMCPStaticBearerAuthorizer.Create(['admin-token'], ['read', 'admin']);
+  var Allowed := Post(CALL, ['Authorization: Bearer admin-token']);
+  Assert.AreEqual(200, Allowed.Status);
+  Assert.IsTrue(Allowed.Body.Contains('This is a simple text response'), Allowed.Body);
+end;
+
+procedure THttpTransportTests.Auth_ScopedTool_OnOpenServer_Is403;
+begin
+  FHarness.ToolsManager.AddTool(TScopedTool.Create);
+  var Reply := Post('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test_scoped","arguments":{}}}', []);
+  Assert.AreEqual(403, Reply.Status, 'nobody holds a scope on an open server');
 end;
 
 end.

--- a/tests/MCPServerTests.dpr
+++ b/tests/MCPServerTests.dpr
@@ -21,6 +21,7 @@ uses
   MCPServer.ContentBlocks in '..\src\Protocol\MCPServer.ContentBlocks.pas',
   MCPServer.Logger in '..\src\Core\MCPServer.Logger.pas',
   MCPServer.Settings in '..\src\Core\MCPServer.Settings.pas',
+  MCPServer.Authorization in '..\src\Core\MCPServer.Authorization.pas',
   MCPServer.Registration in '..\src\Core\MCPServer.Registration.pas',
   MCPServer.ManagerRegistry in '..\src\Core\MCPServer.ManagerRegistry.pas',
   MCPServer.Tool.Base in '..\src\Tools\MCPServer.Tool.Base.pas',
@@ -77,6 +78,7 @@ uses
   MCPServer.Tests.Prompt in 'MCPServer.Tests.Prompt.pas',
   MCPServer.Tests.Mrtr in 'MCPServer.Tests.Mrtr.pas',
   MCPServer.Tests.Subscriptions in 'MCPServer.Tests.Subscriptions.pas',
+  MCPServer.Tests.Authorization in 'MCPServer.Tests.Authorization.pas',
   MCPServer.Tests.PromptsManager in 'MCPServer.Tests.PromptsManager.pas',
   MCPServer.Tests.CompletionManager in 'MCPServer.Tests.CompletionManager.pas';
 

--- a/tests/MCPServerTests.dproj
+++ b/tests/MCPServerTests.dproj
@@ -85,6 +85,7 @@
         <DCCReference Include="..\src\Protocol\MCPServer.ContentBlocks.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.Logger.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.Settings.pas"/>
+        <DCCReference Include="..\src\Core\MCPServer.Authorization.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.Registration.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.ManagerRegistry.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.Base.pas"/>
@@ -106,6 +107,7 @@
         <DCCReference Include="MCPServer.Tests.Prompt.pas"/>
         <DCCReference Include="MCPServer.Tests.Mrtr.pas"/>
         <DCCReference Include="MCPServer.Tests.Subscriptions.pas"/>
+        <DCCReference Include="MCPServer.Tests.Authorization.pas"/>
         <DCCReference Include="MCPServer.Tests.PromptsManager.pas"/>
         <DCCReference Include="MCPServer.Tests.CompletionManager.pas"/>
         <DCCReference Include="..\src\Resources\MCPServer.Resource.Server.pas"/>


### PR DESCRIPTION
## Summary

- `MCPServer.Authorization`: `IMCPAuthorizer`, `TMCPStaticBearerAuthorizer` (constant-time comparison), the abstract `TMCPOAuthResourceServerAuthorizer` (mandatory `aud` and `exp`, `RequiredScopes`) and `TMCPIntrospectionAuthorizer` (RFC 7662).
- `TMCPIdHTTPServer.Authorizer` gates every request except `OPTIONS` and the RFC 9728 metadata document; `401`/`403`/`400` carry a `WWW-Authenticate: Bearer` challenge with `resource_metadata`, `error` and `scope`.
- `[RequiresScope]` on tool classes, `Principal`/`Scopes`/`HasScope` on the request context, principal-bound `requestState`.
- `[Auth] BearerTokens`, `AuthorizationServers`, `ResourceUri`, `ScopesSupported`; the executable installs the static authorizer when tokens are configured. The stdio transport never authenticates.

## Verification

- DUnitX: 367/367 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 builds.
- Conformance, HTTP goldens, Inspector smoke and stdio smoke unchanged and green.