### PR TITLE
Host allow-list and diagnostics resources switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,10 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   request's own stream, only when the request carries
   `_meta.io.modelcontextprotocol/logLevel` and the level is at or above it;
   `TMCPLogLevel` and `MCP_LOG_LEVELS` in `MCPServer.Types`.
+- `[Security] AllowedHosts` (`TMCPHostPolicy`): `Host` header allow-list,
+  `403` for other hosts; `[Server] ExposeDiagnosticsResources` to keep
+  `logs://recent`, `logs://{level}` and `server://status` off a server that
+  strangers can reach; `TMCPResourcesManager.RemoveResourceTemplate`.
 - Authentication (`MCPServer.Authorization`): `IMCPAuthorizer` on
   `TMCPIdHTTPServer.Authorizer`, `TMCPStaticBearerAuthorizer` (constant-time
   comparison), the abstract `TMCPOAuthResourceServerAuthorizer` (mandatory

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -162,6 +162,17 @@ at startup. `RequestStateTtlSeconds` bounds the replay window (600 s).
 nine new example tools plus one example prompt ship with the executable;
 they are only registered when their units are in the project.
 
+## Host allow-list and diagnostics resources
+
+**`[Security] AllowedHosts` is empty by default**, so nothing changes until it
+is set; then a request whose `Host` header is not listed gets `403`.
+
+**`[Server] ExposeDiagnosticsResources=0` drops `logs://recent`,
+`logs://{level}` and `server://status`** from the shipped executable. The
+default keeps them, as before. A library that registers the resources itself
+uses `RemoveResource` and the new `RemoveResourceTemplate` on
+`TMCPResourcesManager` to the same effect.
+
 ## Authentication
 
 **Opt-in, and only over HTTP.** Nothing changes until `[Auth] BearerTokens`

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ A Model Context Protocol (MCP) server implementation in Delphi, designed to inte
 - [Integration with Codex](#integration-with-codex)
 - [Testing with MCP Inspector](#testing-with-mcp-inspector)
 - [Available Example Tools](#available-example-tools)
+- [Available Example Prompts](#available-example-prompts)
 - [Available Example Resources](#available-example-resources)
 - [Configuration](#configuration)
+- [Authentication](#authentication)
+- [Network and Security](#network-and-security)
 - [License](#license)
 - [Contributing](#contributing)
 - [About GDK Software](#about-gdk-software)
@@ -33,7 +36,8 @@ A Model Context Protocol (MCP) server implementation in Delphi, designed to inte
 - **Dual Response Mode**: Supports both JSON-RPC and Server-Sent Events in the same server
 - **Tool System**: Extensible tool system with RTTI-based discovery and execution
 - **Resource Management**: Modular resource system supporting various content types
-- **Security**: `Origin` validation against DNS rebinding on every request, loopback binding by default, CORS headers for browser clients, request size and nesting limits
+- **Security**: `Origin` and `Host` validation against DNS rebinding on every request, loopback binding by default, CORS headers for browser clients, request size and nesting limits, opt-in bearer authentication with OAuth 2.1 resource-server discovery
+- **Multi round-trip requests, streaming and subscriptions**: `InputRequiredResult` with signed `requestState`, progress and log notifications on the response stream, `subscriptions/listen` for change notifications
 - **High Performance**: Native implementation using Indy HTTP Server with keep-alive support
 - **Optional Parameters**: Support for optional tool parameters using custom attributes
 - **Cross-Platform**: Supports Windows (Win32/Win64) and Linux (x64)
@@ -854,6 +858,8 @@ consults an authorizer.
 
 - `[Server] BindAddress`: the interface to listen on. Empty (default) derives it from `Host`: a loopback `Host` binds `127.0.0.1` and `::1`, any other `Host` binds every interface. Set `0.0.0.0` to listen everywhere explicitly.
 - `[Security] AllowedOrigins`: origins that pass the `Origin` check next to the loopback origins (`localhost`, `127.0.0.1`, `[::1]`, any port). Comma-separated `scheme://host[:port]`; `:*` allows any port; `*` allows everything. Falls back to `[CORS] AllowedOrigins`. A rejected origin gets `403` with a JSON-RPC error body, also when CORS is disabled.
+- `[Security] AllowedHosts`: `Host` header values the server answers, comma-separated `host[:port]` (an entry without a port matches any port, `*` matches everything). Empty means any host. Set it when the server is reachable through a public name, so that a rebinding DNS name cannot reach it; a rejected host gets `403`.
+- `[Server] ExposeDiagnosticsResources`: `1` (default) registers `logs://recent`, `logs://{level}` and `server://status`; set `0` on a server that strangers can reach, the log buffer and the status counters are diagnostics.
 - `[CORS] Enabled`: adds the CORS response headers for browser clients; the `Origin` check runs regardless.
 - `[Server] EndpointInfoPath`: optional GET path (for example `/info`) that answers a JSON document with the endpoint URL and the protocol versions. The MCP endpoint itself only accepts POST; GET and DELETE get `405`.
 - `[Server] MaxRequestBodyBytes` (4 MB) and `MaxJsonDepth` (64): larger or deeper requests get `413` or `400`; `MaxConnections`: Indy connection limit, `0` = unlimited.

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -27,6 +27,9 @@ MaxRequestBodyBytes=4194304
 MaxJsonDepth=64
 ; Indy connection limit; 0 = unlimited
 MaxConnections=0
+; Serve logs://recent, logs://{level} and server://status; set 0 on a server
+; that strangers can reach, the log buffer and status counters are diagnostics
+ExposeDiagnosticsResources=1
 ; Worker threads of the stdio transport; 1 answers requests in arrival order
 MaxConcurrentRequests=1
 
@@ -35,6 +38,11 @@ MaxConcurrentRequests=1
 ; any port), for DNS-rebinding protection. Comma-separated scheme://host[:port];
 ; ":*" allows any port. Empty = the [CORS] AllowedOrigins list below.
 AllowedOrigins=
+; Host header values the server answers, comma-separated host[:port]; an
+; entry without a port matches any port, * matches everything. Empty = any
+; host. Set it when the server is reachable through a public name so that a
+; rebinding DNS name cannot reach it.
+AllowedHosts=
 ; Secret that signs the requestState tokens of multi round-trip requests.
 ; Empty = a random key per process: tokens stop verifying after a restart
 ; and on other instances. Set the same value on every instance.

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -36,6 +36,8 @@ type
     FMaxConnections: Integer;
     FMaxConcurrentRequests: Integer;
     FSecurityAllowedOrigins: string;
+    FAllowedHosts: string;
+    FExposeDiagnosticsResources: Boolean;
     FRequestStateKey: string;
     FRequestStateTtlSeconds: Integer;
     FBearerTokens: string;
@@ -86,6 +88,9 @@ type
     property MaxConcurrentRequests: Integer read FMaxConcurrentRequests write FMaxConcurrentRequests;
     property SecurityAllowedOrigins: string read FSecurityAllowedOrigins write FSecurityAllowedOrigins;
     property AllowedOrigins: string read GetAllowedOrigins;
+    property AllowedHosts: string read FAllowedHosts write FAllowedHosts;
+    property ExposeDiagnosticsResources: Boolean read FExposeDiagnosticsResources write FExposeDiagnosticsResources;
+    function AllowedHostList: TArray<string>;
     property RequestStateKey: string read FRequestStateKey write FRequestStateKey;
     property RequestStateTtlSeconds: Integer read FRequestStateTtlSeconds write FRequestStateTtlSeconds;
     property BearerTokens: string read FBearerTokens write FBearerTokens;
@@ -161,6 +166,8 @@ begin
   FMaxConcurrentRequests := DEFAULT_MAX_CONCURRENT_REQUESTS;
   FMaxConnections := 0;
   FSecurityAllowedOrigins := '';
+  FAllowedHosts := '';
+  FExposeDiagnosticsResources := True;
   FRequestStateKey := '';
   FRequestStateTtlSeconds := DEFAULT_REQUEST_STATE_TTL_SECONDS;
   FBearerTokens := '';
@@ -177,6 +184,11 @@ begin
     if Item.Trim <> '' then
       Result := Result + [Item.Trim];
   end;
+end;
+
+function TMCPSettings.AllowedHostList: TArray<string>;
+begin
+  Result := SplitList(FAllowedHosts);
 end;
 
 function TMCPSettings.BearerTokenList: TArray<string>;
@@ -234,9 +246,13 @@ begin
     IniFile.WriteInteger('Server', 'MaxJsonDepth', FMaxJsonDepth);
     IniFile.WriteInteger('Server', 'MaxConcurrentRequests', FMaxConcurrentRequests);
     IniFile.WriteInteger('Server', 'MaxConnections', FMaxConnections);
+    IniFile.WriteString('Server', '; Serve logs://recent, logs://{level} and server://status (0 = keep diagnostics private)', '');
+    IniFile.WriteBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
 
     IniFile.WriteString('Security', '; Origins allowed next to the loopback origins (empty = [CORS] AllowedOrigins)', '');
     IniFile.WriteString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
+    IniFile.WriteString('Security', '; Host header values accepted, comma-separated host[:port] (empty = any)', '');
+    IniFile.WriteString('Security', 'AllowedHosts', FAllowedHosts);
     IniFile.WriteString('Security', '; Secret that signs requestState tokens (empty = random per process)', '');
     IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
     IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
@@ -294,6 +310,8 @@ begin
     FMaxConnections := IniFile.ReadInteger('Server', 'MaxConnections', FMaxConnections);
 
     FSecurityAllowedOrigins := IniFile.ReadString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
+    FAllowedHosts := IniFile.ReadString('Security', 'AllowedHosts', FAllowedHosts);
+    FExposeDiagnosticsResources := IniFile.ReadBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
     FRequestStateKey := IniFile.ReadString('Security', 'RequestStateKey', FRequestStateKey);
     FRequestStateTtlSeconds := IniFile.ReadInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 
@@ -351,8 +369,10 @@ begin
     IniFile.WriteInteger('Server', 'MaxJsonDepth', FMaxJsonDepth);
     IniFile.WriteInteger('Server', 'MaxConcurrentRequests', FMaxConcurrentRequests);
     IniFile.WriteInteger('Server', 'MaxConnections', FMaxConnections);
+    IniFile.WriteBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
 
     IniFile.WriteString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
+    IniFile.WriteString('Security', 'AllowedHosts', FAllowedHosts);
     IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
     IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -108,6 +108,12 @@ begin
   CoreManager := TMCPCoreManager.Create(Settings);
   ToolsManager := TMCPToolsManager.Create;
   ResourcesManager := TMCPResourcesManager.Create;
+  if not Settings.ExposeDiagnosticsResources then
+  begin
+    ResourcesManager.RemoveResource('logs://recent');
+    ResourcesManager.RemoveResource('server://status');
+    ResourcesManager.RemoveResourceTemplate('logs://{level}');
+  end;
   PromptsManager := TMCPPromptsManager.Create;
   CompletionManager := TMCPCompletionManager.Create(PromptsManager, ResourcesManager);
   SubscriptionsManager := TMCPSubscriptionsManager.Create;
@@ -162,6 +168,12 @@ begin
   CoreManager := TMCPCoreManager.Create(Settings);
   ToolsManager := TMCPToolsManager.Create;
   ResourcesManager := TMCPResourcesManager.Create;
+  if not Settings.ExposeDiagnosticsResources then
+  begin
+    ResourcesManager.RemoveResource('logs://recent');
+    ResourcesManager.RemoveResource('server://status');
+    ResourcesManager.RemoveResourceTemplate('logs://{level}');
+  end;
   PromptsManager := TMCPPromptsManager.Create;
   CompletionManager := TMCPCompletionManager.Create(PromptsManager, ResourcesManager);
   SubscriptionsManager := TMCPSubscriptionsManager.Create;

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -42,6 +42,7 @@ type
     procedure RemoveResource(const URI: string);
     procedure ResourceUpdated(const URI: string);
     procedure AddResourceTemplate(const Template: IMCPResourceTemplate);
+    procedure RemoveResourceTemplate(const UriTemplate: string);
     function TryGetResource(const URI: string; out Resource: IMCPResource): Boolean;
     function TryGetResourceTemplate(const UriTemplate: string; out Template: IMCPResourceTemplate): Boolean;
 
@@ -198,6 +199,26 @@ procedure TMCPResourcesManager.AddResource(const Resource: IMCPResource);
 begin
   RegisterResource(Resource);
   NotifyListChanged;
+end;
+
+procedure TMCPResourcesManager.RemoveResourceTemplate(const UriTemplate: string);
+begin
+  var Removed := False;
+  FLock.Enter;
+  try
+    for var I := FTemplates.Count - 1 downto 0 do
+    begin
+      if FTemplates[I].UriTemplate = UriTemplate then
+      begin
+        FTemplates.Delete(I);
+        Removed := True;
+      end;
+    end;
+  finally
+    FLock.Leave;
+  end;
+  if Removed then
+    NotifyListChanged;
 end;
 
 procedure TMCPResourcesManager.AddResourceTemplate(const Template: IMCPResourceTemplate);

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -28,6 +28,11 @@ type
     class function Matches(const Origin, Pattern: string): Boolean; static;
   end;
 
+  TMCPHostPolicy = record
+    class function IsAllowed(const HostHeader: string; const AllowList: TArray<string>): Boolean; static;
+    class function Matches(const HostHeader, Pattern: string): Boolean; static;
+  end;
+
   TMCPJsonLimits = record
     class function NestingDepth(const Json: string): Integer; static;
   end;
@@ -208,6 +213,34 @@ begin
   for var Pattern in AllowList do
     if Matches(Value, Pattern) then
       Exit(True);
+  Result := False;
+end;
+
+{ TMCPHostPolicy }
+
+class function TMCPHostPolicy.Matches(const HostHeader, Pattern: string): Boolean;
+var
+  Scheme, HostName, HostPort, PatternName, PatternPort: string;
+begin
+  if Pattern.Trim = TMCPOriginPolicy.ALLOW_ALL then
+    Exit(True);
+
+  SplitOrigin('http://' + HostHeader.Trim, Scheme, HostName, HostPort);
+  SplitOrigin('http://' + Pattern.Trim, Scheme, PatternName, PatternPort);
+  if (HostName = '') or (PatternName = '') or (HostName <> PatternName) then
+    Exit(False);
+  Result := (PatternPort = '') or (PatternPort = '*') or (PatternPort = HostPort);
+end;
+
+class function TMCPHostPolicy.IsAllowed(const HostHeader: string; const AllowList: TArray<string>): Boolean;
+begin
+  if Length(AllowList) = 0 then
+    Exit(True);
+  for var Pattern in AllowList do
+  begin
+    if Matches(HostHeader, Pattern) then
+      Exit(True);
+  end;
   Result := False;
 end;
 

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -55,6 +55,7 @@ type
     procedure HandleHTTPRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
     function AllowedOrigins: TArray<string>;
     function ValidateOrigin(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo): Boolean;
+    function ValidateHost(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo): Boolean;
     procedure ApplyCorsHeaders(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
     procedure HandleEndpointInfo(ResponseInfo: TIdHTTPResponseInfo);
     function IsProtectedResourceMetadataPath(const Document: string): Boolean;
@@ -357,7 +358,7 @@ begin
   try
     TServerStatusResource.IncrementRequestCount;
 
-    if not ValidateOrigin(RequestInfo, ResponseInfo) then
+    if not ValidateHost(RequestInfo, ResponseInfo) or not ValidateOrigin(RequestInfo, ResponseInfo) then
       Exit;
 
     ApplyCorsHeaders(RequestInfo, ResponseInfo);
@@ -436,6 +437,16 @@ begin
 
   TLogger.Warning('Origin not allowed: ' + Origin);
   SendJsonRpcError(ResponseInfo, HTTP_FORBIDDEN, JSONRPC_INVALID_REQUEST, 'Origin not allowed');
+  Result := False;
+end;
+
+function TMCPIdHTTPServer.ValidateHost(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo): Boolean;
+begin
+  if not Assigned(FSettings) or TMCPHostPolicy.IsAllowed(RequestInfo.Host, FSettings.AllowedHostList) then
+    Exit(True);
+
+  TLogger.Warning('Host not allowed: ' + RequestInfo.Host);
+  SendJsonRpcError(ResponseInfo, HTTP_FORBIDDEN, JSONRPC_INVALID_REQUEST, 'Host not allowed');
   Result := False;
 end;
 

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -90,6 +90,7 @@ type
     [Test] procedure Auth_PreflightAndMetadata_NeedNoToken;
     [Test] procedure Auth_ScopedTool_Is403_WithInsufficientScope;
     [Test] procedure Auth_ScopedTool_OnOpenServer_Is403;
+    [Test] procedure Host_NotAllowed_Is403;
   end;
 
 implementation
@@ -725,6 +726,17 @@ begin
   FHarness.ToolsManager.AddTool(TScopedTool.Create);
   var Reply := Post('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test_scoped","arguments":{}}}', []);
   Assert.AreEqual(403, Reply.Status, 'nobody holds a scope on an open server');
+end;
+
+procedure THttpTransportTests.Host_NotAllowed_Is403;
+begin
+  FSettings.AllowedHosts := 'mcp.example, localhost';
+  var Denied := Post(LEGACY_PING, []);
+  Assert.AreEqual(403, Denied.Status, 'the client sends Host: 127.0.0.1');
+  Assert.IsTrue(Denied.Body.Contains('Host not allowed'), Denied.Body);
+
+  FSettings.AllowedHosts := '127.0.0.1:*';
+  Assert.AreEqual(200, Post(LEGACY_PING, []).Status);
 end;
 
 end.

--- a/tests/MCPServer.Tests.HttpHeaders.pas
+++ b/tests/MCPServer.Tests.HttpHeaders.pas
@@ -23,6 +23,7 @@ type
     [Test] procedure Origin_AllowListMatchesSchemeHostAndPort;
     [Test] procedure Origin_PortWildcardAndAllowAll;
     [Test] procedure Origin_DefaultPortEqualsExplicitPort;
+    [Test] procedure Host_AllowList_MatchesNameAndPort;
     [Test] procedure NestingDepth_CountsObjectsAndArraysOutsideStrings;
   end;
 
@@ -152,6 +153,20 @@ begin
   Assert.IsTrue(TMCPOriginPolicy.IsAllowed('http://app.example:80', ['http://app.example']));
   Assert.IsFalse(TMCPOriginPolicy.IsAllowed('http://app.example:8080', ['http://app.example']));
   Assert.IsFalse(TMCPOriginPolicy.IsAllowed('http://app.example:443', ['https://app.example']));
+end;
+
+procedure THttpHeadersTests.Host_AllowList_MatchesNameAndPort;
+begin
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('anything.example:3000', nil), 'empty list allows every host');
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('mcp.example:3000', ['mcp.example']));
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('MCP.example', ['mcp.example']));
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('mcp.example:3000', ['mcp.example:3000']));
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('mcp.example:3000', ['mcp.example:*']));
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('[::1]:3000', ['[::1]']));
+  Assert.IsTrue(TMCPHostPolicy.IsAllowed('evil.example', ['*']));
+  Assert.IsFalse(TMCPHostPolicy.IsAllowed('mcp.example:3001', ['mcp.example:3000']));
+  Assert.IsFalse(TMCPHostPolicy.IsAllowed('evil.example', ['mcp.example', 'localhost']));
+  Assert.IsFalse(TMCPHostPolicy.IsAllowed('', ['mcp.example']));
 end;
 
 procedure THttpHeadersTests.NestingDepth_CountsObjectsAndArraysOutsideStrings;

--- a/tests/MCPServer.Tests.ResourcesManager.pas
+++ b/tests/MCPServer.Tests.ResourcesManager.pas
@@ -68,6 +68,7 @@ type
     [Test] procedure Read_TemplateMismatch_IsNotFound;
     [Test] procedure Read_ViaTemplate_PercentDecodes_KeepsPlusLiteral;
     [Test] procedure Read_ViaTemplate_ConcurrentReads_Succeed;
+    [Test] procedure RemoveResourceTemplate_StopsMatching;
   end;
 
 implementation
@@ -353,6 +354,18 @@ begin
         Json.Free;
       end;
     end);
+end;
+
+procedure TResourcesManagerTests.RemoveResourceTemplate_StopsMatching;
+begin
+  FManager.RemoveResourceTemplate('echo://{value}');
+  try
+    Read('echo://hello', TMCPProtocolEra.Modern).Free;
+    Assert.Fail('the template is gone');
+  except
+    on E: EMCPError do
+      Assert.AreEqual(JSONRPC_INVALID_PARAMS, E.Code);
+  end;
 end;
 
 procedure TResourcesManagerTests.Read_TemplateMismatch_IsNotFound;


### PR DESCRIPTION
## Summary

- `[Security] AllowedHosts` (`TMCPHostPolicy`): requests whose `Host` header is not listed get `403`; empty keeps every host, as before.
- `[Server] ExposeDiagnosticsResources=0` keeps `logs://recent`, `logs://{level}` and `server://status` off the executable; `TMCPResourcesManager.RemoveResourceTemplate` is new.
- README: table of contents, features, authentication and security sections brought up to date.

## Verification

- DUnitX: 370/370 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 builds.
- Conformance, HTTP goldens, Inspector smoke and stdio smoke unchanged and green.