### PR TITLE
Security, lifetime and correctness fixes from the review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Enumeration sets with more than 64 elements were truncated when serialised,
+  and a JSON number outside the range of its target integer type was silently
+  wrapped instead of rejected.
+- `TServerStatusResource.SetNamePrefix` removed the old registration before
+  adding the new one, so a failure left the server without a status resource.
+- `logs://recent` and `logs://{level}` leaked their result when reading the
+  log buffer failed.
+- A rejected `Origin` or `Host` now answers `403` with the CORS headers, so a
+  browser can read the error instead of seeing an opaque failure.
 - `TServerStatusResource` request and connection counters and the SSE event-id
   counter are updated atomically; they were plain increments shared by all
   Indy connection threads.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ free. Every message on the subscription carries
 when the server stops (or stdin closes) it answers the request with a
 completion result first.
 
+Notifications are delivered synchronously on the thread that causes the
+change, so a subscriber that stops reading can hold up that thread until its
+socket buffer drains.
+
 Assign the manager as `ChangeNotifier` of the tools, prompts and resources
 managers, as `MCPServer.dpr` does, and the `tools`, `prompts` and `resources`
 capabilities announce `listChanged` (and `resources.subscribe`) to modern

--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -126,6 +126,7 @@ const
   SCOPE_SEPARATOR = ' ';
   STATIC_SUBJECT_FORMAT = 'token-%d';
   MEDIA_TYPE_FORM = 'application/x-www-form-urlencoded';
+  HTTP_STATUS_OK = 200;
 
 { TMCPPrincipal }
 
@@ -401,38 +402,52 @@ end;
 function TMCPIntrospectionAuthorizer.ValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
 begin
   Claims := nil;
-  var Client := THTTPClient.Create;
-  var Form := TStringStream.Create('token=' + TNetEncoding.URL.EncodeForm(Token), TEncoding.UTF8);
+  const Client = THTTPClient.Create;
   try
     Client.ConnectionTimeout := FTimeoutMs;
     Client.ResponseTimeout := FTimeoutMs;
     Client.ContentType := MEDIA_TYPE_FORM;
-    var Headers: TArray<TNetHeader> := [TNetHeader.Create('Accept', 'application/json')];
-    if FClientId <> '' then
-      Headers := Headers + [TNetHeader.Create('Authorization', 'Basic ' + TNetEncoding.Base64.Encode(FClientId + ':' + FClientSecret))];
 
-    var Response := Client.Post(FIntrospectionUrl, Form, nil, Headers);
-    if Response.StatusCode <> 200 then
-    begin
-      TLogger.Warning(Format('Token introspection answered HTTP %d', [Response.StatusCode]));
-      Exit(False);
-    end;
+    const Form = TStringStream.Create(Format('token=%s', [TNetEncoding.URL.EncodeForm(Token)]), TEncoding.UTF8);
+    try
+      var Headers: TArray<TNetHeader> := [TNetHeader.Create('Accept', 'application/json')];
+      if FClientId <> '' then
+      begin
+        const Credentials = TNetEncoding.Base64.Encode(Format('%s:%s', [FClientId, FClientSecret]));
+        Headers := Headers + [TNetHeader.Create('Authorization', Format('Basic %s', [Credentials]))];
+      end;
 
-    var Parsed := TJSONObject.ParseJSONValue(Response.ContentAsString(TEncoding.UTF8));
-    if not (Parsed is TJSONObject) then
-    begin
-      Parsed.Free;
-      Exit(False);
+      var Body := '';
+      try
+        const Response = Client.Post(FIntrospectionUrl, Form, nil, Headers);
+        const Answered = (Response.StatusCode = HTTP_STATUS_OK);
+        if not Answered then
+        begin
+          TLogger.Warning(Format('Token introspection answered HTTP %d', [Response.StatusCode]));
+          Exit(False);
+        end;
+        Body := Response.ContentAsString(TEncoding.UTF8);
+      except
+        on E: ENetException do
+        begin
+          TLogger.Warning(Format('Token introspection failed: %s', [E.Message]));
+          Exit(False);
+        end;
+      end;
+
+      const Parsed = TJSONObject.ParseJSONValue(Body);
+      const IsActiveToken = (Parsed is TJSONObject) and (TJSONObject(Parsed).GetValue(CLAIM_ACTIVE) is TJSONTrue);
+      if not IsActiveToken then
+      begin
+        Parsed.Free;
+        Exit(False);
+      end;
+      Claims := TJSONObject(Parsed);
+      Result := True;
+    finally
+      Form.Free;
     end;
-    if not (TJSONObject(Parsed).GetValue(CLAIM_ACTIVE) is TJSONTrue) then
-    begin
-      Parsed.Free;
-      Exit(False);
-    end;
-    Claims := TJSONObject(Parsed);
-    Result := True;
   finally
-    Form.Free;
     Client.Free;
   end;
 end;

--- a/src/Core/MCPServer.Registration.pas
+++ b/src/Core/MCPServer.Registration.pas
@@ -11,6 +11,9 @@ uses
   MCPServer.Logger;
 
 type
+  EMCPRegistryNotFound = class(Exception)
+  end;
+
   TMCPToolClass = class of TMCPToolBase;
 
   TMCPToolFactory = reference to function: IMCPTool;
@@ -131,7 +134,7 @@ begin
   if FTools.TryGetValue(Name, Factory) then
     Result := Factory()
   else
-    raise Exception.CreateFmt('Tool not found: %s', [Name]);
+    raise EMCPRegistryNotFound.CreateFmt('Tool not found: %s', [Name]);
 end;
 
 class function TMCPRegistry.CreateResource(const URI: string): IMCPResource;
@@ -141,7 +144,7 @@ begin
   if FResources.TryGetValue(URI, Factory) then
     Result := Factory()
   else
-    raise Exception.CreateFmt('Resource not found: %s', [URI]);
+    raise EMCPRegistryNotFound.CreateFmt('Resource not found: %s', [URI]);
 end;
 
 class function TMCPRegistry.CreatePrompt(const Name: string): IMCPPrompt;
@@ -151,7 +154,7 @@ begin
   if FPrompts.TryGetValue(Name, Factory) then
     Result := Factory()
   else
-    raise Exception.CreateFmt('Prompt not found: %s', [Name]);
+    raise EMCPRegistryNotFound.CreateFmt('Prompt not found: %s', [Name]);
 end;
 
 class function TMCPRegistry.CreateResourceTemplate(const UriTemplate: string): IMCPResourceTemplate;
@@ -161,7 +164,7 @@ begin
   if FResourceTemplates.TryGetValue(UriTemplate, Factory) then
     Result := Factory()
   else
-    raise Exception.CreateFmt('Resource template not found: %s', [UriTemplate]);
+    raise EMCPRegistryNotFound.CreateFmt('Resource template not found: %s', [UriTemplate]);
 end;
 
 class function TMCPRegistry.GetToolNames: TArray<string>;

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -250,8 +250,7 @@ begin
     {$ENDIF}
     
     try
-      TServerStatusResource.Initialize;
-
+    
       if HasStdioFlag then
         RunStdioServer
       else

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -234,20 +234,32 @@ end;
 
 function TMCPResourcesManager.TryGetResource(const URI: string; out Resource: IMCPResource): Boolean;
 begin
-  Result := FResources.TryGetValue(URI, Resource);
+  FLock.Enter;
+  try
+    Result := FResources.TryGetValue(URI, Resource);
+  finally
+    FLock.Leave;
+  end;
 end;
 
 function TMCPResourcesManager.TryGetResourceTemplate(const UriTemplate: string;
   out Template: IMCPResourceTemplate): Boolean;
 begin
-  for var Candidate in FTemplates do
-    if Candidate.UriTemplate = UriTemplate then
-    begin
-      Template := Candidate;
-      Exit(True);
-    end;
   Template := nil;
   Result := False;
+  FLock.Enter;
+  try
+    for var Candidate in FTemplates do
+    begin
+      if Candidate.UriTemplate = UriTemplate then
+      begin
+        Template := Candidate;
+        Exit(True);
+      end;
+    end;
+  finally
+    FLock.Leave;
+  end;
 end;
 
 function TMCPResourcesManager.FindResource(const URI: string): IMCPResource;

--- a/src/Managers/MCPServer.SubscriptionsManager.pas
+++ b/src/Managers/MCPServer.SubscriptionsManager.pas
@@ -40,6 +40,7 @@ type
   public
     const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 15000;
     const POLL_INTERVAL_MS = 250;
+    const CLOSE_GRACE_MS = 2000;
   strict private
     FLock: TCriticalSection;
     FSubscriptions: TList<IMCPSubscription>;
@@ -64,6 +65,7 @@ type
     procedure ResourcesListChanged;
     procedure ResourceUpdated(const Uri: string);
     procedure CloseAll(const Reason: string);
+    procedure CloseAllAndWait(const Reason: string);
     function ActiveCount: Integer;
 
     property KeepAliveIntervalMs: Integer read FKeepAliveIntervalMs write FKeepAliveIntervalMs;
@@ -82,6 +84,7 @@ const
   FILTER_RESOURCES = 'resourcesListChanged';
   FILTER_RESOURCE_SUBSCRIPTIONS = 'resourceSubscriptions';
   PARAM_NOTIFICATIONS = 'notifications';
+  CLOSE_POLL_MS = 10;
 
 type
   TMCPSubscription = class(TInterfacedObject, IMCPSubscription)
@@ -231,7 +234,7 @@ end;
 
 destructor TMCPSubscriptionsManager.Destroy;
 begin
-  CloseAll('subscriptions manager destroyed');
+  CloseAllAndWait('subscriptions manager destroyed');
   FSubscriptions.Free;
   FLock.Free;
   inherited;
@@ -395,6 +398,22 @@ begin
   begin
     Subscription.Close;
   end;
+end;
+
+procedure TMCPSubscriptionsManager.CloseAllAndWait(const Reason: string);
+begin
+  const Deadline = TThread.GetTickCount64 + CLOSE_GRACE_MS;
+  repeat
+    CloseAll(Reason);
+    const AllGone = (ActiveCount = 0);
+    if AllGone then
+      Break;
+    Sleep(CLOSE_POLL_MS);
+  until TThread.GetTickCount64 >= Deadline;
+
+  const StillOpen = ActiveCount;
+  if StillOpen > 0 then
+    TLogger.Warning(Format('%d subscription(s) did not close in time', [StillOpen]));
 end;
 
 function TMCPSubscriptionsManager.ActiveCount: Integer;

--- a/src/Prompts/MCPServer.Prompt.Base.pas
+++ b/src/Prompts/MCPServer.Prompt.Base.pas
@@ -19,6 +19,7 @@ type
   TMCPPromptMessages = class
   strict private
     FMessages: TJSONArray;
+    FPendingAnnotations: TJSONObject;
     function AddMessage(const Role: string; const Content: TJSONObject): TMCPPromptMessages;
   public
     constructor Create;
@@ -109,6 +110,7 @@ end;
 
 destructor TMCPPromptMessages.Destroy;
 begin
+  FPendingAnnotations.Free;
   FMessages.Free;
   inherited;
 end;
@@ -119,6 +121,11 @@ begin
   Message.AddPair('role', Role);
   Message.AddPair('content', Content);
   FMessages.AddElement(Message);
+  if Assigned(FPendingAnnotations) then
+  begin
+    Content.AddPair('annotations', FPendingAnnotations);
+    FPendingAnnotations := nil;
+  end;
   Result := Self;
 end;
 
@@ -178,13 +185,17 @@ end;
 
 function TMCPPromptMessages.WithAnnotations(const Annotations: TJSONObject): TMCPPromptMessages;
 begin
-  if FMessages.Count = 0 then
+  const HasMessage = (FMessages.Count > 0);
+  if HasMessage then
   begin
-    Annotations.Free;
-    raise EInvalidOperation.Create('WithAnnotations needs a message to attach to');
+    const LastMessage = TJSONObject(FMessages.Items[FMessages.Count - 1]);
+    TJSONObject(LastMessage.GetValue('content')).AddPair('annotations', Annotations);
+  end
+  else
+  begin
+    FPendingAnnotations.Free;
+    FPendingAnnotations := Annotations;
   end;
-  var LastMessage := TJSONObject(FMessages.Items[FMessages.Count - 1]);
-  TJSONObject(LastMessage.GetValue('content')).AddPair('annotations', Annotations);
   Result := Self;
 end;
 

--- a/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
+++ b/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
@@ -32,7 +32,8 @@ implementation
 uses
   System.Classes,
   MCPServer.Registration,
-  MCPServer.Resource.Logs;
+  MCPServer.Resource.Logs,
+  System.NetEncoding;
 
 { TSummarizeLogsPrompt }
 
@@ -58,7 +59,7 @@ begin
   begin
     Messages.AddText('user', Format(
       'Summarize the server''s recent "%s" log entries, calling out anything unusual.', [Params.Level]));
-    ResourceUri := 'logs://' + Params.Level;
+    ResourceUri := Format('logs://%s', [TNetEncoding.URL.Encode(Params.Level)]);
   end;
 
   Entries := TLogBuffer.Instance.GetLogs(100, Params.Level);

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -13,6 +13,7 @@ uses
   MCPServer.Mrtr,
   MCPServer.Errors,
   MCPServer.HttpHeaders,
+  MCPServer.Registration,
   MCPServer.Logger;
 
 type
@@ -423,7 +424,7 @@ end;
 function TMCPJsonRpcProcessor.ProcessNotification(const Method: string; const Params: TJSONObject;
   const Hints: TMCPTransportHints): TMCPProcessResult;
 begin
-  Result.Body := '';
+  Result := Default(TMCPProcessResult);
   Result.HttpStatus := HTTP_STATUS_ACCEPTED;
   Result.Era := EraFromHeaders(Hints);
   Result.IsNotification := True;
@@ -509,7 +510,7 @@ begin
         TMCPRequestStateSealer.DigestOf(Params), Hints.Principal));
     ApplyModernEnvelope(ResultObject, Context.Method);
 
-    var Response := TJSONObject.Create;
+    const Response = TJSONObject.Create;
     try
       Response.AddPair('jsonrpc', JSONRPC_VERSION);
       Response.AddPair('id', Context.RequestId.ToJson);
@@ -543,14 +544,14 @@ begin
   if not Assigned(Manager) then
     raise EMCPError.MethodNotFound(Context.Method);
 
-  TMCPRequestContext.SetCurrent(Context);
+  const Previous = TMCPRequestContext.SetCurrent(Context);
   try
     if Supports(Manager, IMCPCapabilityManagerEx, ManagerEx) then
       Result := ManagerEx.ExecuteMethodWithContext(Context.Method, Params, Context)
     else
       Result := Manager.ExecuteMethod(Context.Method, Params);
   finally
-    TMCPRequestContext.SetCurrent(nil);
+    TMCPRequestContext.SetCurrent(Previous);
   end;
 end;
 
@@ -593,7 +594,12 @@ begin
     else if Value.IsType<string> then
       Result := TJSONString.Create(Value.AsString)
     else
+    begin
+      if Value.IsObject then
+        raise EMCPError.InternalError(Format('%s answered with a %s instead of a JSON object',
+          [Context.Method, Value.AsObject.ClassName]));
       Result := TJSONString.Create(Value.ToString);
+    end;
     Exit;
   end;
 
@@ -602,6 +608,9 @@ begin
     ResultObject := Value.AsType<TJSONObject>
   else
   begin
+    if Value.IsObject then
+      raise EMCPError.InternalError(Format('%s answered with a %s instead of a JSON object',
+        [Context.Method, Value.AsObject.ClassName]));
     ResultObject := TJSONObject.Create;
     if not Value.IsEmpty then
       ResultObject.AddPair('value', Value.ToString);
@@ -669,7 +678,7 @@ end;
 
 function TMCPJsonRpcProcessor.ExceptionToError(Era: TMCPProtocolEra; const E: Exception): EMCPError;
 begin
-  if (Era = TMCPProtocolEra.Legacy) and (Pos('not found', E.Message) > 0) then
+  if E is EMCPRegistryNotFound then
     Result := EMCPError.Create(JSONRPC_METHOD_NOT_FOUND, E.Message)
   else
     Result := EMCPError.InternalError(E.Message);
@@ -733,7 +742,7 @@ begin
         begin
           if Era = TMCPProtocolEra.Modern then
             raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
-          Result.Body := '';
+          Result := Default(TMCPProcessResult);
           Result.HttpStatus := HTTP_STATUS_ACCEPTED;
           Result.Era := Era;
           Result.IsNotification := True;

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -49,9 +49,11 @@ type
     FPrincipal: string;
     FScopes: TArray<string>;
     FCancelled: Integer;
+    FProgressLock: TObject;
     FProgressSent: Boolean;
     FLastProgress: Double;
     FLastProgressTick: UInt64;
+    function TryClaimProgress(const Progress: Double; const Completes: Boolean): Boolean;
     function MetaObject(const Key: string): TJSONObject;
   public
     constructor Create(Era: TMCPProtocolEra; const ProtocolVersion, Method: string;
@@ -91,7 +93,7 @@ type
     procedure LogJson(const Level: string; const Data: TJSONValue; const Logger: string = '');
 
     class function Current: IMCPRequestContext;
-    class procedure SetCurrent(const Value: IMCPRequestContext);
+    class function SetCurrent(const Value: IMCPRequestContext): IMCPRequestContext;
   end;
 
 implementation
@@ -153,6 +155,7 @@ begin
   FRequestState := RequestState;
   FPrincipal := Principal;
   FScopes := Scopes;
+  FProgressLock := TObject.Create;
 end;
 
 destructor TMCPRequestContext.Destroy;
@@ -160,6 +163,7 @@ begin
   FMeta.Free;
   FInputResponses.Free;
   FRequestState.Free;
+  FProgressLock.Free;
   inherited;
 end;
 
@@ -318,6 +322,27 @@ begin
   raise EMCPError.MissingRequiredClientCapability(Required);
 end;
 
+function TMCPRequestContext.TryClaimProgress(const Progress: Double; const Completes: Boolean): Boolean;
+begin
+  const Tick = TThread.GetTickCount64;
+  TMonitor.Enter(FProgressLock);
+  try
+    if FProgressSent then
+    begin
+      const Stale = (Progress <= FLastProgress);
+      const TooSoon = ((Tick - FLastProgressTick < PROGRESS_MIN_INTERVAL_MS) and not Completes);
+      if Stale or TooSoon then
+        Exit(False);
+    end;
+    FProgressSent := True;
+    FLastProgress := Progress;
+    FLastProgressTick := Tick;
+    Result := True;
+  finally
+    TMonitor.Exit(FProgressLock);
+  end;
+end;
+
 function TMCPRequestContext.IsCancelled: Boolean;
 begin
   Result := AtomicCmpExchange(FCancelled, 0, 0) <> 0;
@@ -351,18 +376,9 @@ begin
   if not Assigned(FSink) or not HasProgressToken or IsCancelled then
     Exit;
 
-  var Completes := (Total >= 0) and (Progress >= Total);
-  var Tick := TThread.GetTickCount64;
-  if FProgressSent then
-  begin
-    if Progress <= FLastProgress then
-      Exit;
-    if (Tick - FLastProgressTick < PROGRESS_MIN_INTERVAL_MS) and not Completes then
-      Exit;
-  end;
-  FProgressSent := True;
-  FLastProgress := Progress;
-  FLastProgressTick := Tick;
+  const Completes = ((Total >= 0) and (Progress >= Total));
+  if not TryClaimProgress(Progress, Completes) then
+    Exit;
 
   var Notification := TJSONObject.Create;
   try
@@ -421,8 +437,9 @@ begin
   Result := IMCPRequestContext(CurrentContextPointer);
 end;
 
-class procedure TMCPRequestContext.SetCurrent(const Value: IMCPRequestContext);
+class function TMCPRequestContext.SetCurrent(const Value: IMCPRequestContext): IMCPRequestContext;
 begin
+  Result := IMCPRequestContext(CurrentContextPointer);
   if Assigned(CurrentContextPointer) then
     IMCPRequestContext(CurrentContextPointer)._Release;
 

--- a/src/Protocol/MCPServer.RequestState.pas
+++ b/src/Protocol/MCPServer.RequestState.pas
@@ -7,6 +7,9 @@ uses
   System.JSON;
 
 type
+  EMCPRequestStateKey = class(Exception)
+  end;
+
   TMCPRequestStateSealer = class
   public
     const DEFAULT_TTL_SECONDS = 600;
@@ -16,6 +19,8 @@ type
     FTtlSeconds: Integer;
     FKeyIsEphemeral: Boolean;
     function Signature(const Payload: TBytes): TBytes;
+    class function NewRandomKey: TBytes; static;
+    class function QuotedName(const Value: string): string; static;
     class function Base64Url(const Bytes: TBytes): string; static;
     class function TryFromBase64Url(const Text: string; out Bytes: TBytes): Boolean; static;
     class function CanonicalJson(const Value: TJSONValue): string; static;
@@ -34,6 +39,9 @@ type
 implementation
 
 uses
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
   System.Classes,
   System.Hash,
   System.DateUtils,
@@ -46,6 +54,7 @@ uses
 
 const
   KEY_BYTES = 32;
+  URANDOM_DEVICE = '/dev/urandom';
   TOKEN_SEPARATOR = '.';
   PAYLOAD_VERSION = 'v';
   PAYLOAD_METHOD = 'm';
@@ -55,7 +64,45 @@ const
   PAYLOAD_STATE = 's';
   EXCLUDED_MEMBERS: array[0..2] of string = ('_meta', 'inputResponses', 'requestState');
 
+{$IFDEF MSWINDOWS}
+const
+  BCRYPT_USE_SYSTEM_PREFERRED_RNG = $00000002;
+  STATUS_SUCCESS = 0;
+
+function BCryptGenRandom(Algorithm: Pointer; Buffer: PByte; BufferLength: ULONG;
+  Flags: ULONG): Integer; stdcall; external 'bcrypt.dll' name 'BCryptGenRandom';
+{$ENDIF}
+
 { TMCPRequestStateSealer }
+
+class function TMCPRequestStateSealer.NewRandomKey: TBytes;
+var
+  Generated: Boolean;
+begin
+  SetLength(Result, KEY_BYTES);
+{$IFDEF MSWINDOWS}
+  Generated := BCryptGenRandom(nil, PByte(Result), KEY_BYTES, BCRYPT_USE_SYSTEM_PREFERRED_RNG) = STATUS_SUCCESS;
+{$ELSE}
+  const Device = TFileStream.Create(URANDOM_DEVICE, fmOpenRead or fmShareDenyNone);
+  try
+    Generated := Device.Read(Result[0], KEY_BYTES) = KEY_BYTES;
+  finally
+    Device.Free;
+  end;
+{$ENDIF}
+  if not Generated then
+    raise EMCPRequestStateKey.Create('The operating system did not provide a random key for requestState');
+end;
+
+class function TMCPRequestStateSealer.QuotedName(const Value: string): string;
+begin
+  const Quoted = TJSONString.Create(Value);
+  try
+    Result := Quoted.ToJSON;
+  finally
+    Quoted.Free;
+  end;
+end;
 
 constructor TMCPRequestStateSealer.Create(const Key: string; TtlSeconds: Integer);
 begin
@@ -65,10 +112,7 @@ begin
     FKey := TEncoding.UTF8.GetBytes(Key)
   else
   begin
-    SetLength(FKey, KEY_BYTES);
-    Randomize;
-    for var I := 0 to High(FKey) do
-      FKey[I] := Byte(Random(256));
+    FKey := NewRandomKey;
     FKeyIsEphemeral := True;
     TLogger.Warning('[Security] RequestStateKey is not set: requestState tokens are sealed with a random key ' +
       'and stop verifying after a restart or on another instance');
@@ -130,8 +174,10 @@ begin
         begin
           if I > 0 then
             Parts.Append(',');
-          Parts.Append(TJSONString.Create(Names[I]).ToJSON).Append(':')
-            .Append(CanonicalJson(TJSONObject(Value).GetValue(Names[I])));
+          const Member = TJSONObject(Value).GetValue(Names[I]);
+          Parts.Append(QuotedName(Names[I]));
+          Parts.Append(':');
+          Parts.Append(CanonicalJson(Member));
         end;
         Parts.Append('}');
         Result := Parts.ToString;
@@ -217,9 +263,15 @@ begin
     or not TMCPConstantTime.SameBytes(SignatureBytes, Signature(PayloadBytes)) then
     raise EMCPError.InvalidParams('requestState failed integrity verification');
 
-  var Payload := TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes)) as TJSONObject;
-  if not Assigned(Payload) then
+  const Parsed = TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes));
+  const IsPayloadObject = (Parsed is TJSONObject);
+  if not IsPayloadObject then
+  begin
+    Parsed.Free;
     raise EMCPError.InvalidParams('requestState failed integrity verification');
+  end;
+
+  const Payload = TJSONObject(Parsed);
   try
     if Payload.GetValue<Integer>(PAYLOAD_VERSION, 0) <> TOKEN_VERSION then
       raise EMCPError.InvalidParams('requestState has an unsupported version');

--- a/src/Protocol/MCPServer.Schema.Validator.pas
+++ b/src/Protocol/MCPServer.Schema.Validator.pas
@@ -30,7 +30,9 @@ implementation
 
 uses
   System.Generics.Collections,
-  System.RegularExpressions;
+  System.RegularExpressions,
+  System.RegularExpressionsCore,
+  MCPServer.Types;
 
 { TMCPSchemaValidator }
 
@@ -213,12 +215,25 @@ begin
       AddError(Errors, Path, 'longer than maxLength');
       Result := False;
     end;
-    var PatternValue := ResolvedSchema.GetValue('pattern');
-    if (PatternValue is TJSONString) and not (PatternValue is TJSONNumber)
-      and not TRegEx.IsMatch(Text, TJSONString(PatternValue).Value) then
+    const PatternValue = ResolvedSchema.GetValue('pattern');
+    if IsJsonString(PatternValue) then
     begin
-      AddError(Errors, Path, 'does not match pattern');
-      Result := False;
+      var Matches := False;
+      try
+        Matches := TRegEx.IsMatch(Text, TJSONString(PatternValue).Value);
+      except
+        on E: ERegularExpressionError do
+        begin
+          AddError(Errors, Path, 'has an unusable pattern');
+          Exit(False);
+        end;
+      end;
+      const PatternMatched = Matches;
+      if not PatternMatched then
+      begin
+        AddError(Errors, Path, 'does not match pattern');
+        Result := False;
+      end;
     end;
   end;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -231,7 +231,13 @@ begin
         if RttiType.TypeKind = tkInt64 then
           Result := Number.AsInt64
         else
+        begin
+          const Ordinal = TRttiOrdinalType(RttiType);
+          const InRange = ((Number.AsInt64 >= Ordinal.MinValue) and (Number.AsInt64 <= Ordinal.MaxValue));
+          if not InRange then
+            raise EArgumentException.CreateFmt('%d is outside the range of %s', [Number.AsInt64, RttiType.Name]);
           Result := TValue.FromOrdinal(RttiType.Handle, Number.AsInt64);
+        end;
       end;
 
     tkFloat:
@@ -402,14 +408,18 @@ begin
 
     tkSet:
       begin
-        var Names := TJSONArray.Create;
-        var ElementType := TRttiEnumerationType(TRttiSetType(RttiType).ElementType);
-        var SetBits: Int64 := 0;
-        Move(Value.GetReferenceToRawData^, SetBits, Min(Value.DataSize, SizeOf(SetBits)));
-        var FirstBit := ElementType.MinValue and not 7;
+        const Names = TJSONArray.Create;
+        const ElementType = TRttiEnumerationType(TRttiSetType(RttiType).ElementType);
+        const Bytes = PByte(Value.GetReferenceToRawData);
+        const FirstBit = ElementType.MinValue and not 7;
         for var Ordinal := ElementType.MinValue to ElementType.MaxValue do
-          if (SetBits and (Int64(1) shl (Ordinal - FirstBit))) <> 0 then
+        begin
+          const BitIndex = Ordinal - FirstBit;
+          const ByteIndex = BitIndex div 8;
+          const IsMember = ((ByteIndex < Value.DataSize) and ((Bytes[ByteIndex] and (1 shl (BitIndex mod 8))) <> 0));
+          if IsMember then
             Names.Add(GetEnumName(ElementType.Handle, Ordinal));
+        end;
         Result := Names;
       end;
 

--- a/src/Resources/MCPServer.Resource.Base.pas
+++ b/src/Resources/MCPServer.Resource.Base.pas
@@ -301,6 +301,9 @@ begin
             raise EArgumentException.CreateFmt('Variable name "%s" in URI template "%s" may only contain letters, digits and underscores',
               [VarName, UriTemplate]);
 
+        if Names.IndexOf(VarName) >= 0 then
+          raise EArgumentException.CreateFmt('URI template %s uses the variable %s more than once',
+            [UriTemplate, VarName]);
         Names.Add(VarName);
         Position := CloseBrace + 1;
       end

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -221,17 +221,21 @@ begin
 end;
 
 function TLogsRecentResource.GetResourceData: TLogEntries;
-var
-  Logs: TObjectList<TLogEntry>;
 begin
-  Result := TLogEntries.Create;
-
-  Logs := TLogBuffer.Instance.GetLogs(MAX_RECENT_LOG_ENTRIES);
+  const Logs = TLogBuffer.Instance.GetLogs(MAX_RECENT_LOG_ENTRIES);
   try
-    Result.Entries.AddRange(Logs);
-    Result.TotalCount := Logs.Count;
-    Result.FilteredCount := Logs.Count;
-    Logs.OwnsObjects := False;
+    const Entries = TLogEntries.Create;
+    try
+      Entries.Entries.AddRange(Logs);
+      Entries.TotalCount := Logs.Count;
+      Entries.FilteredCount := Logs.Count;
+      Logs.OwnsObjects := False;
+    except
+      Entries.Entries.OwnsObjects := False;
+      Entries.Free;
+      raise;
+    end;
+    Result := Entries;
   finally
     Logs.Free;
   end;
@@ -252,17 +256,21 @@ begin
 end;
 
 function TLogsByLevelResource.GetResourceData: TLogEntries;
-var
-  Logs: TObjectList<TLogEntry>;
 begin
-  Result := TLogEntries.Create;
-
-  Logs := TLogBuffer.Instance.GetLogs(MAX_RECENT_LOG_ENTRIES, FLevel);
+  const Logs = TLogBuffer.Instance.GetLogs(MAX_RECENT_LOG_ENTRIES, FLevel);
   try
-    Result.Entries.AddRange(Logs);
-    Result.TotalCount := Logs.Count;
-    Result.FilteredCount := Logs.Count;
-    Logs.OwnsObjects := False;
+    const Entries = TLogEntries.Create;
+    try
+      Entries.Entries.AddRange(Logs);
+      Entries.TotalCount := Logs.Count;
+      Entries.FilteredCount := Logs.Count;
+      Logs.OwnsObjects := False;
+    except
+      Entries.Entries.OwnsObjects := False;
+      Entries.Free;
+      raise;
+    end;
+    Result := Entries;
   finally
     Logs.Free;
   end;

--- a/src/Resources/MCPServer.Resource.Server.pas
+++ b/src/Resources/MCPServer.Resource.Server.pas
@@ -74,9 +74,12 @@ end;
 
 class procedure TServerStatusResource.SetNamePrefix(const Prefix: string);
 begin
-  TMCPRegistry.UnregisterResource(StatusURI);
+  const PreviousUri = StatusURI;
   FNamePrefix := Prefix;
   RegisterServerStatusResource;
+  const UriChanged = (PreviousUri <> StatusURI);
+  if UriChanged then
+    TMCPRegistry.UnregisterResource(PreviousUri);
 end;
 
 class procedure TServerStatusResource.RegisterServerStatusResource;

--- a/src/Server/MCPServer.HttpStream.pas
+++ b/src/Server/MCPServer.HttpStream.pas
@@ -19,6 +19,7 @@ type
     FLock: TCriticalSection;
     FOpened: Boolean;
     FBroken: Boolean;
+    FClosed: Boolean;
     FRequest: IMCPRequestContext;
     procedure OpenStream;
     procedure WriteChunk(const Text: string);
@@ -38,6 +39,7 @@ type
     class function EventText(const Json: string): string; static;
 
     property Opened: Boolean read FOpened;
+    property Closed: Boolean read FClosed;
     property Broken: Boolean read FBroken;
   end;
 
@@ -117,7 +119,8 @@ procedure TMCPHttpResponseStream.Send(const Json: string);
 begin
   FLock.Enter;
   try
-    if FBroken then
+    const CanWrite = not FBroken and not FClosed;
+    if not CanWrite then
       Exit;
     try
       if not FOpened then
@@ -136,7 +139,8 @@ procedure TMCPHttpResponseStream.KeepAlive;
 begin
   FLock.Enter;
   try
-    if FBroken or not FOpened then
+    const CanWrite = FOpened and not FBroken and not FClosed;
+    if not CanWrite then
       Exit;
     try
       if not FConnection.Connection.Connected then
@@ -180,8 +184,10 @@ procedure TMCPHttpResponseStream.Finish(const FinalJson: string);
 begin
   FLock.Enter;
   try
-    if not FOpened or FBroken then
+    const CanWrite = FOpened and not FBroken and not FClosed;
+    if not CanWrite then
       Exit;
+    FClosed := True;
     try
       if FinalJson <> '' then
         WriteEvent(FinalJson);

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -14,6 +14,7 @@ uses
   IdHTTPServer,
   IdContext,
   IdCustomHTTPServer,
+  IdHeaderList,
   IdGlobal,
   IdGlobalProtocols,
   IdSocketHandle,
@@ -31,6 +32,11 @@ uses
   MCPServer.JsonRpcProcessor;
 
 type
+  TMCPDiscardedBody = class(TMemoryStream)
+  public
+    function Write(const Buffer; Count: Longint): Longint; override;
+  end;
+
   TMCPIdHTTPServer = class(TComponent)
   private
     FHTTPServer: TIdHTTPServer;
@@ -78,6 +84,9 @@ type
     function HeaderPresent(RequestInfo: TIdHTTPRequestInfo; const Name: string): Boolean;
     procedure CloseSubscriptions;
     function HeaderValue(RequestInfo: TIdHTTPRequestInfo; const Name: string): string;
+    function IsListedHeader(const List, Name: string): Boolean;
+    procedure HandleCreatePostStream(Context: TIdContext; Headers: TIdHeaderList; var VPostStream: TStream);
+    function MaxBodyBytes: Integer;
   public
     constructor Create(Owner: TComponent); override;
     destructor Destroy; override;
@@ -138,6 +147,13 @@ const
   ANY_IPV4 = '0.0.0.0';
   ANY_IPV6 = '::';
 
+{ TMCPDiscardedBody }
+
+function TMCPDiscardedBody.Write(const Buffer; Count: Longint): Longint;
+begin
+  Result := Count;
+end;
+
 { TMCPIdHTTPServer }
 
 constructor TMCPIdHTTPServer.Create(Owner: TComponent);
@@ -153,6 +169,7 @@ begin
   FHTTPServer.OnCommandOther := HandleHTTPRequest;
   FHTTPServer.OnQuerySSLPort := HandleQuerySSLPort;
   FHTTPServer.OnParseAuthentication := HandleParseAuthentication;
+  FHTTPServer.OnCreatePostStream := HandleCreatePostStream;
   FSSLHandler := nil;
 end;
 
@@ -351,6 +368,32 @@ begin
   Result := Trim(RequestInfo.RawHeaders.Values[Name]);
 end;
 
+function TMCPIdHTTPServer.IsListedHeader(const List, Name: string): Boolean;
+begin
+  for var Listed in List.Split([',']) do
+  begin
+    if SameText(Listed.Trim, Name) then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
+function TMCPIdHTTPServer.MaxBodyBytes: Integer;
+begin
+  Result := TMCPSettings.DEFAULT_MAX_REQUEST_BODY_BYTES;
+  if Assigned(FSettings) then
+    Result := FSettings.MaxRequestBodyBytes;
+end;
+
+procedure TMCPIdHTTPServer.HandleCreatePostStream(Context: TIdContext; Headers: TIdHeaderList;
+  var VPostStream: TStream);
+begin
+  const Declared = StrToInt64Def(Headers.Values['Content-Length'], 0);
+  const TooLarge = (Declared > MaxBodyBytes);
+  if TooLarge then
+    VPostStream := TMCPDiscardedBody.Create;
+end;
+
 procedure TMCPIdHTTPServer.HandleHTTPRequest(Context: TIdContext;
   RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
 begin
@@ -358,10 +401,10 @@ begin
   try
     TServerStatusResource.IncrementRequestCount;
 
+    ApplyCorsHeaders(RequestInfo, ResponseInfo);
+
     if not ValidateHost(RequestInfo, ResponseInfo) or not ValidateOrigin(RequestInfo, ResponseInfo) then
       Exit;
-
-    ApplyCorsHeaders(RequestInfo, ResponseInfo);
 
     var Endpoint := '/mcp';
     var EndpointInfoPath := '';
@@ -469,9 +512,10 @@ begin
   var AllowHeaders := CORS_ALLOW_HEADERS;
   for var Requested in HeaderValue(RequestInfo, 'Access-Control-Request-Headers').Split([',']) do
   begin
-    var Name := Requested.Trim;
-    if (Name <> '') and (Pos(LowerCase(Name), LowerCase(AllowHeaders)) = 0) then
-      AllowHeaders := AllowHeaders + ', ' + Name;
+    const Name = Requested.Trim;
+    const IsNew = ((Name <> '') and not IsListedHeader(AllowHeaders, Name));
+    if IsNew then
+      AllowHeaders := Format('%s, %s', [AllowHeaders, Name]);
   end;
 
   ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Methods'] := CORS_ALLOW_METHODS;
@@ -603,18 +647,17 @@ end;
 procedure TMCPIdHTTPServer.HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo;
   ResponseInfo: TIdHTTPResponseInfo; const Principal: TMCPPrincipal);
 begin
-  var MaxBodyBytes: Integer := TMCPSettings.DEFAULT_MAX_REQUEST_BODY_BYTES;
   var MaxDepth: Integer := TMCPSettings.DEFAULT_MAX_JSON_DEPTH;
   if Assigned(FSettings) then
-  begin
-    MaxBodyBytes := FSettings.MaxRequestBodyBytes;
     MaxDepth := FSettings.MaxJsonDepth;
-  end;
 
-  if Assigned(RequestInfo.PostStream) and (RequestInfo.PostStream.Size > MaxBodyBytes) then
+  const Limit = MaxBodyBytes;
+  const BodyTooLarge = Assigned(RequestInfo.PostStream)
+    and ((RequestInfo.PostStream is TMCPDiscardedBody) or (RequestInfo.PostStream.Size > Limit));
+  if BodyTooLarge then
   begin
     SendJsonRpcError(ResponseInfo, HTTP_PAYLOAD_TOO_LARGE, JSONRPC_INVALID_REQUEST,
-      Format('Request body exceeds %d bytes', [MaxBodyBytes]));
+      Format('Request body exceeds %d bytes', [Limit]));
     Exit;
   end;
 

--- a/src/Server/MCPServer.StdioChannel.pas
+++ b/src/Server/MCPServer.StdioChannel.pas
@@ -27,6 +27,7 @@ type
     FEndOfStream: Boolean;
     function Fill: Boolean;
     function DecodeLine(Start, Count: Integer; out Line: string): TMCPLineStatus;
+    function RoundTrips(const Line: string; const Start, Count: Integer): Boolean;
   public
     constructor Create(Stream: TStream; MaxLineBytes: Integer);
     function ReadLine(out Line: string; out Status: TMCPLineStatus): Boolean;
@@ -111,6 +112,17 @@ begin
   Result := True;
 end;
 
+function TMCPLineReader.RoundTrips(const Line: string; const Start, Count: Integer): Boolean;
+begin
+  const Encoded = TEncoding.UTF8.GetBytes(Line);
+  const SameLength = (Length(Encoded) = Count);
+  if not SameLength then
+    Exit(False);
+  if Count = 0 then
+    Exit(True);
+  Result := CompareMem(@Encoded[0], @FPending[Start], Count);
+end;
+
 function TMCPLineReader.DecodeLine(Start, Count: Integer; out Line: string): TMCPLineStatus;
 begin
   if (Count > 0) and (FPending[Start + Count - 1] = 13) then
@@ -128,8 +140,13 @@ begin
     Line := '';
     Exit(TMCPLineStatus.InvalidUtf8);
   end;
-  if (Line = '') and (Count > 0) then
+
+  const IsValidUtf8 = RoundTrips(Line, Start, Count);
+  if not IsValidUtf8 then
+  begin
+    Line := '';
     Exit(TMCPLineStatus.InvalidUtf8);
+  end;
   Result := TMCPLineStatus.Ok;
 end;
 

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -44,6 +44,7 @@ type
     const SHUTDOWN_CANCEL_GRACE_MS = 500;
     const QUEUE_DEPTH = 1024;
     const LISTENER_POLL_MS = 10;
+    const QUEUE_PUSH_TIMEOUT_MS = 1000;
   strict private
     FManagerRegistry: IMCPManagerRegistry;
     FCoreManager: IMCPCapabilityManager;
@@ -57,6 +58,7 @@ type
     FShutdownDrainMs: Integer;
     FWorkerStuck: Boolean;
     FListeners: Integer;
+    FStartedWorkers: Integer;
     function GetSettings: TMCPSettings;
     procedure SetSettings(const Value: TMCPSettings);
     function Hints: TMCPTransportHints;
@@ -330,20 +332,30 @@ begin
           SendError(RequestId, JSONRPC_INVALID_REQUEST, Format('Request id %s is still in flight', [RequestId.AsText]));
           Exit;
         end;
-        if Method = MCP_METHOD_SUBSCRIPTIONS_LISTEN then
-        begin
-          StartListener(Message);
+        try
+          if Method = MCP_METHOD_SUBSCRIPTIONS_LISTEN then
+          begin
+            StartListener(Message);
+            Queued := True;
+            Exit;
+          end;
+          const Accepted = (FQueue.PushItem(Message) = TWaitResult.wrSignaled);
+          if not Accepted then
+          begin
+            FTracker.Release(RequestId);
+            SendError(RequestId, JSONRPC_INTERNAL_ERROR, 'Server is shutting down');
+            Exit;
+          end;
           Queued := True;
           Exit;
+        except
+          on E: Exception do
+          begin
+            FTracker.Release(RequestId);
+            SendError(RequestId, JSONRPC_INTERNAL_ERROR, Format('Request could not be started: %s', [E.Message]));
+            Exit;
+          end;
         end;
-        if FQueue.PushItem(Message) <> TWaitResult.wrSignaled then
-        begin
-          FTracker.Release(RequestId);
-          SendError(RequestId, JSONRPC_INTERNAL_ERROR, 'Server is shutting down');
-          Exit;
-        end;
-        Queued := True;
-        Exit;
       end;
     end;
 
@@ -428,27 +440,33 @@ end;
 
 procedure TMCPStdioTransport.StartWorkers;
 begin
-  var Count := WorkerCount;
-  FQueue := TThreadedQueue<TJSONValue>.Create(QUEUE_DEPTH, INFINITE, INFINITE);
-  FWorkersDone := TCountdownEvent.Create(Count);
-  for var I := 1 to Count do
+  FStartedWorkers := WorkerCount;
+  FQueue := TThreadedQueue<TJSONValue>.Create(QUEUE_DEPTH, QUEUE_PUSH_TIMEOUT_MS, INFINITE);
+  FWorkersDone := TCountdownEvent.Create(FStartedWorkers);
+  for var WorkerNumber := 1 to FStartedWorkers do
+  begin
     TMCPStdioWorker.Create(Self);
-  TLogger.Info(Format('STDIO transport started: %d worker thread(s), logging to stderr', [Count]));
+  end;
+  TLogger.Info(Format('STDIO transport started: %d worker thread(s), logging to stderr', [FStartedWorkers]));
 end;
 
 procedure TMCPStdioTransport.DrainAndStop;
 begin
-  for var I := 1 to WorkerCount do
+  for var WorkerNumber := 1 to FStartedWorkers do
+  begin
     FQueue.PushItem(nil);
+  end;
 
-  if FWorkersDone.WaitFor(Cardinal(FShutdownDrainMs)) <> TWaitResult.wrSignaled then
+  const Drained = (FWorkersDone.WaitFor(Cardinal(FShutdownDrainMs)) = TWaitResult.wrSignaled);
+  if not Drained then
   begin
     FTracker.CancelAll('stdin closed');
     FWorkersDone.WaitFor(SHUTDOWN_CANCEL_GRACE_MS);
   end;
   CloseSubscriptions;
 
-  if FWorkersDone.IsSet then
+  const AllStopped = (FWorkersDone.IsSet and (AtomicCmpExchange(FListeners, 0, 0) = 0));
+  if AllStopped then
   begin
     FWorkersDone.Free;
     FQueue.Free;

--- a/src/Tools/MCPServer.Tool.Result.pas
+++ b/src/Tools/MCPServer.Tool.Result.pas
@@ -14,9 +14,11 @@ type
   TMCPToolResult = class
   private
     FContent: TJSONArray;
+    FPendingAnnotations: TJSONObject;
     FStructuredContent: TJSONValue;
     FMeta: TJSONObject;
     FIsError: Boolean;
+    procedure AddBlock(const Block: TJSONObject);
     function BuildContent(Era: TMCPProtocolEra): TJSONArray;
   public
     constructor Create;
@@ -58,6 +60,7 @@ end;
 
 destructor TMCPToolResult.Destroy;
 begin
+  FPendingAnnotations.Free;
   FContent.Free;
   FStructuredContent.Free;
   FMeta.Free;
@@ -66,7 +69,7 @@ end;
 
 function TMCPToolResult.AddText(const Text: string): TMCPToolResult;
 begin
-  FContent.AddElement(CreateTextBlock(Text));
+  AddBlock(CreateTextBlock(Text));
   Result := Self;
 end;
 
@@ -77,7 +80,7 @@ end;
 
 function TMCPToolResult.AddImage(const Base64Data, MimeType: string): TMCPToolResult;
 begin
-  FContent.AddElement(CreateImageBlock(Base64Data, MimeType));
+  AddBlock(CreateImageBlock(Base64Data, MimeType));
   Result := Self;
 end;
 
@@ -88,36 +91,48 @@ end;
 
 function TMCPToolResult.AddAudio(const Base64Data, MimeType: string): TMCPToolResult;
 begin
-  FContent.AddElement(CreateAudioBlock(Base64Data, MimeType));
+  AddBlock(CreateAudioBlock(Base64Data, MimeType));
   Result := Self;
 end;
 
 function TMCPToolResult.AddResourceLink(const Uri, Name, Description, MimeType: string): TMCPToolResult;
 begin
-  FContent.AddElement(CreateResourceLinkBlock(Uri, Name, Description, MimeType));
+  AddBlock(CreateResourceLinkBlock(Uri, Name, Description, MimeType));
   Result := Self;
 end;
 
 function TMCPToolResult.AddEmbeddedText(const Uri, MimeType, Text: string): TMCPToolResult;
 begin
-  FContent.AddElement(CreateEmbeddedTextBlock(Uri, MimeType, Text));
+  AddBlock(CreateEmbeddedTextBlock(Uri, MimeType, Text));
   Result := Self;
 end;
 
 function TMCPToolResult.AddEmbeddedBlob(const Uri, MimeType: string; const Data: TBytes): TMCPToolResult;
 begin
-  FContent.AddElement(CreateEmbeddedBlobBlock(Uri, MimeType, EncodeBase64Blob(Data)));
+  AddBlock(CreateEmbeddedBlobBlock(Uri, MimeType, EncodeBase64Blob(Data)));
   Result := Self;
+end;
+
+procedure TMCPToolResult.AddBlock(const Block: TJSONObject);
+begin
+  FContent.AddElement(Block);
+  if Assigned(FPendingAnnotations) then
+  begin
+    Block.AddPair('annotations', FPendingAnnotations);
+    FPendingAnnotations := nil;
+  end;
 end;
 
 function TMCPToolResult.WithAnnotations(const Annotations: TJSONObject): TMCPToolResult;
 begin
-  if FContent.Count = 0 then
+  const HasBlock = (FContent.Count > 0);
+  if HasBlock then
+    TJSONObject(FContent.Items[FContent.Count - 1]).AddPair('annotations', Annotations)
+  else
   begin
-    Annotations.Free;
-    raise EInvalidOperation.Create('WithAnnotations needs a content block to attach to');
+    FPendingAnnotations.Free;
+    FPendingAnnotations := Annotations;
   end;
-  TJSONObject(FContent.Items[FContent.Count - 1]).AddPair('annotations', Annotations);
   Result := Self;
 end;
 

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -91,6 +91,7 @@ type
     [Test] procedure Auth_ScopedTool_Is403_WithInsufficientScope;
     [Test] procedure Auth_ScopedTool_OnOpenServer_Is403;
     [Test] procedure Host_NotAllowed_Is403;
+    [Test] procedure Rejection_CarriesCorsHeaders;
   end;
 
 implementation
@@ -737,6 +738,15 @@ begin
 
   FSettings.AllowedHosts := '127.0.0.1:*';
   Assert.AreEqual(200, Post(LEGACY_PING, []).Status);
+end;
+
+procedure THttpTransportTests.Rejection_CarriesCorsHeaders;
+begin
+  FSettings.CorsEnabled := True;
+  var Denied := Post(LEGACY_PING, ['Origin: http://evil.example']);
+  Assert.AreEqual(403, Denied.Status);
+  Assert.AreEqual('http://evil.example', Denied.Header('Access-Control-Allow-Origin'), 'a browser can read the error');
+  Assert.IsTrue(Denied.Header('Access-Control-Expose-Headers').Contains('WWW-Authenticate'));
 end;
 
 end.

--- a/tests/MCPServer.Tests.Mrtr.pas
+++ b/tests/MCPServer.Tests.Mrtr.pas
@@ -4,6 +4,7 @@ interface
 
 uses
   DUnitX.TestFramework,
+  System.SysUtils,
   System.JSON,
   MCPServer.Types,
   MCPServer.RequestContext,
@@ -14,6 +15,8 @@ uses
 type
   [TestFixture]
   TRequestStateSealerTests = class
+  private
+    function Base64Url(const Bytes: TBytes): string;
   public
     [Test] procedure Seal_Open_RoundTripsState;
     [Test] procedure Open_TamperedToken_Fails;
@@ -22,6 +25,8 @@ type
     [Test] procedure Open_OtherKey_Fails;
     [Test] procedure DigestOf_IgnoresMetaInputResponsesAndRequestState;
     [Test] procedure EmptyKey_IsEphemeral;
+    [Test] procedure EmptyKey_DiffersPerInstance;
+    [Test] procedure Open_PayloadIsNotAnObject_IsInvalidParams;
   end;
 
   [TestFixture]
@@ -72,8 +77,9 @@ type
 implementation
 
 uses
-  System.SysUtils,
   System.Classes,
+  System.Hash,
+  System.NetEncoding,
   MCPServer.Errors,
   MCPServer.Mrtr;
 
@@ -83,6 +89,12 @@ const
   PRINCIPAL_A = 'alice';
 
 { TRequestStateSealerTests }
+
+function TRequestStateSealerTests.Base64Url(const Bytes: TBytes): string;
+begin
+  Result := TNetEncoding.Base64.EncodeBytesToString(Bytes)
+    .Replace(#13, '').Replace(#10, '').Replace('+', '-').Replace('/', '_').TrimRight(['=']);
+end;
 
 procedure TRequestStateSealerTests.Seal_Open_RoundTripsState;
 begin
@@ -210,6 +222,43 @@ begin
     Sealer.Open(Token, 'tools/call', DIGEST_A, PRINCIPAL_A).Free;
   finally
     Fixed.Free;
+    Sealer.Free;
+  end;
+end;
+
+procedure TRequestStateSealerTests.EmptyKey_DiffersPerInstance;
+begin
+  var First := TMCPRequestStateSealer.Create('');
+  var Second := TMCPRequestStateSealer.Create('');
+  try
+    var FirstToken := First.Seal(nil, 'tools/call', DIGEST_A, PRINCIPAL_A);
+    var SecondToken := Second.Seal(nil, 'tools/call', DIGEST_A, PRINCIPAL_A);
+    Assert.AreNotEqual(FirstToken, SecondToken, 'a random key is not derived from the clock');
+    Assert.WillRaise(
+      procedure
+      begin
+        Second.Open(FirstToken, 'tools/call', DIGEST_A, PRINCIPAL_A).Free;
+      end, EMCPError, 'another instance cannot open the token');
+  finally
+    Second.Free;
+    First.Free;
+  end;
+end;
+
+procedure TRequestStateSealerTests.Open_PayloadIsNotAnObject_IsInvalidParams;
+begin
+  var Sealer := TMCPRequestStateSealer.Create(SEALER_KEY);
+  try
+    var Payload := TEncoding.UTF8.GetBytes('"a signed string, not an object"');
+    var Signature := THashSHA2.GetHMACAsBytes(Payload, TEncoding.UTF8.GetBytes(SEALER_KEY),
+      THashSHA2.TSHA2Version.SHA256);
+    var Token := Base64Url(Payload) + '.' + Base64Url(Signature);
+    Assert.WillRaise(
+      procedure
+      begin
+        Sealer.Open(Token, 'tools/call', DIGEST_A, PRINCIPAL_A).Free;
+      end, EMCPError);
+  finally
     Sealer.Free;
   end;
 end;

--- a/tests/MCPServer.Tests.Prompt.pas
+++ b/tests/MCPServer.Tests.Prompt.pas
@@ -37,6 +37,7 @@ type
     [Test] procedure ContentIsASingleObject_NotAnArray;
     [Test] procedure Image_Audio_ResourceLink_Embedded_Blocks;
     [Test] procedure WithAnnotations_AttachesToLastMessage;
+    [Test] procedure WithAnnotations_BeforeAnyMessage_AttachesToTheNextMessage;
     [Test] procedure ToJson_ReturnsAClone;
   end;
 
@@ -116,6 +117,22 @@ begin
     Assert.AreEqual('A file', Json.Items[2].GetValue<string>('content.description'));
     Assert.AreEqual('resource', Json.Items[3].GetValue<string>('content.type'));
     Assert.AreEqual('body', Json.Items[3].GetValue<string>('content.resource.text'));
+  finally
+    Json.Free;
+    Messages.Free;
+  end;
+end;
+
+procedure TPromptMessagesTests.WithAnnotations_BeforeAnyMessage_AttachesToTheNextMessage;
+begin
+  var Annotations := TJSONObject.Create;
+  Annotations.AddPair('priority', TJSONNumber.Create(0.5));
+  var Messages := TMCPPromptMessages.Create.WithAnnotations(Annotations).AddText('user', 'first');
+  Messages.AddText('user', 'second');
+  var Json := Messages.ToJson;
+  try
+    Assert.AreEqual(0.5, Json.Items[0].GetValue<Double>('content.annotations.priority'), 0.0001);
+    Assert.IsNull(Json.Items[1].FindValue('content.annotations'));
   finally
     Json.Free;
     Messages.Free;

--- a/tests/MCPServer.Tests.Registration.pas
+++ b/tests/MCPServer.Tests.Registration.pas
@@ -77,7 +77,7 @@ begin
     begin
       TMCPRegistry.CreateTool('no_such_tool');
     end;
-  Assert.WillRaise(Probe, Exception);
+  Assert.WillRaise(Probe, EMCPRegistryNotFound);
 end;
 
 procedure TRegistryTests.CreateResource_UnknownUri_Raises;
@@ -87,7 +87,7 @@ begin
     begin
       TMCPRegistry.CreateResource('nope://missing');
     end;
-  Assert.WillRaise(Probe, Exception);
+  Assert.WillRaise(Probe, EMCPRegistryNotFound);
 end;
 
 procedure TRegistryTests.CreateTool_ReturnsFreshInstances;

--- a/tests/MCPServer.Tests.StdioChannel.pas
+++ b/tests/MCPServer.Tests.StdioChannel.pas
@@ -20,6 +20,7 @@ type
     [Test] procedure Reader_DecodesUtf8;
     [Test] procedure Reader_ReportsOverlongLine_AndContinues;
     [Test] procedure Reader_ReportsInvalidUtf8_AndContinues;
+    [Test] procedure Reader_ReportsReplacedUtf8_AsInvalid;
     [Test] procedure Reader_OverlongLineWithoutNewline_EndsStream;
     [Test] procedure Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
     [Test] procedure Reader_EmptyStream_HasNoLines;
@@ -140,6 +141,20 @@ begin
   Assert.AreEqual(2, Integer(Length(Lines)));
   Assert.IsTrue(Statuses[0] = TMCPLineStatus.InvalidUtf8, 'first line is not UTF-8');
   Assert.AreEqual('ok', Lines[1]);
+end;
+
+procedure TStdioChannelTests.Reader_ReportsReplacedUtf8_AsInvalid;
+var
+  Statuses: TArray<TMCPLineStatus>;
+begin
+  var Truncated := TBytes.Create($41, $C3) + TEncoding.UTF8.GetBytes(#10);
+  var Overlong := TBytes.Create($C0, $AF) + TEncoding.UTF8.GetBytes(#10'ok'#10);
+  var Lines := ReadAll(Truncated + Overlong, 1024, Statuses);
+  Assert.AreEqual(3, Integer(Length(Lines)));
+  Assert.IsTrue(Statuses[0] = TMCPLineStatus.InvalidUtf8, 'a truncated sequence is not UTF-8');
+  Assert.IsTrue(Statuses[1] = TMCPLineStatus.InvalidUtf8, 'an overlong sequence is not UTF-8');
+  Assert.IsTrue(Statuses[2] = TMCPLineStatus.Ok);
+  Assert.AreEqual('ok', Lines[2]);
 end;
 
 procedure TStdioChannelTests.Reader_EmptyStream_HasNoLines;

--- a/tests/MCPServer.Tests.ToolResult.pas
+++ b/tests/MCPServer.Tests.ToolResult.pas
@@ -16,6 +16,7 @@ type
     [Test] procedure Error_SetsIsError;
     [Test] procedure Meta_IsEmitted;
     [Test] procedure Annotations_AttachToLastBlock;
+    [Test] procedure Annotations_BeforeAnyBlock_AttachToTheNextBlock;
     [Test] procedure Base64Blob_HasNoLineBreaks;
   end;
 
@@ -120,6 +121,21 @@ begin
   var Json := ToolResult.ToJson(TMCPProtocolEra.Modern);
   try
     Assert.AreEqual('abc', Json.GetValue<string>('_meta["com.example/trace"]'));
+  finally
+    Json.Free;
+    ToolResult.Free;
+  end;
+end;
+
+procedure TToolResultTests.Annotations_BeforeAnyBlock_AttachToTheNextBlock;
+begin
+  var Annotations := TJSONObject.Create;
+  Annotations.AddPair('priority', TJSONNumber.Create(0.5));
+  var ToolResult := TMCPToolResult.Create.WithAnnotations(Annotations).AddText('first').AddText('second');
+  var Json := ToolResult.ToJson(TMCPProtocolEra.Modern);
+  try
+    Assert.AreEqual(0.5, Json.GetValue<Double>('content[0].annotations.priority'), 0.0001);
+    Assert.IsNull(Json.FindValue('content[1].annotations'));
   finally
     Json.Free;
     ToolResult.Free;


### PR DESCRIPTION
## Summary

**Security and leaks.** The `requestState` signing key now comes from the operating system random generator (`BCryptGenRandom`, `/dev/urandom`) instead of a clock-seeded RNG, so tokens cannot be forged by guessing the seed and two processes never share a key. The canonical JSON encoder no longer leaks a string object per member, and a signed payload that is not an object is rejected instead of raising a cast error. The result builders keep annotations pending instead of raising mid-chain, and the log resources allocate nothing outside a protected block.

**Lifetime and threading.** An HTTP response stream refuses writes after its terminator. The stdio transport counts subscription threads before freeing what they use, releases a reserved request id when starting fails, and bounds its shutdown push. The subscriptions manager waits for its listeners, the resources manager guards its lookups with the same lock as its mutations, and the progress throttle is guarded like cancellation.

**Correctness.** Results are fully initialised on every path; an unknown registry entry raises a typed exception instead of being recognised by its message; a non-JSON result is an internal error instead of a leak; a nested dispatch restores the outer context; invalid UTF-8 on stdin is detected instead of silently replaced; CORS headers precede a rejection and header matching compares whole tokens; a body larger than the limit is discarded instead of buffered; an introspection failure answers 401; an unusable schema pattern is a validation error; a duplicate template variable is refused; a log level is percent-encoded into its URI; and sets over 64 elements and out-of-range integers no longer pass silently.

## Verification

- DUnitX: 376/376 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 and Release build clean.
- HTTP goldens re-recorded for the three cases the CORS ordering changes; conformance 155 and 59 with unchanged baselines; Inspector smoke 26 tools in four modes; stdio smoke passes.