### PR TITLE
Types instead of loose routines, typed exceptions and result records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,19 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- The content block helpers, the protocol version helpers and the redaction
+  helpers are class functions on `TMCPContentBlock`, `TMCPProtocolVersion` and
+  `TLogger`; `MCPServer.Schema.Generator` keeps its RTTI context in a class
+  variable instead of an `initialization` section.
+- `IMCPAuthorizer.Authorize` returns a `TMCPAuthResult`, a custom authorizer
+  overrides `TryValidateToken`, `TMCPLineReader.TryReadLine` returns a
+  `TMCPLine`, `TMCPSchemaValidator.TryValidate` replaces `Validate`, and
+  `TMCPResourceTemplateBase.CompilePattern` returns a `TMCPCompiledTemplate`.
+- `TMCPRegistry` raises `EMCPRegistryNotFound`, the managers raise
+  `EMCPError.MethodNotFound` for a method they do not handle, and
+  `TMCPIdHTTPServer` raises `EMCPConfigurationError`; no code path raises the
+  base `Exception` any more.
+
 - `TMCPToolBase` (the non-generic, hand-written-schema base) now validates
   its arguments against `BuildSchema` before calling the tool: the abstract
   method a descendant overrides is `DoExecute`, not `Execute`, which is now

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -214,6 +214,25 @@ lists with a lock now, so run-time changes are safe from any thread.
 stdin close the open subscriptions with a completion response before the
 transport goes down (up to one second, or the stdio drain time).
 
+## Renamed and reshaped API
+
+These types are new in this release, so the change only affects code written
+against a pre-release build:
+
+- The content block helpers are class functions on `TMCPContentBlock`
+  (`TMCPContentBlock.Text`, `.Image`, `.Audio`, `.ResourceLink`,
+  `.EmbeddedText`, `.EmbeddedBlob`, `.EncodeBlob`).
+- The protocol version helpers are class functions on `TMCPProtocolVersion`
+  (`IsLegacy`, `IsModern`, `NegotiateLegacy`).
+- `IMCPAuthorizer.Authorize` returns a `TMCPAuthResult` (decision, principal,
+  challenge) instead of writing two `out` parameters, and the method a custom
+  authorizer overrides is `TryValidateToken`.
+- `TMCPLineReader.TryReadLine` returns a `TMCPLine` (status and text).
+- `TMCPSchemaValidator.TryValidate` is the new name of `Validate`.
+- `TMCPRegistry` raises `EMCPRegistryNotFound` for an unknown name, the
+  managers raise `EMCPError.MethodNotFound`, and `TMCPIdHTTPServer` raises
+  `EMCPConfigurationError` for a missing registry or certificate.
+
 ## Library use
 
 - `TMCPJsonRpcProcessor.ProcessRequest` and the manager interfaces are

--- a/coding-rules.md
+++ b/coding-rules.md
@@ -1,33 +1,71 @@
 # Coding rules
 
-This file records where this repository deviates from the GDK Delphi coding standard and why. Everything not listed here follows that standard.
+The code in this repository follows a house style: inline variables, `const`
+parameters, named constants, small units, no comments, and zero compiler hints
+or warnings. This file records the conventions that a reader might otherwise
+take for mistakes, and the places where the library deliberately keeps a
+pattern that a stricter reading would reject.
 
-## Exceptions
+## Conventions
+
+### Constants are `UPPER_CASE`
+
+Protocol values carry the names the MCP specification uses
+(`MCP_PROTOCOL_VERSION_2026_07_28`, `JSONRPC_INVALID_PARAMS`), and the rest of
+the code follows the same shape (`READ_CHUNK_BYTES`,
+`DEFAULT_KEEP_ALIVE_INTERVAL_MS`). One convention across the repository is
+worth more than matching a general preference for `PascalCase`.
 
 ### Registration in `initialization` sections
 
-Tools, prompts, resources and resource templates register themselves in the `initialization` section of their own unit. Consumers add a unit to their project's `uses` clause and the item is available; that is the public contract of the library and the reason no central registration list exists. New tool, prompt and resource units follow the same pattern.
+Tools, prompts, resources and resource templates register themselves in the
+`initialization` section of their own unit. Consumers add a unit to their
+project's `uses` clause and the item is available; that is the public contract
+of the library and the reason no central registration list exists. New tool,
+prompt and resource units follow the same pattern. Nothing else uses
+`initialization` or `finalization`: state that outlives a call lives in a
+`class var` with a `class constructor`.
+
+### One unit per concept, not per type
+
+A unit holds the types that belong to one mechanism: the subscriptions manager
+with its filter and its subscription, the stdio transport with its tracker and
+its worker, the exception classes together, the sample tools per theme.
+`MCPServer.Types` is the umbrella every consumer puts in its `uses` clause, so
+its interfaces, attributes and records stay in one place.
 
 ### System.Generics.Collections
 
-The library has no third-party dependencies so that it can be dropped into any Delphi project. `System.Generics.Collections` is used instead of Spring4D collections.
+The library has no third-party dependencies so that it can be dropped into any
+Delphi project. `System.Generics.Collections` is used instead of Spring4D
+collections.
 
 ### Public global functions
 
-`MCPServer.Types` and a few other units expose global functions (`IsJsonString`, `StandardInputStream`, `StandardOutputStream`) because they are part of the public API and because attribute or record helpers cannot host them. Internal helpers still belong in classes or records.
+`MCPServer.Types` exposes `IsJsonString` and `MCPServer.StdioChannel` exposes
+`StandardInputStream` and `StandardOutputStream`, because they are part of the
+public API and cannot live on a type. Operating-system imports are declared
+where they are used (`BCryptGenRandom` in `MCPServer.RequestState`). Every
+other routine belongs to a class or a record.
 
-### Constructor parameter names in attributes
+### Parameter names in attributes and exceptions
 
-Schema attributes and exception classes keep the `A` prefix on constructor parameters where the parameter would otherwise shadow a property of the same class (`Code`, `Message`, `Description`). Elsewhere parameters carry no prefix.
+Schema attributes and exception classes keep the `A` prefix on constructor
+parameters where the parameter would otherwise shadow a property of the same
+class (`Code`, `Message`, `Description`). Elsewhere parameters carry no prefix.
 
 ### Framework callback signatures
 
-Indy event handlers keep the signature Indy declares, including `var` parameters (for example `OnQuerySSLPort`).
+Indy event handlers keep the signature Indy declares, including `var`
+parameters (`OnQuerySSLPort`, `OnCreatePostStream`, `OnParseAuthentication`).
 
 ### DUnitX fixtures
 
-The test runner uses RTTI discovery (`UseRTTI := True`). Test units have no `initialization` section.
+The test runner uses RTTI discovery. Test units have no `initialization`
+section, and every fixture carries `[TestFixture]`.
 
 ### Class section markers
 
-The `{ TClassName }` markers the IDE generates in the implementation section are kept. No other comments are used; behaviour is documented in the README, CHANGELOG and MIGRATION guide.
+The `{ TClassName }` markers the IDE generates in the implementation section
+are kept. No other comments are used; behaviour is documented in the README,
+the CHANGELOG and the migration guide.

--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -27,10 +27,17 @@ type
     class function InsufficientScope(const Scope: string): TMCPAuthChallenge; static;
   end;
 
+  TMCPAuthResult = record
+    Decision: TMCPAuthDecision;
+    Principal: TMCPPrincipal;
+    Challenge: TMCPAuthChallenge;
+    class function Allowed(const Principal: TMCPPrincipal): TMCPAuthResult; static;
+    class function Denied(const Decision: TMCPAuthDecision; const Challenge: TMCPAuthChallenge): TMCPAuthResult; static;
+  end;
+
   IMCPAuthorizer = interface
     ['{7B3D5F1A-9C2E-4A8B-B6D0-1E3F5A7C9B2D}']
-    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
-      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    function Authorize(const BearerToken, HttpMethod, Path: string): TMCPAuthResult;
   end;
 
   RequiresScopeAttribute = class(TCustomAttribute)
@@ -63,8 +70,7 @@ type
     FScopes: TArray<string>;
   public
     constructor Create(const Tokens: TArray<string>; const Scopes: TArray<string> = nil);
-    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
-      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    function Authorize(const BearerToken, HttpMethod, Path: string): TMCPAuthResult;
     class function SameToken(const Presented, Expected: TBytes): Boolean; static;
   end;
 
@@ -73,14 +79,13 @@ type
     FExpectedAudience: string;
     FRequiredScopes: TArray<string>;
   protected
-    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; virtual; abstract;
+    function TryValidateToken(const Token: string; out Claims: TJSONObject): Boolean; virtual; abstract;
     function AudienceMatches(const Claims: TJSONObject): Boolean; virtual;
     function IsExpired(const Claims: TJSONObject): Boolean; virtual;
     function ScopesOf(const Claims: TJSONObject): TArray<string>; virtual;
   public
     constructor Create(const ExpectedAudience: string);
-    function Authorize(const BearerToken, HttpMethod, Path: string; out Principal: TMCPPrincipal;
-      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    function Authorize(const BearerToken, HttpMethod, Path: string): TMCPAuthResult;
     property ExpectedAudience: string read FExpectedAudience;
     property RequiredScopes: TArray<string> read FRequiredScopes write FRequiredScopes;
   end;
@@ -92,7 +97,7 @@ type
     FClientSecret: string;
     FTimeoutMs: Integer;
   protected
-    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
+    function TryValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
   public
     const DEFAULT_TIMEOUT_MS = 5000;
     constructor Create(const ExpectedAudience, IntrospectionUrl, ClientId, ClientSecret: string);
@@ -143,6 +148,23 @@ begin
       Exit(True);
   end;
   Result := False;
+end;
+
+{ TMCPAuthResult }
+
+class function TMCPAuthResult.Allowed(const Principal: TMCPPrincipal): TMCPAuthResult;
+begin
+  Result := Default(TMCPAuthResult);
+  Result.Decision := TMCPAuthDecision.Allow;
+  Result.Principal := Principal;
+end;
+
+class function TMCPAuthResult.Denied(const Decision: TMCPAuthDecision;
+  const Challenge: TMCPAuthChallenge): TMCPAuthResult;
+begin
+  Result := Default(TMCPAuthResult);
+  Result.Decision := Decision;
+  Result.Challenge := Challenge;
 end;
 
 { TMCPAuthChallenge }
@@ -270,27 +292,25 @@ begin
   Result := TMCPConstantTime.SameBytes(Presented, Expected);
 end;
 
-function TMCPStaticBearerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string;
-  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+function TMCPStaticBearerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string): TMCPAuthResult;
 begin
-  Principal := TMCPPrincipal.None;
-  Challenge := TMCPAuthChallenge.None;
-  var Presented := TEncoding.UTF8.GetBytes(BearerToken);
+  const Presented = TEncoding.UTF8.GetBytes(BearerToken);
   var Matched: Integer := -1;
-  for var I := 0 to High(FTokens) do
+  for var Index := 0 to High(FTokens) do
   begin
-    if SameToken(Presented, FTokens[I]) then
-      Matched := Integer(I);
+    if SameToken(Presented, FTokens[Index]) then
+      Matched := Integer(Index);
   end;
 
-  if Matched < 0 then
-  begin
-    Challenge := TMCPAuthChallenge.InvalidToken('The bearer token is not recognised');
-    Exit(TMCPAuthDecision.Unauthorized);
-  end;
+  const IsKnown = (Matched >= 0);
+  if not IsKnown then
+    Exit(TMCPAuthResult.Denied(TMCPAuthDecision.Unauthorized,
+      TMCPAuthChallenge.InvalidToken('The bearer token is not recognised')));
+
+  var Principal := TMCPPrincipal.None;
   Principal.Subject := Format(STATIC_SUBJECT_FORMAT, [Matched + 1]);
   Principal.Scopes := FScopes;
-  Result := TMCPAuthDecision.Allow;
+  Result := TMCPAuthResult.Allowed(Principal);
 end;
 
 { TMCPOAuthResourceServerAuthorizer }
@@ -345,42 +365,36 @@ begin
   end;
 end;
 
-function TMCPOAuthResourceServerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string;
-  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+function TMCPOAuthResourceServerAuthorizer.Authorize(const BearerToken, HttpMethod, Path: string): TMCPAuthResult;
 var
   Claims: TJSONObject;
 begin
-  Principal := TMCPPrincipal.None;
-  Challenge := TMCPAuthChallenge.None;
-  if not ValidateToken(BearerToken, Claims) then
-  begin
-    Challenge := TMCPAuthChallenge.InvalidToken('The access token is not valid');
-    Exit(TMCPAuthDecision.Unauthorized);
-  end;
+  const IsValid = TryValidateToken(BearerToken, Claims);
+  if not IsValid then
+    Exit(TMCPAuthResult.Denied(TMCPAuthDecision.Unauthorized,
+      TMCPAuthChallenge.InvalidToken('The access token is not valid')));
 
   try
-    if not AudienceMatches(Claims) then
-    begin
-      Challenge := TMCPAuthChallenge.InvalidToken('The access token was not issued for this server');
-      Exit(TMCPAuthDecision.Unauthorized);
-    end;
-    if IsExpired(Claims) then
-    begin
-      Challenge := TMCPAuthChallenge.InvalidToken('The access token has expired');
-      Exit(TMCPAuthDecision.Unauthorized);
-    end;
+    const IsForThisServer = AudienceMatches(Claims);
+    if not IsForThisServer then
+      Exit(TMCPAuthResult.Denied(TMCPAuthDecision.Unauthorized,
+        TMCPAuthChallenge.InvalidToken('The access token was not issued for this server')));
 
+    const HasExpired = IsExpired(Claims);
+    if HasExpired then
+      Exit(TMCPAuthResult.Denied(TMCPAuthDecision.Unauthorized,
+        TMCPAuthChallenge.InvalidToken('The access token has expired')));
+
+    var Principal := TMCPPrincipal.None;
     Principal.Subject := Claims.GetValue<string>(CLAIM_SUBJECT, '');
     Principal.Scopes := ScopesOf(Claims);
     for var Required in FRequiredScopes do
     begin
       if not Principal.HasScope(Required) then
-      begin
-        Challenge := TMCPAuthChallenge.InsufficientScope(string.Join(SCOPE_SEPARATOR, FRequiredScopes));
-        Exit(TMCPAuthDecision.Forbidden);
-      end;
+        Exit(TMCPAuthResult.Denied(TMCPAuthDecision.Forbidden,
+          TMCPAuthChallenge.InsufficientScope(string.Join(SCOPE_SEPARATOR, FRequiredScopes))));
     end;
-    Result := TMCPAuthDecision.Allow;
+    Result := TMCPAuthResult.Allowed(Principal);
   finally
     Claims.Free;
   end;
@@ -399,7 +413,7 @@ begin
   FTimeoutMs := DEFAULT_TIMEOUT_MS;
 end;
 
-function TMCPIntrospectionAuthorizer.ValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
+function TMCPIntrospectionAuthorizer.TryValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
 begin
   Claims := nil;
   const Client = THTTPClient.Create;

--- a/src/Core/MCPServer.Logger.pas
+++ b/src/Core/MCPServer.Logger.pas
@@ -49,6 +49,8 @@ type
     constructor CreateInstance;
     procedure DoWriteLog(const Level: TLogLevel; const Message: string);
     procedure EnsureLogFile;
+    function OpenSharedLogStream: TFileStream;
+    procedure DisableFileLogging(const Reason: string);
     procedure DoCloseLogFile;
   public
     class constructor Create;
@@ -70,6 +72,8 @@ type
     class procedure Error(const Format: string; const Args: array of const); overload;
     class procedure Error(const Exception: Exception); overload;
 
+    class function IsSensitiveKey(const Key: string): Boolean;
+    class procedure RedactValue(const Value: TJSONValue);
     class function RedactJson(const Json: string): string;
 
     class property LogToConsole: Boolean read GetLogToConsole write SetLogToConsole;
@@ -137,11 +141,43 @@ end;
 
 procedure TLogger.EnsureLogFile;
 begin
-  if FLogToFile and not Assigned(FLogFile) then
-  begin
-    FLogFile := TStreamWriter.Create(FLogFileName, True, TEncoding.UTF8);
+  const AlreadyOpen = (not FLogToFile) or Assigned(FLogFile);
+  if AlreadyOpen then
+    Exit;
+
+  try
+    const LogStream = OpenSharedLogStream;
+    FLogFile := TStreamWriter.Create(LogStream, TEncoding.UTF8);
+    FLogFile.OwnStream;
     FLogFile.AutoFlush := True;
+  except
+    on E: Exception do
+      DisableFileLogging(E.Message);
   end;
+end;
+
+function TLogger.OpenSharedLogStream: TFileStream;
+begin
+  const Exists = FileExists(FLogFileName);
+  if Exists then
+    Result := TFileStream.Create(FLogFileName, fmOpenReadWrite or fmShareDenyNone)
+  else
+    Result := TFileStream.Create(FLogFileName, fmCreate or fmShareDenyNone);
+  Result.Seek(0, soEnd);
+end;
+
+procedure TLogger.DisableFileLogging(const Reason: string);
+begin
+  FLogToFile := False;
+  if not FLogToConsole then
+    Exit;
+
+  const Warning = Format('[WARN ] File logging disabled, cannot open "%s": %s', [FLogFileName, Reason]);
+  const ToStdErr = (FUseStdErr or FStdoutReserved);
+  if ToStdErr then
+    WriteLn(ErrOutput, Warning)
+  else
+    WriteLn(Warning);
 end;
 
 procedure TLogger.DoCloseLogFile;
@@ -198,7 +234,10 @@ begin
     begin
       EnsureLogFile;
       if Assigned(FLogFile) then
+      begin
+        FLogFile.BaseStream.Seek(0, soEnd);
         FLogFile.WriteLine(LogLine);
+      end;
     end;
 
     if Assigned(FOnLogMessage) then
@@ -253,7 +292,7 @@ begin
   Instance.DoWriteLog(TLogLevel.Error, System.SysUtils.Format('%s: %s', [Exception.ClassName, Exception.Message]));
 end;
 
-function IsSensitiveKey(const Key: string): Boolean;
+class function TLogger.IsSensitiveKey(const Key: string): Boolean;
 const
   EXACT_KEYS: array[0..2] of string = ('_meta', 'requestState', 'inputResponses');
   PARTIAL_KEYS: array[0..5] of string = ('token', 'secret', 'password', 'authorization', 'apikey', 'api_key');
@@ -269,7 +308,7 @@ begin
   Result := False;
 end;
 
-procedure RedactValue(const Value: TJSONValue);
+class procedure TLogger.RedactValue(const Value: TJSONValue);
 begin
   if Value is TJSONObject then
   begin

--- a/src/Managers/MCPServer.CompletionManager.pas
+++ b/src/Managers/MCPServer.CompletionManager.pas
@@ -91,7 +91,7 @@ begin
   if Method = 'completion/complete' then
     Result := Complete(Params, EraOf(Context))
   else
-    raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+    raise EMCPError.MethodNotFound(Method);
 end;
 
 function TMCPCompletionManager.ResolveTarget(const Ref: TJSONObject; Era: TMCPProtocolEra): IInterface;

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -43,7 +43,8 @@ implementation
 
 uses
   MCPServer.Capabilities,
-  MCPServer.RequestContext;
+  MCPServer.RequestContext,
+  MCPServer.Errors;
 
 const
   CACHE_SCOPE_PUBLIC = 'public';
@@ -99,7 +100,7 @@ begin
   else if Method = 'server/discover' then
     Result := Discover(Context)
   else
-    raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+    raise EMCPError.MethodNotFound(Method);
 end;
 
 function TMCPCoreManager.BuildServerInfo: TJSONObject;
@@ -168,7 +169,7 @@ begin
       if RequestedValue is TJSONString then
         Requested := TJSONString(RequestedValue).Value;
     end;
-    Negotiated := NegotiateLegacyProtocolVersion(Requested);
+    Negotiated := TMCPProtocolVersion.NegotiateLegacy(Requested);
   end;
 
   if Assigned(Params) then

--- a/src/Managers/MCPServer.PromptsManager.pas
+++ b/src/Managers/MCPServer.PromptsManager.pas
@@ -121,7 +121,7 @@ begin
   else if Method = 'prompts/get' then
     Result := GetPrompt(Params, EraOf(Context))
   else
-    raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+    raise EMCPError.MethodNotFound(Method);
 end;
 
 procedure TMCPPromptsManager.RegisterPrompt(const Prompt: IMCPPrompt);

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -142,7 +142,7 @@ begin
   else if Method = 'resources/templates/list' then
     Result := ListResourceTemplates(Params, EraOf(Context))
   else
-    raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+    raise EMCPError.MethodNotFound(Method);
 end;
 
 procedure TMCPResourcesManager.RegisterResource(const Resource: IMCPResource);
@@ -353,7 +353,7 @@ begin
       Result.AddPair('mimeType', Resource.MimeType);
 
     if Supports(Resource, IMCPBinaryResource, Binary) then
-      Result.AddPair('blob', EncodeBase64Blob(Binary.ReadBinary))
+      Result.AddPair('blob', TMCPContentBlock.EncodeBlob(Binary.ReadBinary))
     else
       Result.AddPair('text', Resource.Read);
   except

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -32,6 +32,9 @@ type
     procedure CheckCursor(const Params: TJSONObject);
     procedure ValidateToolName(const Name: string);
     procedure CheckRequiredScopes(const Tool: IMCPTool);
+    {$IFDEF DEBUG}
+    procedure WarnIfStructuredContentMismatchesSchema(const Tool: IMCPTool; const Result: TJSONObject);
+    {$ENDIF}
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
   private
     procedure RegisterTool(const Tool: IMCPTool);
@@ -77,7 +80,7 @@ const
   TOOL_NAME_PATTERN = '^[A-Za-z0-9_.\-]{1,128}$';
 
 {$IFDEF DEBUG}
-procedure WarnIfStructuredContentMismatchesSchema(const Tool: IMCPTool; const Result: TJSONObject);
+procedure TMCPToolsManager.WarnIfStructuredContentMismatchesSchema(const Tool: IMCPTool; const Result: TJSONObject);
 begin
   var OutputSchema := Tool.OutputSchema;
   try
@@ -86,7 +89,7 @@ begin
       Exit;
 
     var Errors: TArray<string>;
-    if not TMCPSchemaValidator.Validate(OutputSchema, StructuredContent, Errors) then
+    if not TMCPSchemaValidator.TryValidate(OutputSchema, StructuredContent, Errors) then
       TLogger.Warning(Format('Tool "%s" structuredContent does not match its outputSchema: %s',
         [Tool.Name, string.Join('; ', Errors)]));
   finally
@@ -155,7 +158,7 @@ begin
   else if Method = 'tools/call' then
     Result := CallTool(Params, EraOf(Context))
   else
-    raise Exception.CreateFmt('Method %s not handled by %s', [Method, GetCapabilityName]);
+    raise EMCPError.MethodNotFound(Method);
 end;
 
 procedure TMCPToolsManager.CheckRequiredScopes(const Tool: IMCPTool);

--- a/src/Prompts/MCPServer.Prompt.Base.pas
+++ b/src/Prompts/MCPServer.Prompt.Base.pas
@@ -131,46 +131,46 @@ end;
 
 function TMCPPromptMessages.AddText(const Role, Text: string): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateTextBlock(Text));
+  Result := AddMessage(Role, TMCPContentBlock.Text(Text));
 end;
 
 function TMCPPromptMessages.AddImage(const Role: string; const Data: TBytes;
   const MimeType: string): TMCPPromptMessages;
 begin
-  Result := AddImage(Role, EncodeBase64Blob(Data), MimeType);
+  Result := AddImage(Role, TMCPContentBlock.EncodeBlob(Data), MimeType);
 end;
 
 function TMCPPromptMessages.AddImage(const Role, Base64Data, MimeType: string): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateImageBlock(Base64Data, MimeType));
+  Result := AddMessage(Role, TMCPContentBlock.Image(Base64Data, MimeType));
 end;
 
 function TMCPPromptMessages.AddAudio(const Role: string; const Data: TBytes;
   const MimeType: string): TMCPPromptMessages;
 begin
-  Result := AddAudio(Role, EncodeBase64Blob(Data), MimeType);
+  Result := AddAudio(Role, TMCPContentBlock.EncodeBlob(Data), MimeType);
 end;
 
 function TMCPPromptMessages.AddAudio(const Role, Base64Data, MimeType: string): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateAudioBlock(Base64Data, MimeType));
+  Result := AddMessage(Role, TMCPContentBlock.Audio(Base64Data, MimeType));
 end;
 
 function TMCPPromptMessages.AddResourceLink(const Role, Uri, Name, Description,
   MimeType: string): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateResourceLinkBlock(Uri, Name, Description, MimeType));
+  Result := AddMessage(Role, TMCPContentBlock.ResourceLink(Uri, Name, Description, MimeType));
 end;
 
 function TMCPPromptMessages.AddEmbeddedText(const Role, Uri, MimeType, Text: string): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateEmbeddedTextBlock(Uri, MimeType, Text));
+  Result := AddMessage(Role, TMCPContentBlock.EmbeddedText(Uri, MimeType, Text));
 end;
 
 function TMCPPromptMessages.AddEmbeddedBlob(const Role, Uri, MimeType: string;
   const Data: TBytes): TMCPPromptMessages;
 begin
-  Result := AddMessage(Role, CreateEmbeddedBlobBlock(Uri, MimeType, EncodeBase64Blob(Data)));
+  Result := AddMessage(Role, TMCPContentBlock.EmbeddedBlob(Uri, MimeType, TMCPContentBlock.EncodeBlob(Data)));
 end;
 
 function TMCPPromptMessages.AddEmbeddedResource(const Role: string; const Resource: IMCPResource): TMCPPromptMessages;

--- a/src/Protocol/MCPServer.ContentBlocks.pas
+++ b/src/Protocol/MCPServer.ContentBlocks.pas
@@ -6,22 +6,26 @@ uses
   System.SysUtils,
   System.JSON;
 
-function CreateTextBlock(const Text: string): TJSONObject;
-function CreateImageBlock(const Base64Data, MimeType: string): TJSONObject;
-function CreateAudioBlock(const Base64Data, MimeType: string): TJSONObject;
-function CreateResourceLinkBlock(const Uri, Name: string; const Description: string = '';
-  const MimeType: string = ''): TJSONObject;
-function CreateEmbeddedTextBlock(const Uri, MimeType, Text: string): TJSONObject;
-function CreateEmbeddedBlobBlock(const Uri, MimeType, Base64Blob: string): TJSONObject;
-
-function EncodeBase64Blob(const Data: TBytes): string;
+type
+  TMCPContentBlock = record
+    class function Text(const Value: string): TJSONObject; static;
+    class function Image(const Base64Data, MimeType: string): TJSONObject; static;
+    class function Audio(const Base64Data, MimeType: string): TJSONObject; static;
+    class function ResourceLink(const Uri, Name: string; const Description: string = '';
+      const MimeType: string = ''): TJSONObject; static;
+    class function EmbeddedText(const Uri, MimeType, Text: string): TJSONObject; static;
+    class function EmbeddedBlob(const Uri, MimeType, Base64Blob: string): TJSONObject; static;
+    class function EncodeBlob(const Data: TBytes): string; static;
+  end;
 
 implementation
 
 uses
   System.NetEncoding;
 
-function EncodeBase64Blob(const Data: TBytes): string;
+{ TMCPContentBlock }
+
+class function TMCPContentBlock.EncodeBlob(const Data: TBytes): string;
 begin
   var Encoding := TBase64Encoding.Create(0);
   try
@@ -31,14 +35,14 @@ begin
   end;
 end;
 
-function CreateTextBlock(const Text: string): TJSONObject;
+class function TMCPContentBlock.Text(const Value: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
   Result.AddPair('type', 'text');
-  Result.AddPair('text', Text);
+  Result.AddPair('text', Value);
 end;
 
-function CreateImageBlock(const Base64Data, MimeType: string): TJSONObject;
+class function TMCPContentBlock.Image(const Base64Data, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
   Result.AddPair('type', 'image');
@@ -46,7 +50,7 @@ begin
   Result.AddPair('mimeType', MimeType);
 end;
 
-function CreateAudioBlock(const Base64Data, MimeType: string): TJSONObject;
+class function TMCPContentBlock.Audio(const Base64Data, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
   Result.AddPair('type', 'audio');
@@ -54,7 +58,7 @@ begin
   Result.AddPair('mimeType', MimeType);
 end;
 
-function CreateResourceLinkBlock(const Uri, Name, Description, MimeType: string): TJSONObject;
+class function TMCPContentBlock.ResourceLink(const Uri, Name, Description, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
   Result.AddPair('type', 'resource_link');
@@ -66,7 +70,7 @@ begin
     Result.AddPair('mimeType', MimeType);
 end;
 
-function CreateEmbeddedTextBlock(const Uri, MimeType, Text: string): TJSONObject;
+class function TMCPContentBlock.EmbeddedText(const Uri, MimeType, Text: string): TJSONObject;
 begin
   var Resource := TJSONObject.Create;
   Resource.AddPair('uri', Uri);
@@ -77,7 +81,7 @@ begin
   Result.AddPair('resource', Resource);
 end;
 
-function CreateEmbeddedBlobBlock(const Uri, MimeType, Base64Blob: string): TJSONObject;
+class function TMCPContentBlock.EmbeddedBlob(const Uri, MimeType, Base64Blob: string): TJSONObject;
 begin
   var Resource := TJSONObject.Create;
   Resource.AddPair('uri', Uri);

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -44,6 +44,9 @@ type
   EMCPTransportError = class(Exception)
   end;
 
+  EMCPConfigurationError = class(Exception)
+  end;
+
   EMCPRequestCancelled = class(Exception);
 
 const

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -102,14 +102,6 @@ const
   PARAM_INPUT_RESPONSES = 'inputResponses';
   PARAM_REQUEST_STATE = 'requestState';
 
-function InArray(const Value: string; const Values: array of string): Boolean;
-begin
-  for var Item in Values do
-    if Item = Value then
-      Exit(True);
-  Result := False;
-end;
-
 { TMCPJsonRpcProcessor }
 
 constructor TMCPJsonRpcProcessor.Create(ManagerRegistry: IMCPManagerRegistry);
@@ -175,24 +167,24 @@ end;
 
 function TMCPJsonRpcProcessor.IsLegacyOnlyMethod(const Method: string): Boolean;
 begin
-  Result := InArray(Method, LEGACY_ONLY_METHODS);
+  Result := TMCPStrings.Contains(Method, LEGACY_ONLY_METHODS);
   if Result and (Method = 'ping') and FSettings.LenientModernPing then
     Result := False;
 end;
 
 function TMCPJsonRpcProcessor.IsModernOnlyMethod(const Method: string): Boolean;
 begin
-  Result := InArray(Method, MODERN_ONLY_METHODS);
+  Result := TMCPStrings.Contains(Method, MODERN_ONLY_METHODS);
 end;
 
 function TMCPJsonRpcProcessor.IsCacheableMethod(const Method: string): Boolean;
 begin
-  Result := InArray(Method, MCP_CACHEABLE_METHODS);
+  Result := TMCPStrings.Contains(Method, MCP_CACHEABLE_METHODS);
 end;
 
 function TMCPJsonRpcProcessor.IsInputRequiredMethod(const Method: string): Boolean;
 begin
-  Result := InArray(Method, INPUT_REQUIRED_METHODS);
+  Result := TMCPStrings.Contains(Method, INPUT_REQUIRED_METHODS);
 end;
 
 function TMCPJsonRpcProcessor.ClientInputResponses(const Params: TJSONObject): TJSONObject;
@@ -234,7 +226,7 @@ end;
 function TMCPJsonRpcProcessor.EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
 begin
   if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader
-    and IsModernProtocolVersion(Hints.ProtocolVersionHeader) then
+    and TMCPProtocolVersion.IsModern(Hints.ProtocolVersionHeader) then
     Result := TMCPProtocolEra.Modern
   else
     Result := TMCPProtocolEra.Legacy;
@@ -357,7 +349,7 @@ begin
           [Hints.ProtocolVersionHeader, Version]));
     end;
 
-    if not IsModernProtocolVersion(Version) then
+    if not TMCPProtocolVersion.IsModern(Version) then
       raise EMCPError.UnsupportedProtocolVersion(Version, SupportedModernVersions);
 
     if Hints.HasHeaderLayer then
@@ -391,7 +383,7 @@ begin
       if IsJsonString(RequestedValue) then
         Requested := TJSONString(RequestedValue).Value;
     end;
-    Exit(NewContext(TMCPProtocolEra.Legacy, NegotiateLegacyProtocolVersion(Requested), Method, RequestId, Meta, Hints));
+    Exit(NewContext(TMCPProtocolEra.Legacy, TMCPProtocolVersion.NegotiateLegacy(Requested), Method, RequestId, Meta, Hints));
   end;
 
   if IsModernOnlyMethod(Method) then
@@ -401,11 +393,11 @@ begin
   if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader then
   begin
     var Header := Hints.ProtocolVersionHeader;
-    if IsModernProtocolVersion(Header) then
+    if TMCPProtocolVersion.IsModern(Header) then
       raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
         Format('MCP-Protocol-Version %s requires params._meta.%s', [Header, MCP_META_PROTOCOL_VERSION]),
         nil, HTTP_STATUS_BAD_REQUEST);
-    if not IsLegacyProtocolVersion(Header) and (Header <> MCP_PROTOCOL_VERSION_2025_03_26) then
+    if not TMCPProtocolVersion.IsLegacy(Header) and (Header <> MCP_PROTOCOL_VERSION_2025_03_26) then
       raise EMCPError.Create(JSONRPC_INVALID_REQUEST,
         'Unsupported MCP-Protocol-Version header: ' + Header, nil, HTTP_STATUS_BAD_REQUEST);
 

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -12,6 +12,7 @@ type
   TMCPSchemaGenerator = class
   private
     const MAX_NESTING_DEPTH = 8;
+    class var FContext: TRttiContext;
     class function GetPropertyJsonName(Prop: TRttiProperty): string;
     class function IsRequiredProperty(Prop: TRttiProperty): Boolean;
     class function CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
@@ -21,6 +22,8 @@ type
     class function NumberValue(const Value: Double): TJSONNumber;
     class procedure ApplyAttributes(Prop: TRttiProperty; const PropSchema: TJSONObject);
   public
+    class constructor Create;
+    class destructor Destroy;
     class function GenerateSchema(Cls: TClass): TJSONObject;
     class function GenerateSchemaFromInstance(Instance: TObject): TJSONObject;
   end;
@@ -31,14 +34,21 @@ uses
   System.Generics.Collections,
   MCPServer.Types;
 
-var
-  RttiContext: TRttiContext;
-
 { TMCPSchemaGenerator }
+
+class constructor TMCPSchemaGenerator.Create;
+begin
+  FContext := TRttiContext.Create;
+end;
+
+class destructor TMCPSchemaGenerator.Destroy;
+begin
+  FContext.Free;
+end;
 
 class function TMCPSchemaGenerator.GenerateSchema(Cls: TClass): TJSONObject;
 begin
-  Result := ObjectSchema(RttiContext.GetType(Cls), 0);
+  Result := ObjectSchema(FContext.GetType(Cls), 0);
 end;
 
 class function TMCPSchemaGenerator.GenerateSchemaFromInstance(Instance: TObject): TJSONObject;
@@ -279,11 +289,5 @@ begin
     raise;
   end;
 end;
-
-initialization
-  RttiContext := TRttiContext.Create;
-
-finalization
-  RttiContext.Free;
 
 end.

--- a/src/Protocol/MCPServer.Schema.Validator.pas
+++ b/src/Protocol/MCPServer.Schema.Validator.pas
@@ -12,15 +12,15 @@ type
   public
     const MAX_DEPTH = 32;
 
-    class function Validate(const Schema: TJSONObject; const Instance: TJSONValue;
+    class function TryValidate(const Schema: TJSONObject; const Instance: TJSONValue;
       out Errors: TArray<string>): Boolean;
   private
     class function ValidateNode(const Schema: TJSONObject; const Instance: TJSONValue;
       const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
-    class function ResolveRef(const RootSchema: TJSONObject; const Ref: string;
+    class function TryResolveRef(const RootSchema: TJSONObject; const Ref: string;
       out Resolved: TJSONObject): Boolean;
     class function MatchesType(const Instance: TJSONValue; const TypeName: string): Boolean;
-    class function CheckType(const Schema: TJSONObject; const Instance: TJSONValue;
+    class function TryCheckType(const Schema: TJSONObject; const Instance: TJSONValue;
       out ErrorMessage: string): Boolean;
     class function JsonEquals(A, B: TJSONValue): Boolean;
     class procedure AddError(Errors: TStrings; const Path, Message: string);
@@ -64,7 +64,7 @@ begin
     Result := False;
 end;
 
-class function TMCPSchemaValidator.CheckType(const Schema: TJSONObject; const Instance: TJSONValue;
+class function TMCPSchemaValidator.TryCheckType(const Schema: TJSONObject; const Instance: TJSONValue;
   out ErrorMessage: string): Boolean;
 begin
   Result := True;
@@ -115,7 +115,7 @@ begin
   Result := A.ToJSON = B.ToJSON;
 end;
 
-class function TMCPSchemaValidator.ResolveRef(const RootSchema: TJSONObject; const Ref: string;
+class function TMCPSchemaValidator.TryResolveRef(const RootSchema: TJSONObject; const Ref: string;
   out Resolved: TJSONObject): Boolean;
 const
   DEFS_PREFIX = '#/$defs/';
@@ -162,7 +162,7 @@ begin
   var RefValue := Schema.GetValue('$ref');
   if (RefValue is TJSONString) and not (RefValue is TJSONNumber) then
   begin
-    if not ResolveRef(RootSchema, TJSONString(RefValue).Value, ResolvedSchema) then
+    if not TryResolveRef(RootSchema, TJSONString(RefValue).Value, ResolvedSchema) then
     begin
       AddError(Errors, Path, 'unsupported $ref "' + TJSONString(RefValue).Value + '"');
       Exit(False);
@@ -194,7 +194,7 @@ begin
   end;
 
   var TypeError: string;
-  if not CheckType(ResolvedSchema, Instance, TypeError) then
+  if not TryCheckType(ResolvedSchema, Instance, TypeError) then
   begin
     AddError(Errors, Path, TypeError);
     Exit(False);
@@ -304,7 +304,7 @@ begin
   end;
 end;
 
-class function TMCPSchemaValidator.Validate(const Schema: TJSONObject; const Instance: TJSONValue;
+class function TMCPSchemaValidator.TryValidate(const Schema: TJSONObject; const Instance: TJSONValue;
   out Errors: TArray<string>): Boolean;
 begin
   var ErrorList := TStringList.Create;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -72,14 +72,20 @@ const
   MCP_LOG_LEVELS: array[0..7] of string = (
     'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency');
 
-function IsLegacyProtocolVersion(const Version: string): Boolean;
-function IsModernProtocolVersion(const Version: string): Boolean;
-function NegotiateLegacyProtocolVersion(const Requested: string): string;
-
 type
+  TMCPProtocolVersion = record
+    class function IsLegacy(const Version: string): Boolean; static;
+    class function IsModern(const Version: string): Boolean; static;
+    class function NegotiateLegacy(const Requested: string): string; static;
+  end;
+
   TMCPLogLevel = record
     class function Rank(const Level: string): Integer; static;
     class function IsKnown(const Level: string): Boolean; static;
+  end;
+
+  TMCPStrings = record
+    class function Contains(const Value: string; const Values: array of string): Boolean; static;
   end;
 
   TMCPConstantTime = record
@@ -469,6 +475,16 @@ begin
   Result := Rank(Level) >= 0;
 end;
 
+class function TMCPStrings.Contains(const Value: string; const Values: array of string): Boolean;
+begin
+  for var Item in Values do
+  begin
+    if Item = Value then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
 class function TMCPConstantTime.SameBytes(const A, B: TBytes): Boolean;
 begin
   var Difference := Length(A) xor Length(B);
@@ -527,7 +543,7 @@ begin
   end;
 end;
 
-function IsLegacyProtocolVersion(const Version: string): Boolean;
+class function TMCPProtocolVersion.IsLegacy(const Version: string): Boolean;
 begin
   for var Known in MCP_LEGACY_PROTOCOL_VERSIONS do
     if Known = Version then
@@ -535,7 +551,7 @@ begin
   Result := False;
 end;
 
-function IsModernProtocolVersion(const Version: string): Boolean;
+class function TMCPProtocolVersion.IsModern(const Version: string): Boolean;
 begin
   for var Known in MCP_MODERN_PROTOCOL_VERSIONS do
     if Known = Version then
@@ -543,9 +559,9 @@ begin
   Result := False;
 end;
 
-function NegotiateLegacyProtocolVersion(const Requested: string): string;
+class function TMCPProtocolVersion.NegotiateLegacy(const Requested: string): string;
 begin
-  if IsLegacyProtocolVersion(Requested) then
+  if TMCPProtocolVersion.IsLegacy(Requested) then
     Result := Requested
   else
     Result := MCP_LATEST_LEGACY_PROTOCOL_VERSION;

--- a/src/Resources/MCPServer.Resource.Base.pas
+++ b/src/Resources/MCPServer.Resource.Base.pas
@@ -85,6 +85,11 @@ type
     property MimeType: string read GetMimeType;
   end;
 
+  TMCPCompiledTemplate = record
+    Pattern: string;
+    VariableNames: TArray<string>;
+  end;
+
   TMCPResourceTemplateBase = class(TInterfacedObject, IMCPResourceTemplate)
   strict private
     FPattern: string;
@@ -93,7 +98,7 @@ type
     FCompileLock: TCriticalSection;
     procedure EnsureCompiled;
     class function PercentDecode(const Text: string): string; static;
-    class function CompilePattern(const UriTemplate: string; out VariableNames: TArray<string>): string; static;
+    class function CompilePattern(const UriTemplate: string): TMCPCompiledTemplate; static;
   protected
     FUriTemplate: string;
     FName: string;
@@ -263,8 +268,7 @@ begin
   Result := TEncoding.UTF8.GetString(Bytes);
 end;
 
-class function TMCPResourceTemplateBase.CompilePattern(const UriTemplate: string;
-  out VariableNames: TArray<string>): string;
+class function TMCPResourceTemplateBase.CompilePattern(const UriTemplate: string): TMCPCompiledTemplate;
 var
   Names: TList<string>;
   Position: Integer;
@@ -273,7 +277,7 @@ var
 begin
   Names := TList<string>.Create;
   try
-    Result := '';
+    Result.Pattern := '';
     Position := 1;
     while Position <= Length(UriTemplate) do
     begin
@@ -287,12 +291,12 @@ begin
         if (Expr <> '') and (Expr[1] = '+') then
         begin
           VarName := Copy(Expr, 2, MaxInt);
-          Result := Result + Format('(?<%s>.+)', [VarName]);
+          Result.Pattern := Result.Pattern + Format('(?<%s>.+)', [VarName]);
         end
         else
         begin
           VarName := Expr;
-          Result := Result + Format('(?<%s>[^/]+)', [VarName]);
+          Result.Pattern := Result.Pattern + Format('(?<%s>[^/]+)', [VarName]);
         end;
         if VarName = '' then
           raise EArgumentException.CreateFmt('Empty variable name in URI template "%s"', [UriTemplate]);
@@ -313,11 +317,11 @@ begin
         while (Position <= Length(UriTemplate)) and (UriTemplate[Position] <> '{') do
           Inc(Position);
         LiteralRun := Copy(UriTemplate, LiteralStart, Position - LiteralStart);
-        Result := Result + TRegEx.Escape(LiteralRun);
+        Result.Pattern := Result.Pattern + TRegEx.Escape(LiteralRun);
       end;
     end;
-    Result := '^' + Result + '$';
-    VariableNames := Names.ToArray;
+    Result.Pattern := Format('^%s$', [Result.Pattern]);
+    Result.VariableNames := Names.ToArray;
   finally
     Names.Free;
   end;
@@ -329,7 +333,9 @@ begin
   try
     if not FCompiled then
     begin
-      FPattern := CompilePattern(FUriTemplate, FVariableNames);
+      const Compiled = CompilePattern(FUriTemplate);
+      FPattern := Compiled.Pattern;
+      FVariableNames := Compiled.VariableNames;
       FCompiled := True;
     end;
   finally

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -20,6 +20,14 @@ type
     class function Accepts(const AcceptHeader, MediaType: string): Boolean; static;
   end;
 
+  TMCPOriginParts = record
+    Scheme: string;
+    Host: string;
+    Port: string;
+    class function Parse(const Origin: string): TMCPOriginParts; static;
+    function DefaultPort: string;
+  end;
+
   TMCPOriginPolicy = record
     const ALLOW_ALL = '*';
 
@@ -124,7 +132,41 @@ end;
 
 { TMCPOriginPolicy }
 
-function DefaultPortOf(const Scheme: string): string;
+{ TMCPOriginParts }
+
+class function TMCPOriginParts.Parse(const Origin: string): TMCPOriginParts;
+begin
+  Result := Default(TMCPOriginParts);
+  var Rest := Origin.Trim;
+  var SchemeEnd := Rest.IndexOf('://');
+  if SchemeEnd < 0 then
+    Exit;
+  Result.Scheme := Rest.Substring(0, SchemeEnd).ToLower;
+  Rest := Rest.Substring(SchemeEnd + 3);
+
+  var PortStart: Integer;
+  if Rest.StartsWith('[') then
+  begin
+    var BracketEnd := Rest.IndexOf(']');
+    if BracketEnd < 0 then
+      Exit;
+    Result.Host := Rest.Substring(0, BracketEnd + 1).ToLower;
+    PortStart := Rest.IndexOf(':', BracketEnd);
+  end
+  else
+  begin
+    PortStart := Rest.IndexOf(':');
+    if PortStart >= 0 then
+      Result.Host := Rest.Substring(0, PortStart).ToLower
+    else
+      Result.Host := Rest.ToLower;
+  end;
+
+  if PortStart >= 0 then
+    Result.Port := Rest.Substring(PortStart + 1);
+end;
+
+function TMCPOriginParts.DefaultPort: string;
 begin
   if Scheme = 'https' then
     Result := '443'
@@ -134,70 +176,33 @@ begin
     Result := '';
 end;
 
-procedure SplitOrigin(const Origin: string; out Scheme, Host, Port: string);
-begin
-  Scheme := '';
-  Host := '';
-  Port := '';
-
-  var Rest := Origin.Trim;
-  var SchemeEnd := Rest.IndexOf('://');
-  if SchemeEnd < 0 then
-    Exit;
-  Scheme := Rest.Substring(0, SchemeEnd).ToLower;
-  Rest := Rest.Substring(SchemeEnd + 3);
-
-  var PortStart: Integer;
-  if Rest.StartsWith('[') then
-  begin
-    var BracketEnd := Rest.IndexOf(']');
-    if BracketEnd < 0 then
-      Exit;
-    Host := Rest.Substring(0, BracketEnd + 1).ToLower;
-    PortStart := Rest.IndexOf(':', BracketEnd);
-  end
-  else
-  begin
-    PortStart := Rest.IndexOf(':');
-    if PortStart >= 0 then
-      Host := Rest.Substring(0, PortStart).ToLower
-    else
-      Host := Rest.ToLower;
-  end;
-
-  if PortStart >= 0 then
-    Port := Rest.Substring(PortStart + 1);
-end;
-
 class function TMCPOriginPolicy.IsLoopback(const Origin: string): Boolean;
-var
-  Scheme, Host, Port: string;
 begin
-  SplitOrigin(Origin, Scheme, Host, Port);
-  Result := ((Scheme = 'http') or (Scheme = 'https'))
-    and ((Host = 'localhost') or (Host = '127.0.0.1') or (Host = '[::1]'));
+  const Parts = TMCPOriginParts.Parse(Origin);
+  const IsHttp = ((Parts.Scheme = 'http') or (Parts.Scheme = 'https'));
+  const IsLocal = ((Parts.Host = 'localhost') or (Parts.Host = '127.0.0.1') or (Parts.Host = '[::1]'));
+  Result := IsHttp and IsLocal;
 end;
 
 class function TMCPOriginPolicy.Matches(const Origin, Pattern: string): Boolean;
-var
-  OriginScheme, OriginHost, OriginPort: string;
-  PatternScheme, PatternHost, PatternPort: string;
 begin
   if Pattern.Trim = ALLOW_ALL then
     Exit(True);
 
-  SplitOrigin(Origin, OriginScheme, OriginHost, OriginPort);
-  SplitOrigin(Pattern, PatternScheme, PatternHost, PatternPort);
-  if (OriginScheme = '') or (PatternScheme = '') then
+  var Wanted := TMCPOriginParts.Parse(Origin);
+  var Allowed := TMCPOriginParts.Parse(Pattern);
+  const IsParsed = ((Wanted.Scheme <> '') and (Allowed.Scheme <> ''));
+  if not IsParsed then
     Exit(False);
 
-  if (OriginPort = '') then
-    OriginPort := DefaultPortOf(OriginScheme);
-  if (PatternPort = '') then
-    PatternPort := DefaultPortOf(PatternScheme);
+  if Wanted.Port = '' then
+    Wanted.Port := Wanted.DefaultPort;
+  if Allowed.Port = '' then
+    Allowed.Port := Allowed.DefaultPort;
 
-  Result := (OriginScheme = PatternScheme) and (OriginHost = PatternHost)
-    and ((PatternPort = '*') or (OriginPort = PatternPort));
+  const SameHost = ((Wanted.Scheme = Allowed.Scheme) and (Wanted.Host = Allowed.Host));
+  const SamePort = ((Allowed.Port = '*') or (Wanted.Port = Allowed.Port));
+  Result := SameHost and SamePort;
 end;
 
 class function TMCPOriginPolicy.IsAllowed(const Origin: string; const AllowList: TArray<string>): Boolean;
@@ -219,17 +224,16 @@ end;
 { TMCPHostPolicy }
 
 class function TMCPHostPolicy.Matches(const HostHeader, Pattern: string): Boolean;
-var
-  Scheme, HostName, HostPort, PatternName, PatternPort: string;
 begin
   if Pattern.Trim = TMCPOriginPolicy.ALLOW_ALL then
     Exit(True);
 
-  SplitOrigin('http://' + HostHeader.Trim, Scheme, HostName, HostPort);
-  SplitOrigin('http://' + Pattern.Trim, Scheme, PatternName, PatternPort);
-  if (HostName = '') or (PatternName = '') or (HostName <> PatternName) then
+  const Wanted = TMCPOriginParts.Parse(Format('http://%s', [HostHeader.Trim]));
+  const Allowed = TMCPOriginParts.Parse(Format('http://%s', [Pattern.Trim]));
+  const SameHost = ((Wanted.Host <> '') and (Allowed.Host <> '') and (Wanted.Host = Allowed.Host));
+  if not SameHost then
     Exit(False);
-  Result := (PatternPort = '') or (PatternPort = '*') or (PatternPort = HostPort);
+  Result := (Allowed.Port = '') or (Allowed.Port = '*') or (Allowed.Port = Wanted.Port);
 end;
 
 class function TMCPHostPolicy.IsAllowed(const HostHeader: string; const AllowList: TArray<string>): Boolean;

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -68,7 +68,7 @@ type
     function ResourceUri: string;
     function ResourceMetadataUrl: string;
     procedure HandleProtectedResourceMetadata(ResponseInfo: TIdHTTPResponseInfo);
-    function Authenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+    function TryAuthenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
       out Principal: TMCPPrincipal): Boolean;
     procedure SendChallenge(ResponseInfo: TIdHTTPResponseInfo; Status: Integer; const Challenge: TMCPAuthChallenge;
       const Message: string);
@@ -190,7 +190,7 @@ begin
     Exit;
 
   if not Assigned(FManagerRegistry) then
-    raise Exception.Create('Manager registry not assigned');
+    raise EMCPConfigurationError.Create('Manager registry not assigned');
 
   FJsonRpcProcessor.Free;
   FJsonRpcProcessor := TMCPJsonRpcProcessor.Create(FManagerRegistry, FSettings);
@@ -309,14 +309,14 @@ procedure TMCPIdHTTPServer.ConfigureSSL;
 begin
   if not TFile.Exists(FSettings.SSLCertFile) then
   begin
-    TLogger.Error('SSL Certificate file not found: ' + FSettings.SSLCertFile);
-    raise Exception.Create('SSL Certificate file not found: ' + FSettings.SSLCertFile);
+    TLogger.Error(Format('SSL certificate file not found: %s', [FSettings.SSLCertFile]));
+    raise EMCPConfigurationError.CreateFmt('SSL certificate file not found: %s', [FSettings.SSLCertFile]);
   end;
 
   if not TFile.Exists(FSettings.SSLKeyFile) then
   begin
-    TLogger.Error('SSL Key file not found: ' + FSettings.SSLKeyFile);
-    raise Exception.Create('SSL Key file not found: ' + FSettings.SSLKeyFile);
+    TLogger.Error(Format('SSL key file not found: %s', [FSettings.SSLKeyFile]));
+    raise EMCPConfigurationError.CreateFmt('SSL key file not found: %s', [FSettings.SSLKeyFile]);
   end;
 
   {$IFDEF USE_TAURUS_TLS}
@@ -440,7 +440,7 @@ begin
     end;
 
     var Principal := TMCPPrincipal.None;
-    if Assigned(FAuthorizer) and not Authenticate(RequestInfo, ResponseInfo, Principal) then
+    if Assigned(FAuthorizer) and not TryAuthenticate(RequestInfo, ResponseInfo, Principal) then
       Exit;
 
     if RequestInfo.CommandType = hcPOST then
@@ -590,39 +590,42 @@ begin
   SendJsonRpcError(ResponseInfo, Status, JSONRPC_INVALID_REQUEST, Message);
 end;
 
-function TMCPIdHTTPServer.Authenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+function TMCPIdHTTPServer.TryAuthenticate(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
   out Principal: TMCPPrincipal): Boolean;
-var
-  Challenge: TMCPAuthChallenge;
 begin
   Principal := TMCPPrincipal.None;
   Result := False;
 
-  var Header := HeaderValue(RequestInfo, HEADER_AUTHORIZATION);
-  if Header = '' then
+  const Header = HeaderValue(RequestInfo, HEADER_AUTHORIZATION);
+  const IsMissing = (Header = '');
+  if IsMissing then
   begin
     SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, TMCPAuthChallenge.None, 'Authorization required');
     Exit;
   end;
-  if not Header.StartsWith(BEARER_PREFIX, True) or (Header.Length <= BEARER_PREFIX.Length) then
+
+  const IsBearer = (Header.StartsWith(BEARER_PREFIX, True) and (Header.Length > BEARER_PREFIX.Length));
+  if not IsBearer then
   begin
     SendChallenge(ResponseInfo, HTTP_STATUS_BAD_REQUEST,
       TMCPAuthChallenge.InvalidRequest('Only the Bearer scheme is supported'), 'Malformed Authorization header');
     Exit;
   end;
 
-  var Token := Header.Substring(BEARER_PREFIX.Length).Trim;
-  case FAuthorizer.Authorize(Token, RequestInfo.Command, RequestInfo.Document, Principal, Challenge) of
+  const Token = Header.Substring(BEARER_PREFIX.Length).Trim;
+  const Outcome = FAuthorizer.Authorize(Token, RequestInfo.Command, RequestInfo.Document);
+  Principal := Outcome.Principal;
+  case Outcome.Decision of
     TMCPAuthDecision.Allow:
       Result := True;
     TMCPAuthDecision.Unauthorized:
-      SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Challenge, 'Unauthorized');
+      SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Outcome.Challenge, 'Unauthorized');
     TMCPAuthDecision.Forbidden:
-      SendChallenge(ResponseInfo, HTTP_FORBIDDEN, Challenge, 'Forbidden');
+      SendChallenge(ResponseInfo, HTTP_FORBIDDEN, Outcome.Challenge, 'Forbidden');
     TMCPAuthDecision.BadRequest:
-      SendChallenge(ResponseInfo, HTTP_STATUS_BAD_REQUEST, Challenge, 'Malformed authorization request');
+      SendChallenge(ResponseInfo, HTTP_STATUS_BAD_REQUEST, Outcome.Challenge, 'Malformed authorization request');
   else
-    SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Challenge, 'Unauthorized');
+    SendChallenge(ResponseInfo, HTTP_UNAUTHORIZED, Outcome.Challenge, 'Unauthorized');
   end;
 end;
 

--- a/src/Server/MCPServer.StdioChannel.pas
+++ b/src/Server/MCPServer.StdioChannel.pas
@@ -15,9 +15,15 @@ type
     InvalidUtf8
   );
 
+  TMCPLine = record
+    Status: TMCPLineStatus;
+    Text: string;
+  end;
+
   TMCPLineReader = class
   strict private
     const READ_CHUNK_BYTES = 64 * 1024;
+    const CARRIAGE_RETURN = 13;
   strict private
     FStream: TStream;
     FMaxLineBytes: Integer;
@@ -26,11 +32,11 @@ type
     FAtStart: Boolean;
     FEndOfStream: Boolean;
     function Fill: Boolean;
-    function DecodeLine(Start, Count: Integer; out Line: string): TMCPLineStatus;
+    function DecodeLine(const Start, Count: Integer): TMCPLine;
     function RoundTrips(const Line: string; const Start, Count: Integer): Boolean;
   public
     constructor Create(Stream: TStream; MaxLineBytes: Integer);
-    function ReadLine(out Line: string; out Status: TMCPLineStatus): Boolean;
+    function TryReadLine(out Line: TMCPLine): Boolean;
   end;
 
   TMCPLineWriter = class(TInterfacedObject, IMCPMessageSink)
@@ -123,37 +129,40 @@ begin
   Result := CompareMem(@Encoded[0], @FPending[Start], Count);
 end;
 
-function TMCPLineReader.DecodeLine(Start, Count: Integer; out Line: string): TMCPLineStatus;
+function TMCPLineReader.DecodeLine(const Start, Count: Integer): TMCPLine;
 begin
-  if (Count > 0) and (FPending[Start + Count - 1] = 13) then
-    Dec(Count);
+  Result := Default(TMCPLine);
+  var Length := Count;
+  const EndsWithCarriageReturn = ((Length > 0) and (FPending[Start + Length - 1] = CARRIAGE_RETURN));
+  if EndsWithCarriageReturn then
+    Dec(Length);
 
-  if Count > FMaxLineBytes then
+  const IsTooLong = (Length > FMaxLineBytes);
+  if IsTooLong then
   begin
-    Line := '';
-    Exit(TMCPLineStatus.TooLong);
+    Result.Status := TMCPLineStatus.TooLong;
+    Exit;
   end;
 
   try
-    Line := TEncoding.UTF8.GetString(FPending, Start, Count);
+    Result.Text := TEncoding.UTF8.GetString(FPending, Start, Length);
   except
-    Line := '';
-    Exit(TMCPLineStatus.InvalidUtf8);
+    Result.Text := '';
+    Result.Status := TMCPLineStatus.InvalidUtf8;
+    Exit;
   end;
 
-  const IsValidUtf8 = RoundTrips(Line, Start, Count);
+  const IsValidUtf8 = RoundTrips(Result.Text, Start, Length);
   if not IsValidUtf8 then
   begin
-    Line := '';
-    Exit(TMCPLineStatus.InvalidUtf8);
+    Result.Text := '';
+    Result.Status := TMCPLineStatus.InvalidUtf8;
   end;
-  Result := TMCPLineStatus.Ok;
 end;
 
-function TMCPLineReader.ReadLine(out Line: string; out Status: TMCPLineStatus): Boolean;
+function TMCPLineReader.TryReadLine(out Line: TMCPLine): Boolean;
 begin
-  Line := '';
-  Status := TMCPLineStatus.Ok;
+  Line := Default(TMCPLine);
   var ScanFrom := 0;
 
   while True do
@@ -161,7 +170,7 @@ begin
     for var I := ScanFrom to FPendingLength - 1 do
       if FPending[I] = 10 then
       begin
-        Status := DecodeLine(0, I, Line);
+        Line := DecodeLine(0, I);
         var Remaining := FPendingLength - (I + 1);
         if Remaining > 0 then
           Move(FPending[I + 1], FPending[0], Remaining);
@@ -181,8 +190,7 @@ begin
         if Count <= 0 then
         begin
           FEndOfStream := True;
-          Line := '';
-          Status := TMCPLineStatus.TooLong;
+          Line.Status := TMCPLineStatus.TooLong;
           Exit(True);
         end;
         for var I := 0 to Count - 1 do
@@ -192,8 +200,7 @@ begin
             if Rest > 0 then
               Move(Skipped[I + 1], FPending[0], Rest);
             FPendingLength := Rest;
-            Line := '';
-            Status := TMCPLineStatus.TooLong;
+            Line.Status := TMCPLineStatus.TooLong;
             Exit(True);
           end;
       end;
@@ -203,7 +210,7 @@ begin
     begin
       if FPendingLength = 0 then
         Exit(False);
-      Status := DecodeLine(0, FPendingLength, Line);
+      Line := DecodeLine(0, FPendingLength);
       FPendingLength := 0;
       Exit(True);
     end;

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -482,25 +482,24 @@ end;
 
 procedure TMCPStdioTransport.ReadLoop(InputStream: TStream);
 var
-  Line: string;
-  Status: TMCPLineStatus;
+  Line: TMCPLine;
 begin
   var Reader := TMCPLineReader.Create(InputStream, Settings.MaxRequestBodyBytes);
   try
-    while Reader.ReadLine(Line, Status) do
+    while Reader.TryReadLine(Line) do
     begin
       try
-        case Status of
+        case Line.Status of
           TMCPLineStatus.TooLong:
             SendError(TMCPRequestId.FromJson(nil), JSONRPC_INVALID_REQUEST,
               Format('Message exceeds %d bytes', [Settings.MaxRequestBodyBytes]));
           TMCPLineStatus.InvalidUtf8:
             SendError(TMCPRequestId.FromJson(nil), JSONRPC_PARSE_ERROR, 'Message is not valid UTF-8');
         else
-          if Line.Trim = '' then
+          if Line.Text.Trim = '' then
             Continue;
-          TLogger.Debug('Received: ' + TLogger.RedactJson(Line));
-          DispatchLine(TJSONObject.ParseJSONValue(Line));
+          TLogger.Debug('Received: ' + TLogger.RedactJson(Line.Text));
+          DispatchLine(TJSONObject.ParseJSONValue(Line.Text));
         end;
       except
         on E: Exception do

--- a/src/Tools/MCPServer.Tool.Base.pas
+++ b/src/Tools/MCPServer.Tool.Base.pas
@@ -161,7 +161,7 @@ begin
   var Schema := BuildSchema;
   try
     var Errors: TArray<string>;
-    if not TMCPSchemaValidator.Validate(Schema, Arguments, Errors) then
+    if not TMCPSchemaValidator.TryValidate(Schema, Arguments, Errors) then
       raise EArgumentException.Create(string.Join('; ', Errors));
   finally
     Schema.Free;

--- a/src/Tools/MCPServer.Tool.Result.pas
+++ b/src/Tools/MCPServer.Tool.Result.pas
@@ -69,47 +69,47 @@ end;
 
 function TMCPToolResult.AddText(const Text: string): TMCPToolResult;
 begin
-  AddBlock(CreateTextBlock(Text));
+  AddBlock(TMCPContentBlock.Text(Text));
   Result := Self;
 end;
 
 function TMCPToolResult.AddImage(const Data: TBytes; const MimeType: string): TMCPToolResult;
 begin
-  Result := AddImage(EncodeBase64Blob(Data), MimeType);
+  Result := AddImage(TMCPContentBlock.EncodeBlob(Data), MimeType);
 end;
 
 function TMCPToolResult.AddImage(const Base64Data, MimeType: string): TMCPToolResult;
 begin
-  AddBlock(CreateImageBlock(Base64Data, MimeType));
+  AddBlock(TMCPContentBlock.Image(Base64Data, MimeType));
   Result := Self;
 end;
 
 function TMCPToolResult.AddAudio(const Data: TBytes; const MimeType: string): TMCPToolResult;
 begin
-  Result := AddAudio(EncodeBase64Blob(Data), MimeType);
+  Result := AddAudio(TMCPContentBlock.EncodeBlob(Data), MimeType);
 end;
 
 function TMCPToolResult.AddAudio(const Base64Data, MimeType: string): TMCPToolResult;
 begin
-  AddBlock(CreateAudioBlock(Base64Data, MimeType));
+  AddBlock(TMCPContentBlock.Audio(Base64Data, MimeType));
   Result := Self;
 end;
 
 function TMCPToolResult.AddResourceLink(const Uri, Name, Description, MimeType: string): TMCPToolResult;
 begin
-  AddBlock(CreateResourceLinkBlock(Uri, Name, Description, MimeType));
+  AddBlock(TMCPContentBlock.ResourceLink(Uri, Name, Description, MimeType));
   Result := Self;
 end;
 
 function TMCPToolResult.AddEmbeddedText(const Uri, MimeType, Text: string): TMCPToolResult;
 begin
-  AddBlock(CreateEmbeddedTextBlock(Uri, MimeType, Text));
+  AddBlock(TMCPContentBlock.EmbeddedText(Uri, MimeType, Text));
   Result := Self;
 end;
 
 function TMCPToolResult.AddEmbeddedBlob(const Uri, MimeType: string; const Data: TBytes): TMCPToolResult;
 begin
-  AddBlock(CreateEmbeddedBlobBlock(Uri, MimeType, EncodeBase64Blob(Data)));
+  AddBlock(TMCPContentBlock.EmbeddedBlob(Uri, MimeType, TMCPContentBlock.EncodeBlob(Data)));
   Result := Self;
 end;
 

--- a/tests/MCPServer.Tests.Authorization.pas
+++ b/tests/MCPServer.Tests.Authorization.pas
@@ -18,7 +18,7 @@ type
   strict private
     FClaimsJson: string;
   protected
-    function ValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
+    function TryValidateToken(const Token: string; out Claims: TJSONObject): Boolean; override;
   public
     constructor Create(const ExpectedAudience, ClaimsJson: string);
   end;
@@ -30,8 +30,7 @@ type
     FSeenAuthorization: string;
     FSeenBody: string;
     procedure HandleIntrospection(Context: TIdContext; Request: TIdHTTPRequestInfo; Response: TIdHTTPResponseInfo);
-    function Decide(const Authorizer: IMCPAuthorizer; const Token: string; out Principal: TMCPPrincipal;
-      out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+    function Decide(const Authorizer: IMCPAuthorizer; const Token: string): TMCPAuthResult;
   public
     [TearDown]
     procedure TearDown;
@@ -64,7 +63,7 @@ begin
   FClaimsJson := ClaimsJson;
 end;
 
-function TClaimsAuthorizer.ValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
+function TClaimsAuthorizer.TryValidateToken(const Token: string; out Claims: TJSONObject): Boolean;
 begin
   Claims := nil;
   if Token <> 'valid' then
@@ -81,32 +80,34 @@ begin
   FIntrospection := nil;
 end;
 
-function TAuthorizationTests.Decide(const Authorizer: IMCPAuthorizer; const Token: string;
-  out Principal: TMCPPrincipal; out Challenge: TMCPAuthChallenge): TMCPAuthDecision;
+function TAuthorizationTests.Decide(const Authorizer: IMCPAuthorizer; const Token: string): TMCPAuthResult;
 begin
-  Result := Authorizer.Authorize(Token, 'POST', '/mcp', Principal, Challenge);
+  Result := Authorizer.Authorize(Token, 'POST', '/mcp');
 end;
 
 procedure TAuthorizationTests.StaticBearer_AcceptsListedTokens_RejectsOthers;
-var
-  Principal: TMCPPrincipal;
-  Challenge: TMCPAuthChallenge;
 begin
   var Authorizer: IMCPAuthorizer := TMCPStaticBearerAuthorizer.Create(['alpha', ' beta ']);
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'alpha', Principal, Challenge));
-  Assert.AreEqual('token-1', Principal.Subject);
-  Assert.IsTrue(Principal.HasScope('anything'), 'pre-shared tokens grant every scope');
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'beta', Principal, Challenge));
-  Assert.AreEqual('token-2', Principal.Subject);
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, 'alph', Principal, Challenge));
-  Assert.AreEqual('invalid_token', Challenge.Error);
-  Assert.AreEqual('', Principal.Subject);
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, '', Principal, Challenge));
+  var First := Decide(Authorizer, 'alpha');
+  Assert.AreEqual(TMCPAuthDecision.Allow, First.Decision);
+  Assert.AreEqual('token-1', First.Principal.Subject);
+  Assert.IsTrue(First.Principal.HasScope('anything'), 'pre-shared tokens grant every scope');
+
+  var Second := Decide(Authorizer, 'beta');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Second.Decision);
+  Assert.AreEqual('token-2', Second.Principal.Subject);
+
+  var Unknown := Decide(Authorizer, 'alph');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Unknown.Decision);
+  Assert.AreEqual('invalid_token', Unknown.Challenge.Error);
+  Assert.AreEqual('', Unknown.Principal.Subject);
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, '').Decision);
 
   var Scoped: IMCPAuthorizer := TMCPStaticBearerAuthorizer.Create(['alpha'], ['read']);
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Scoped, 'alpha', Principal, Challenge));
-  Assert.IsTrue(Principal.HasScope('read'));
-  Assert.IsFalse(Principal.HasScope('write'));
+  var Limited := Decide(Scoped, 'alpha');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Limited.Decision);
+  Assert.IsTrue(Limited.Principal.HasScope('read'));
+  Assert.IsFalse(Limited.Principal.HasScope('write'));
 end;
 
 procedure TAuthorizationTests.StaticBearer_NeedsAToken;
@@ -139,54 +140,55 @@ begin
 end;
 
 procedure TAuthorizationTests.OAuth_RejectsWrongAudience_Expiry_AndScope;
-var
-  Principal: TMCPPrincipal;
-  Challenge: TMCPAuthChallenge;
 begin
   var Future := System.DateUtils.DateTimeToUnix(Now, False) + 600;
   var Past := System.DateUtils.DateTimeToUnix(Now, False) - 600;
 
   var Invalid: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d}', [AUDIENCE, Future]));
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Invalid, 'nope', Principal, Challenge));
-  Assert.AreEqual('invalid_token', Challenge.Error);
+  var Rejected := Decide(Invalid, 'nope');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Rejected.Decision);
+  Assert.AreEqual('invalid_token', Rejected.Challenge.Error);
 
   var WrongAudience: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"https://other","exp":%d}', [Future]));
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(WrongAudience, 'valid', Principal, Challenge));
-  Assert.IsTrue(Challenge.ErrorDescription.Contains('not issued for this server'), Challenge.ErrorDescription);
+  var ForAnother := Decide(WrongAudience, 'valid');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, ForAnother.Decision);
+  Assert.IsTrue(ForAnother.Challenge.ErrorDescription.Contains('not issued for this server'),
+    ForAnother.Challenge.ErrorDescription);
 
   var Expired: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d}', [AUDIENCE, Past]));
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Expired, 'valid', Principal, Challenge));
-  Assert.IsTrue(Challenge.ErrorDescription.Contains('expired'), Challenge.ErrorDescription);
+  var Stale := Decide(Expired, 'valid');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Stale.Decision);
+  Assert.IsTrue(Stale.Challenge.ErrorDescription.Contains('expired'), Stale.Challenge.ErrorDescription);
 
   var NoExpiry: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s"}', [AUDIENCE]));
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(NoExpiry, 'valid', Principal, Challenge), 'exp is mandatory');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(NoExpiry, 'valid').Decision, 'exp is mandatory');
 
   var Scoped := TClaimsAuthorizer.Create(AUDIENCE, Format('{"sub":"u","aud":"%s","exp":%d,"scope":"read"}', [AUDIENCE, Future]));
   var ScopedRef: IMCPAuthorizer := Scoped;
   Scoped.RequiredScopes := ['read', 'write'];
-  Assert.AreEqual(TMCPAuthDecision.Forbidden, Decide(ScopedRef, 'valid', Principal, Challenge));
-  Assert.AreEqual('insufficient_scope', Challenge.Error);
-  Assert.AreEqual('read write', Challenge.Scope);
+  var Denied := Decide(ScopedRef, 'valid');
+  Assert.AreEqual(TMCPAuthDecision.Forbidden, Denied.Decision);
+  Assert.AreEqual('insufficient_scope', Denied.Challenge.Error);
+  Assert.AreEqual('read write', Denied.Challenge.Scope);
 
   Scoped.RequiredScopes := ['read'];
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(ScopedRef, 'valid', Principal, Challenge));
-  Assert.AreEqual('u', Principal.Subject);
-  Assert.IsTrue(Principal.HasScope('read'));
-  Assert.IsFalse(Principal.HasScope('write'));
+  var Allowed := Decide(ScopedRef, 'valid');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Allowed.Decision);
+  Assert.AreEqual('u', Allowed.Principal.Subject);
+  Assert.IsTrue(Allowed.Principal.HasScope('read'));
+  Assert.IsFalse(Allowed.Principal.HasScope('write'));
 end;
 
 procedure TAuthorizationTests.OAuth_AcceptsAudienceArray_AndScopeArray;
-var
-  Principal: TMCPPrincipal;
-  Challenge: TMCPAuthChallenge;
 begin
   var Future := System.DateUtils.DateTimeToUnix(Now, False) + 600;
   var Authorizer: IMCPAuthorizer := TClaimsAuthorizer.Create(AUDIENCE,
     Format('{"sub":"u","aud":["https://other","%s"],"exp":%d,"scp":["a","b"]}', [AUDIENCE.ToUpper, Future]));
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'valid', Principal, Challenge));
-  Assert.IsTrue(Principal.HasScope('a'));
-  Assert.IsTrue(Principal.HasScope('b'));
-  Assert.IsFalse(Principal.HasScope('c'));
+  var Outcome := Decide(Authorizer, 'valid');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Outcome.Decision);
+  Assert.IsTrue(Outcome.Principal.HasScope('a'));
+  Assert.IsTrue(Outcome.Principal.HasScope('b'));
+  Assert.IsFalse(Outcome.Principal.HasScope('c'));
 end;
 
 procedure TAuthorizationTests.OAuth_NeedsAnAudience;
@@ -248,9 +250,6 @@ begin
 end;
 
 procedure TAuthorizationTests.Introspection_PostsTokenWithClientCredentials;
-var
-  Principal: TMCPPrincipal;
-  Challenge: TMCPAuthChallenge;
 begin
   FIntrospection := TIdHTTPServer.Create(nil);
   FIntrospection.Bindings.Add.IP := '127.0.0.1';
@@ -260,14 +259,16 @@ begin
   var Url := Format('http://127.0.0.1:%d/introspect', [FIntrospection.Bindings[0].Port]);
 
   var Authorizer: IMCPAuthorizer := TMCPIntrospectionAuthorizer.Create(AUDIENCE, Url, 'mcp', 's3cret');
-  Assert.AreEqual(TMCPAuthDecision.Allow, Decide(Authorizer, 'good', Principal, Challenge));
-  Assert.AreEqual('alice', Principal.Subject);
-  Assert.IsTrue(Principal.HasScope('read'));
+  var Active := Decide(Authorizer, 'good');
+  Assert.AreEqual(TMCPAuthDecision.Allow, Active.Decision);
+  Assert.AreEqual('alice', Active.Principal.Subject);
+  Assert.IsTrue(Active.Principal.HasScope('read'));
   Assert.AreEqual('token=good', FSeenBody);
   Assert.IsTrue(FSeenAuthorization.StartsWith('Basic '), FSeenAuthorization);
 
-  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Decide(Authorizer, 'stale', Principal, Challenge));
-  Assert.AreEqual('invalid_token', Challenge.Error);
+  var Stale := Decide(Authorizer, 'stale');
+  Assert.AreEqual(TMCPAuthDecision.Unauthorized, Stale.Decision);
+  Assert.AreEqual('invalid_token', Stale.Challenge.Error);
 end;
 
 end.

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -199,7 +199,7 @@ begin
     else if Method = 'OPTIONS' then
       Http.Options(Url(Path), Response)
     else
-      raise Exception.Create('unsupported method ' + Method);
+      raise EArgumentException.CreateFmt('Unsupported HTTP method %s', [Method]);
 
     Result.Status := Http.ResponseCode;
     Result.ContentLength := Http.Response.ContentLength;

--- a/tests/MCPServer.Tests.RequestContext.pas
+++ b/tests/MCPServer.Tests.RequestContext.pas
@@ -21,6 +21,7 @@ type
     FProcessor: TMCPJsonRpcProcessor;
     FSession: TMCPLegacySession;
     function Build(const RequestJson: string; const Hints: TMCPTransportHints): IMCPRequestContext;
+    function Request(const Method: string; const ParamsJson: string = ''): string;
     procedure ExpectError(const RequestJson: string; const Hints: TMCPTransportHints;
       ExpectedCode, ExpectedStatus: Integer; const Because: string);
   public
@@ -69,15 +70,15 @@ const
     + '"io.modelcontextprotocol/clientInfo":{"name":"ctx-client","version":"2.0"},'
     + '"io.modelcontextprotocol/logLevel":"info"}';
 
-function Request(const Method: string; const ParamsJson: string = ''): string;
+{ TRequestContextTests }
+
+function TRequestContextTests.Request(const Method: string; const ParamsJson: string): string;
 begin
   if ParamsJson = '' then
     Result := Format('{"jsonrpc":"2.0","id":1,"method":"%s"}', [Method])
   else
     Result := Format('{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}', [Method, ParamsJson]);
 end;
-
-{ TRequestContextTests }
 
 procedure TRequestContextTests.Setup;
 begin

--- a/tests/MCPServer.Tests.ResourcesManager.pas
+++ b/tests/MCPServer.Tests.ResourcesManager.pas
@@ -4,12 +4,16 @@ interface
 
 uses
   DUnitX.TestFramework,
+  System.SysUtils,
   System.JSON,
   MCPServer.Types,
   MCPServer.Resource.Base,
   MCPServer.ResourcesManager;
 
 type
+  EFailingResource = class(Exception)
+  end;
+
   TFailingData = class
   end;
 
@@ -74,7 +78,6 @@ type
 implementation
 
 uses
-  System.SysUtils,
   System.Threading,
   System.Generics.Collections,
   MCPServer.Errors;
@@ -91,7 +94,7 @@ end;
 
 function TFailingResource.GetResourceData: TFailingData;
 begin
-  raise Exception.Create('disk on fire');
+  raise EFailingResource.Create('disk on fire');
 end;
 
 { TEchoResource }

--- a/tests/MCPServer.Tests.SchemaValidator.pas
+++ b/tests/MCPServer.Tests.SchemaValidator.pas
@@ -41,7 +41,7 @@ begin
   var Instance := TJSONNumber.Create(1);
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.AreEqual(1, Integer(Length(Errors)));
     Assert.IsTrue(Errors[0].Contains('expected string'));
   finally
@@ -58,9 +58,9 @@ begin
   var NumberInstance := TJSONNumber.Create(1);
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, TextInstance, Errors));
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, NullInstance, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, NumberInstance, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, TextInstance, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, NullInstance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, NumberInstance, Errors));
   finally
     Schema.Free;
     TextInstance.Free;
@@ -76,8 +76,8 @@ begin
   var FractionInstance := TJSONNumber.Create(3.5);
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, WholeInstance, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, FractionInstance, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, WholeInstance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, FractionInstance, Errors));
   finally
     Schema.Free;
     WholeInstance.Free;
@@ -91,7 +91,7 @@ begin
   var Instance := TJSONObject.ParseJSONValue('{}') as TJSONObject;
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[0].Contains('missing required property "a"'));
   finally
     Schema.Free;
@@ -106,7 +106,7 @@ begin
   var Instance := TJSONObject.ParseJSONValue('{"child":{}}') as TJSONObject;
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[0].Contains('value.child'));
   finally
     Schema.Free;
@@ -121,7 +121,7 @@ begin
   var Instance := TJSONObject.ParseJSONValue('{"a":"x","b":1}') as TJSONObject;
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[0].Contains('unexpected property "b"'));
   finally
     Schema.Free;
@@ -135,7 +135,7 @@ begin
   var Instance := TJSONObject.ParseJSONValue('[1,2,"x"]') as TJSONArray;
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[0].Contains('value[2]'));
   finally
     Schema.Free;
@@ -151,9 +151,9 @@ begin
   var AboveRange := TJSONNumber.Create(11);
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, InRange, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, BelowRange, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, AboveRange, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, InRange, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, BelowRange, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, AboveRange, Errors));
   finally
     Schema.Free;
     InRange.Free;
@@ -172,10 +172,10 @@ begin
   var WrongPattern := TJSONString.Create('AB');
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, Ok, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, TooShort, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, TooLong, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, WrongPattern, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Ok, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, TooShort, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, TooLong, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, WrongPattern, Errors));
   finally
     Schema.Free;
     Ok.Free;
@@ -192,8 +192,8 @@ begin
   var NotAllowed := TJSONString.Create('c');
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, Allowed, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, NotAllowed, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Allowed, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, NotAllowed, Errors));
   finally
     Schema.Free;
     Allowed.Free;
@@ -208,8 +208,8 @@ begin
   var DifferentValue := TJSONString.Create('other');
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, SameValue, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, DifferentValue, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, SameValue, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, DifferentValue, Errors));
   finally
     Schema.Free;
     SameValue.Free;
@@ -226,8 +226,8 @@ begin
   var Invalid := TJSONObject.ParseJSONValue('{"a":0}') as TJSONObject;
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, Valid, Errors));
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Invalid, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Valid, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Invalid, Errors));
   finally
     Schema.Free;
     Valid.Free;
@@ -241,7 +241,7 @@ begin
   var Instance := TJSONString.Create('x');
   try
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[0].Contains('unsupported $ref'));
   finally
     Schema.Free;
@@ -257,7 +257,7 @@ begin
   var Instance := TJSONObject.ParseJSONValue('{"name":"a","age":3}') as TJSONObject;
   try
     var Errors: TArray<string>;
-    Assert.IsTrue(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.AreEqual(0, Integer(Length(Errors)));
   finally
     Schema.Free;
@@ -286,7 +286,7 @@ begin
     end;
 
     var Errors: TArray<string>;
-    Assert.IsFalse(TMCPSchemaValidator.Validate(Schema, Instance, Errors));
+    Assert.IsFalse(TMCPSchemaValidator.TryValidate(Schema, Instance, Errors));
     Assert.IsTrue(Errors[Length(Errors) - 1].Contains('nested too deeply'));
   finally
     Schema.Free;

--- a/tests/MCPServer.Tests.ServerStatus.pas
+++ b/tests/MCPServer.Tests.ServerStatus.pas
@@ -6,10 +6,15 @@ uses
   DUnitX.TestFramework;
 
 type
+  TServerCounters = record
+    RequestCount: Int64;
+    ActiveConnections: Integer;
+  end;
+
   [TestFixture]
   TServerStatusResourceTests = class
   private
-    procedure ReadCounters(out RequestCount: Int64; out ActiveConnections: Integer);
+    function ReadCounters: TServerCounters;
   public
     [Setup]
     procedure Setup;
@@ -41,14 +46,15 @@ begin
   TServerStatusResource.Initialize;
 end;
 
-procedure TServerStatusResourceTests.ReadCounters(out RequestCount: Int64; out ActiveConnections: Integer);
+function TServerStatusResourceTests.ReadCounters: TServerCounters;
 begin
+  Result := Default(TServerCounters);
   var Resource: IMCPResource := TServerStatusResource.Create;
-  var Status := TJSONObject.ParseJSONValue(Resource.Read) as TJSONObject;
+  const Status = TJSONObject.ParseJSONValue(Resource.Read) as TJSONObject;
   try
     Assert.IsNotNull(Status, 'server://status must return a JSON object');
-    RequestCount := Status.GetValue<Int64>('requestcount');
-    ActiveConnections := Status.GetValue<Integer>('activeconnections');
+    Result.RequestCount := Status.GetValue<Int64>('requestcount');
+    Result.ActiveConnections := Status.GetValue<Integer>('activeconnections');
   finally
     Status.Free;
   end;
@@ -56,12 +62,10 @@ end;
 
 procedure TServerStatusResourceTests.Counters_StartAtZero;
 begin
-  var RequestCount: Int64;
-  var ActiveConnections: Integer;
-  ReadCounters(RequestCount, ActiveConnections);
+  const Counters = ReadCounters;
 
-  Assert.AreEqual(Int64(0), RequestCount);
-  Assert.AreEqual(0, ActiveConnections);
+  Assert.AreEqual(Int64(0), Counters.RequestCount);
+  Assert.AreEqual(0, Counters.ActiveConnections);
 end;
 
 procedure TServerStatusResourceTests.Counters_AreExactUnderConcurrentUpdates;
@@ -81,12 +85,10 @@ begin
       end);
   TTask.WaitForAll(Tasks);
 
-  var RequestCount: Int64;
-  var ActiveConnections: Integer;
-  ReadCounters(RequestCount, ActiveConnections);
+  const Counters = ReadCounters;
 
-  Assert.AreEqual(Int64(THREAD_COUNT) * ITERATIONS_PER_THREAD, RequestCount, 'lost request increments');
-  Assert.AreEqual(0, ActiveConnections, 'every opened connection was closed');
+  Assert.AreEqual(Int64(THREAD_COUNT) * ITERATIONS_PER_THREAD, Counters.RequestCount, 'lost request increments');
+  Assert.AreEqual(0, Counters.ActiveConnections, 'every opened connection was closed');
 end;
 
 procedure TServerStatusResourceTests.ConnectionClosed_NeverGoesBelowZero;
@@ -97,11 +99,9 @@ begin
   TServerStatusResource.ConnectionClosed;
   TServerStatusResource.ConnectionClosed;
 
-  var RequestCount: Int64;
-  var ActiveConnections: Integer;
-  ReadCounters(RequestCount, ActiveConnections);
+  const Counters = ReadCounters;
 
-  Assert.AreEqual(0, ActiveConnections);
+  Assert.AreEqual(0, Counters.ActiveConnections);
 end;
 
 procedure TServerStatusResourceTests.Read_ProducesJsonWithStatusFields;

--- a/tests/MCPServer.Tests.StdioChannel.pas
+++ b/tests/MCPServer.Tests.StdioChannel.pas
@@ -13,7 +13,7 @@ type
   [TestFixture]
   TStdioChannelTests = class
   private
-    function ReadAll(const Bytes: TBytes; MaxLineBytes: Integer; out Statuses: TArray<TMCPLineStatus>): TArray<string>;
+    function ReadAll(const Bytes: TBytes; const MaxLineBytes: Integer): TArray<TMCPLine>;
   public
     [Test] procedure Reader_SplitsOnLf_DropsCr_LastLineWithoutNewline;
     [Test] procedure Reader_SkipsByteOrderMark;
@@ -37,21 +37,17 @@ uses
 
 { TStdioChannelTests }
 
-function TStdioChannelTests.ReadAll(const Bytes: TBytes; MaxLineBytes: Integer;
-  out Statuses: TArray<TMCPLineStatus>): TArray<string>;
+function TStdioChannelTests.ReadAll(const Bytes: TBytes; const MaxLineBytes: Integer): TArray<TMCPLine>;
 var
-  Line: string;
-  Status: TMCPLineStatus;
+  Line: TMCPLine;
 begin
   Result := nil;
-  Statuses := nil;
-  var Stream := TBytesStream.Create(Bytes);
-  var Reader := TMCPLineReader.Create(Stream, MaxLineBytes);
+  const Stream = TBytesStream.Create(Bytes);
+  const Reader = TMCPLineReader.Create(Stream, MaxLineBytes);
   try
-    while Reader.ReadLine(Line, Status) do
+    while Reader.TryReadLine(Line) do
     begin
       Result := Result + [Line];
-      Statuses := Statuses + [Status];
     end;
   finally
     Reader.Free;
@@ -60,108 +56,92 @@ begin
 end;
 
 procedure TStdioChannelTests.Reader_SplitsOnLf_DropsCr_LastLineWithoutNewline;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
-  var Lines := ReadAll(TEncoding.UTF8.GetBytes('one'#13#10'two'#10#10'three'), 1024, Statuses);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes('one'#13#10'two'#10#10'three'), 1024);
   Assert.AreEqual(4, Integer(Length(Lines)));
-  Assert.AreEqual('one', Lines[0]);
-  Assert.AreEqual('two', Lines[1]);
-  Assert.AreEqual('', Lines[2]);
-  Assert.AreEqual('three', Lines[3]);
-  for var Status in Statuses do
-    Assert.IsTrue(Status = TMCPLineStatus.Ok);
+  Assert.AreEqual('one', Lines[0].Text);
+  Assert.AreEqual('two', Lines[1].Text);
+  Assert.AreEqual('', Lines[2].Text);
+  Assert.AreEqual('three', Lines[3].Text);
+  for var Line in Lines do
+  begin
+    Assert.IsTrue(Line.Status = TMCPLineStatus.Ok);
+  end;
 end;
 
 procedure TStdioChannelTests.Reader_SkipsByteOrderMark;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Bytes := TBytes.Create($EF, $BB, $BF) + TEncoding.UTF8.GetBytes('{"a":1}'#10);
-  var Lines := ReadAll(Bytes, 1024, Statuses);
+  var Lines := ReadAll(Bytes, 1024);
   Assert.AreEqual(1, Integer(Length(Lines)));
-  Assert.AreEqual('{"a":1}', Lines[0]);
+  Assert.AreEqual('{"a":1}', Lines[0].Text);
 end;
 
 procedure TStdioChannelTests.Reader_DecodesUtf8;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Probe := 'h' + Char($00E9) + 'llo w' + Char($00F6) + 'rld ' + Char($D83D) + Char($DE00);
-  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Probe + #10), 1024, Statuses);
-  Assert.AreEqual(Probe, Lines[0]);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Probe + #10), 1024);
+  Assert.AreEqual(Probe, Lines[0].Text);
 end;
 
 procedure TStdioChannelTests.Reader_ReportsOverlongLine_AndContinues;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Long := StringOfChar('x', 100);
-  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Long + #10'short'#10), 50, Statuses);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Long + #10'short'#10), 50);
   Assert.AreEqual(2, Integer(Length(Lines)));
-  Assert.IsTrue(Statuses[0] = TMCPLineStatus.TooLong);
-  Assert.AreEqual('', Lines[0]);
-  Assert.IsTrue(Statuses[1] = TMCPLineStatus.Ok);
-  Assert.AreEqual('short', Lines[1]);
+  Assert.IsTrue(Lines[0].Status = TMCPLineStatus.TooLong);
+  Assert.AreEqual('', Lines[0].Text);
+  Assert.IsTrue(Lines[1].Status = TMCPLineStatus.Ok);
+  Assert.AreEqual('short', Lines[1].Text);
 end;
 
 procedure TStdioChannelTests.Reader_OverlongLineWithoutNewline_EndsStream;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
-  var Lines := ReadAll(TEncoding.UTF8.GetBytes(StringOfChar('x', 100)), 50, Statuses);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(StringOfChar('x', 100)), 50);
   Assert.AreEqual(1, Integer(Length(Lines)));
-  Assert.IsTrue(Statuses[0] = TMCPLineStatus.TooLong);
-  Assert.AreEqual('', Lines[0]);
+  Assert.IsTrue(Lines[0].Status = TMCPLineStatus.TooLong);
+  Assert.AreEqual('', Lines[0].Text);
 end;
 
 procedure TStdioChannelTests.Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
 const
   BEYOND_ONE_CHUNK = 70 * 1024;
   LIMIT = 1024;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Long := StringOfChar('y', BEYOND_ONE_CHUNK);
-  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Long + #10'after'#10'last'), LIMIT, Statuses);
+  var Lines := ReadAll(TEncoding.UTF8.GetBytes(Long + #10'after'#10'last'), LIMIT);
   Assert.AreEqual(3, Integer(Length(Lines)));
-  Assert.IsTrue(Statuses[0] = TMCPLineStatus.TooLong);
-  Assert.IsTrue(Statuses[1] = TMCPLineStatus.Ok);
-  Assert.AreEqual('after', Lines[1]);
-  Assert.IsTrue(Statuses[2] = TMCPLineStatus.Ok);
-  Assert.AreEqual('last', Lines[2]);
+  Assert.IsTrue(Lines[0].Status = TMCPLineStatus.TooLong);
+  Assert.IsTrue(Lines[1].Status = TMCPLineStatus.Ok);
+  Assert.AreEqual('after', Lines[1].Text);
+  Assert.IsTrue(Lines[2].Status = TMCPLineStatus.Ok);
+  Assert.AreEqual('last', Lines[2].Text);
 end;
 
 procedure TStdioChannelTests.Reader_ReportsInvalidUtf8_AndContinues;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Bytes := TBytes.Create($FF, $FE, $41) + TEncoding.UTF8.GetBytes(#10'ok'#10);
-  var Lines := ReadAll(Bytes, 1024, Statuses);
+  var Lines := ReadAll(Bytes, 1024);
   Assert.AreEqual(2, Integer(Length(Lines)));
-  Assert.IsTrue(Statuses[0] = TMCPLineStatus.InvalidUtf8, 'first line is not UTF-8');
-  Assert.AreEqual('ok', Lines[1]);
+  Assert.IsTrue(Lines[0].Status = TMCPLineStatus.InvalidUtf8, 'first line is not UTF-8');
+  Assert.AreEqual('ok', Lines[1].Text);
 end;
 
 procedure TStdioChannelTests.Reader_ReportsReplacedUtf8_AsInvalid;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
   var Truncated := TBytes.Create($41, $C3) + TEncoding.UTF8.GetBytes(#10);
   var Overlong := TBytes.Create($C0, $AF) + TEncoding.UTF8.GetBytes(#10'ok'#10);
-  var Lines := ReadAll(Truncated + Overlong, 1024, Statuses);
+  var Lines := ReadAll(Truncated + Overlong, 1024);
   Assert.AreEqual(3, Integer(Length(Lines)));
-  Assert.IsTrue(Statuses[0] = TMCPLineStatus.InvalidUtf8, 'a truncated sequence is not UTF-8');
-  Assert.IsTrue(Statuses[1] = TMCPLineStatus.InvalidUtf8, 'an overlong sequence is not UTF-8');
-  Assert.IsTrue(Statuses[2] = TMCPLineStatus.Ok);
-  Assert.AreEqual('ok', Lines[2]);
+  Assert.IsTrue(Lines[0].Status = TMCPLineStatus.InvalidUtf8, 'a truncated sequence is not UTF-8');
+  Assert.IsTrue(Lines[1].Status = TMCPLineStatus.InvalidUtf8, 'an overlong sequence is not UTF-8');
+  Assert.IsTrue(Lines[2].Status = TMCPLineStatus.Ok);
+  Assert.AreEqual('ok', Lines[2].Text);
 end;
 
 procedure TStdioChannelTests.Reader_EmptyStream_HasNoLines;
-var
-  Statuses: TArray<TMCPLineStatus>;
 begin
-  var Lines := ReadAll(nil, 1024, Statuses);
+  var Lines := ReadAll(nil, 1024);
   Assert.AreEqual(0, Integer(Length(Lines)));
 end;
 

--- a/tests/MCPServer.Tests.ToolResult.pas
+++ b/tests/MCPServer.Tests.ToolResult.pas
@@ -163,7 +163,7 @@ begin
   SetLength(Bytes, 300);
   for var I := 0 to High(Bytes) do
     Bytes[I] := Byte(I);
-  var Encoded := EncodeBase64Blob(Bytes);
+  var Encoded := TMCPContentBlock.EncodeBlob(Bytes);
   Assert.AreEqual(400, Length(Encoded));
   Assert.IsFalse(Encoded.Contains(#13) or Encoded.Contains(#10));
 end;


### PR DESCRIPTION
## Summary

- Every loose routine outside the documented public API moves onto a type: `TMCPContentBlock`, `TMCPProtocolVersion`, `TMCPOriginParts`, `TMCPStrings`, and private methods on `TLogger`, `TMCPToolsManager` and the request context fixture. The schema generator keeps its RTTI context in a class variable instead of an `initialization` section.
- No code path raises the base `Exception`: `EMCPRegistryNotFound`, `EMCPError.MethodNotFound` and `EMCPConfigurationError` replace it, in `src` and in the tests.
- Functions that reported through `out` parameters return a record (`TMCPAuthResult`, `TMCPLine`, `TMCPCompiledTemplate`, `TServerCounters`) or carry a `Try` prefix (`TryValidateToken`, `TryReadLine`, `TryValidate`, `TryResolveRef`, `TryCheckType`, `TryAuthenticate`).
- `coding-rules.md` stands on its own and records the conventions a reader could take for mistakes: `UPPER_CASE` constants, registration in `initialization`, units per concept, the remaining public global functions, and the framework signatures.

## Verification

- DUnitX: 376/376 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 and Release build clean.
- HTTP goldens, conformance (155 and 59, baselines unchanged), Inspector smoke and stdio smoke all pass.