### PR TITLE
One constant per protocol value, no repeated literals

### DIFF
--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -117,7 +117,8 @@ uses
   System.Net.HttpClient,
   System.Net.URLClient,
   System.NetConsts,
-  MCPServer.Logger;
+  MCPServer.Logger,
+  MCPServer.Errors;
 
 const
   CLAIM_SUBJECT = 'sub';
@@ -126,12 +127,10 @@ const
   CLAIM_SCOPE = 'scope';
   CLAIM_SCOPE_ARRAY = 'scp';
   CLAIM_ACTIVE = 'active';
-  SCOPE_ANY = '*';
   SCOPE_OFFLINE_ACCESS = 'offline_access';
   SCOPE_SEPARATOR = ' ';
   STATIC_SUBJECT_FORMAT = 'token-%d';
   MEDIA_TYPE_FORM = 'application/x-www-form-urlencoded';
-  HTTP_STATUS_OK = 200;
 
 { TMCPPrincipal }
 
@@ -144,7 +143,7 @@ function TMCPPrincipal.HasScope(const Scope: string): Boolean;
 begin
   for var Granted in Scopes do
   begin
-    if (Granted = Scope) or (Granted = SCOPE_ANY) then
+    if (Granted = Scope) or (Granted = MCP_SCOPE_ANY) then
       Exit(True);
   end;
   Result := False;
@@ -284,7 +283,7 @@ begin
     raise EMCPAuthorizationConfiguration.Create('A static bearer authorizer needs at least one token');
   FScopes := Scopes;
   if Length(FScopes) = 0 then
-    FScopes := [SCOPE_ANY];
+    FScopes := [MCP_SCOPE_ANY];
 end;
 
 class function TMCPStaticBearerAuthorizer.SameToken(const Presented, Expected: TBytes): Boolean;

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -112,6 +112,15 @@ implementation
 uses
   MCPServer.Logger;
 
+const
+  SECTION_SERVER = 'Server';
+  SECTION_SECURITY = 'Security';
+  SECTION_AUTH = 'Auth';
+  SECTION_SSL = 'SSL';
+  SECTION_PROTOCOL = 'Protocol';
+  SECTION_CORS = 'CORS';
+
+
 { TMCPSettings }
 
 constructor TMCPSettings.Create(const ASettingsFile: string; const ACreateFile: Boolean);
@@ -228,57 +237,57 @@ var
 begin
   IniFile := TIniFile.Create(FSettingsFile);
   try
-    IniFile.WriteString('Server', '; Server configuration', '');
-    IniFile.WriteInteger('Server', 'Port', FPort);
-    IniFile.WriteString('Server', 'Host', FHost);
-    IniFile.WriteString('Server', 'Name', FServerName);
-    IniFile.WriteString('Server', 'Version', FServerVersion);
-    IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    IniFile.WriteString('Server', '; Optional identity reported to clients', '');
-    IniFile.WriteString('Server', 'Title', FServerTitle);
-    IniFile.WriteString('Server', 'Description', FServerDescription);
-    IniFile.WriteString('Server', 'WebsiteUrl', FServerWebsiteUrl);
-    IniFile.WriteString('Server', 'Instructions', FInstructions);
-    IniFile.WriteString('Server', '; Network: BindAddress empty = derived from Host (loopback for localhost)', '');
-    IniFile.WriteString('Server', 'BindAddress', FBindAddress);
-    IniFile.WriteString('Server', 'EndpointInfoPath', FEndpointInfoPath);
-    IniFile.WriteInteger('Server', 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
-    IniFile.WriteInteger('Server', 'MaxJsonDepth', FMaxJsonDepth);
-    IniFile.WriteInteger('Server', 'MaxConcurrentRequests', FMaxConcurrentRequests);
-    IniFile.WriteInteger('Server', 'MaxConnections', FMaxConnections);
-    IniFile.WriteString('Server', '; Serve logs://recent, logs://{level} and server://status (0 = keep diagnostics private)', '');
-    IniFile.WriteBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
+    IniFile.WriteString(SECTION_SERVER, '; Server configuration', '');
+    IniFile.WriteInteger(SECTION_SERVER, 'Port', FPort);
+    IniFile.WriteString(SECTION_SERVER, 'Host', FHost);
+    IniFile.WriteString(SECTION_SERVER, 'Name', FServerName);
+    IniFile.WriteString(SECTION_SERVER, 'Version', FServerVersion);
+    IniFile.WriteString(SECTION_SERVER, 'Endpoint', FEndpoint);
+    IniFile.WriteString(SECTION_SERVER, '; Optional identity reported to clients', '');
+    IniFile.WriteString(SECTION_SERVER, 'Title', FServerTitle);
+    IniFile.WriteString(SECTION_SERVER, 'Description', FServerDescription);
+    IniFile.WriteString(SECTION_SERVER, 'WebsiteUrl', FServerWebsiteUrl);
+    IniFile.WriteString(SECTION_SERVER, 'Instructions', FInstructions);
+    IniFile.WriteString(SECTION_SERVER, '; Network: BindAddress empty = derived from Host (loopback for localhost)', '');
+    IniFile.WriteString(SECTION_SERVER, 'BindAddress', FBindAddress);
+    IniFile.WriteString(SECTION_SERVER, 'EndpointInfoPath', FEndpointInfoPath);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxJsonDepth', FMaxJsonDepth);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxConcurrentRequests', FMaxConcurrentRequests);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxConnections', FMaxConnections);
+    IniFile.WriteString(SECTION_SERVER, '; Serve logs://recent, logs://{level} and server://status (0 = keep diagnostics private)', '');
+    IniFile.WriteBool(SECTION_SERVER, 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
 
-    IniFile.WriteString('Security', '; Origins allowed next to the loopback origins (empty = [CORS] AllowedOrigins)', '');
-    IniFile.WriteString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
-    IniFile.WriteString('Security', '; Host header values accepted, comma-separated host[:port] (empty = any)', '');
-    IniFile.WriteString('Security', 'AllowedHosts', FAllowedHosts);
-    IniFile.WriteString('Security', '; Secret that signs requestState tokens (empty = random per process)', '');
-    IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
-    IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
+    IniFile.WriteString(SECTION_SECURITY, '; Origins allowed next to the loopback origins (empty = [CORS] AllowedOrigins)', '');
+    IniFile.WriteString(SECTION_SECURITY, 'AllowedOrigins', FSecurityAllowedOrigins);
+    IniFile.WriteString(SECTION_SECURITY, '; Host header values accepted, comma-separated host[:port] (empty = any)', '');
+    IniFile.WriteString(SECTION_SECURITY, 'AllowedHosts', FAllowedHosts);
+    IniFile.WriteString(SECTION_SECURITY, '; Secret that signs requestState tokens (empty = random per process)', '');
+    IniFile.WriteString(SECTION_SECURITY, 'RequestStateKey', FRequestStateKey);
+    IniFile.WriteInteger(SECTION_SECURITY, 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 
-    IniFile.WriteString('Auth', '; Bearer tokens accepted on the HTTP endpoint (comma-separated; empty = open server)', '');
-    IniFile.WriteString('Auth', 'BearerTokens', FBearerTokens);
-    IniFile.WriteString('Auth', '; OAuth authorization servers published in the protected resource metadata', '');
-    IniFile.WriteString('Auth', 'AuthorizationServers', FAuthorizationServers);
-    IniFile.WriteString('Auth', 'ResourceUri', FResourceUri);
-    IniFile.WriteString('Auth', 'ScopesSupported', FScopesSupported);
+    IniFile.WriteString(SECTION_AUTH, '; Bearer tokens accepted on the HTTP endpoint (comma-separated; empty = open server)', '');
+    IniFile.WriteString(SECTION_AUTH, 'BearerTokens', FBearerTokens);
+    IniFile.WriteString(SECTION_AUTH, '; OAuth authorization servers published in the protected resource metadata', '');
+    IniFile.WriteString(SECTION_AUTH, 'AuthorizationServers', FAuthorizationServers);
+    IniFile.WriteString(SECTION_AUTH, 'ResourceUri', FResourceUri);
+    IniFile.WriteString(SECTION_AUTH, 'ScopesSupported', FScopesSupported);
 
-    IniFile.WriteString('Protocol', '; Protocol options (1 = on, 0 = off)', '');
-    IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
-    IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
-    IniFile.WriteInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+    IniFile.WriteString(SECTION_PROTOCOL, '; Protocol options (1 = on, 0 = off)', '');
+    IniFile.WriteBool(SECTION_PROTOCOL, 'LenientModernPing', FLenientModernPing);
+    IniFile.WriteBool(SECTION_PROTOCOL, 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    IniFile.WriteInteger(SECTION_PROTOCOL, 'DiscoverTtlMs', FDiscoverTtlMs);
 
-    IniFile.WriteString('CORS', '; Cross-Origin Resource Sharing configuration', '');
-    IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
-    IniFile.WriteString('CORS', '; Comma-separated list of allowed origins', '');
-    IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
+    IniFile.WriteString(SECTION_CORS, '; Cross-Origin Resource Sharing configuration', '');
+    IniFile.WriteBool(SECTION_CORS, 'Enabled', FCorsEnabled);
+    IniFile.WriteString(SECTION_CORS, '; Comma-separated list of allowed origins', '');
+    IniFile.WriteString(SECTION_CORS, 'AllowedOrigins', FCorsAllowedOrigins);
 
-    IniFile.WriteString('SSL', '; SSL/TLS configuration (optional)', '');
-    IniFile.WriteBool('SSL', 'Enabled', FSSLEnabled);
-    IniFile.WriteString('SSL', 'CertFile', FSSLCertFile);
-    IniFile.WriteString('SSL', 'KeyFile', FSSLKeyFile);
-    IniFile.WriteString('SSL', 'RootCertFile', FSSLRootCertFile);
+    IniFile.WriteString(SECTION_SSL, '; SSL/TLS configuration (optional)', '');
+    IniFile.WriteBool(SECTION_SSL, 'Enabled', FSSLEnabled);
+    IniFile.WriteString(SECTION_SSL, 'CertFile', FSSLCertFile);
+    IniFile.WriteString(SECTION_SSL, 'KeyFile', FSSLKeyFile);
+    IniFile.WriteString(SECTION_SSL, 'RootCertFile', FSSLRootCertFile);
   finally
     IniFile.Free;
   end;
@@ -293,44 +302,44 @@ begin
 
   IniFile := TIniFile.Create(FSettingsFile);
   try
-    FPort := IniFile.ReadInteger('Server', 'Port', FPort);
-    FHost := IniFile.ReadString('Server', 'Host', FHost);
-    FServerName := IniFile.ReadString('Server', 'Name', FServerName);
-    FServerVersion := IniFile.ReadString('Server', 'Version', FServerVersion);
-    FEndpoint := IniFile.ReadString('Server', 'Endpoint', FEndpoint);
-    FServerTitle := IniFile.ReadString('Server', 'Title', FServerTitle);
-    FServerDescription := IniFile.ReadString('Server', 'Description', FServerDescription);
-    FServerWebsiteUrl := IniFile.ReadString('Server', 'WebsiteUrl', FServerWebsiteUrl);
-    FInstructions := IniFile.ReadString('Server', 'Instructions', FInstructions);
-    FBindAddress := IniFile.ReadString('Server', 'BindAddress', FBindAddress);
-    FEndpointInfoPath := IniFile.ReadString('Server', 'EndpointInfoPath', FEndpointInfoPath);
-    FMaxRequestBodyBytes := IniFile.ReadInteger('Server', 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
-    FMaxJsonDepth := IniFile.ReadInteger('Server', 'MaxJsonDepth', FMaxJsonDepth);
-    FMaxConcurrentRequests := IniFile.ReadInteger('Server', 'MaxConcurrentRequests', FMaxConcurrentRequests);
-    FMaxConnections := IniFile.ReadInteger('Server', 'MaxConnections', FMaxConnections);
+    FPort := IniFile.ReadInteger(SECTION_SERVER, 'Port', FPort);
+    FHost := IniFile.ReadString(SECTION_SERVER, 'Host', FHost);
+    FServerName := IniFile.ReadString(SECTION_SERVER, 'Name', FServerName);
+    FServerVersion := IniFile.ReadString(SECTION_SERVER, 'Version', FServerVersion);
+    FEndpoint := IniFile.ReadString(SECTION_SERVER, 'Endpoint', FEndpoint);
+    FServerTitle := IniFile.ReadString(SECTION_SERVER, 'Title', FServerTitle);
+    FServerDescription := IniFile.ReadString(SECTION_SERVER, 'Description', FServerDescription);
+    FServerWebsiteUrl := IniFile.ReadString(SECTION_SERVER, 'WebsiteUrl', FServerWebsiteUrl);
+    FInstructions := IniFile.ReadString(SECTION_SERVER, 'Instructions', FInstructions);
+    FBindAddress := IniFile.ReadString(SECTION_SERVER, 'BindAddress', FBindAddress);
+    FEndpointInfoPath := IniFile.ReadString(SECTION_SERVER, 'EndpointInfoPath', FEndpointInfoPath);
+    FMaxRequestBodyBytes := IniFile.ReadInteger(SECTION_SERVER, 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
+    FMaxJsonDepth := IniFile.ReadInteger(SECTION_SERVER, 'MaxJsonDepth', FMaxJsonDepth);
+    FMaxConcurrentRequests := IniFile.ReadInteger(SECTION_SERVER, 'MaxConcurrentRequests', FMaxConcurrentRequests);
+    FMaxConnections := IniFile.ReadInteger(SECTION_SERVER, 'MaxConnections', FMaxConnections);
 
-    FSecurityAllowedOrigins := IniFile.ReadString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
-    FAllowedHosts := IniFile.ReadString('Security', 'AllowedHosts', FAllowedHosts);
-    FExposeDiagnosticsResources := IniFile.ReadBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
-    FRequestStateKey := IniFile.ReadString('Security', 'RequestStateKey', FRequestStateKey);
-    FRequestStateTtlSeconds := IniFile.ReadInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
+    FSecurityAllowedOrigins := IniFile.ReadString(SECTION_SECURITY, 'AllowedOrigins', FSecurityAllowedOrigins);
+    FAllowedHosts := IniFile.ReadString(SECTION_SECURITY, 'AllowedHosts', FAllowedHosts);
+    FExposeDiagnosticsResources := IniFile.ReadBool(SECTION_SERVER, 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
+    FRequestStateKey := IniFile.ReadString(SECTION_SECURITY, 'RequestStateKey', FRequestStateKey);
+    FRequestStateTtlSeconds := IniFile.ReadInteger(SECTION_SECURITY, 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 
-    FBearerTokens := IniFile.ReadString('Auth', 'BearerTokens', FBearerTokens);
-    FAuthorizationServers := IniFile.ReadString('Auth', 'AuthorizationServers', FAuthorizationServers);
-    FResourceUri := IniFile.ReadString('Auth', 'ResourceUri', FResourceUri);
-    FScopesSupported := IniFile.ReadString('Auth', 'ScopesSupported', FScopesSupported);
+    FBearerTokens := IniFile.ReadString(SECTION_AUTH, 'BearerTokens', FBearerTokens);
+    FAuthorizationServers := IniFile.ReadString(SECTION_AUTH, 'AuthorizationServers', FAuthorizationServers);
+    FResourceUri := IniFile.ReadString(SECTION_AUTH, 'ResourceUri', FResourceUri);
+    FScopesSupported := IniFile.ReadString(SECTION_AUTH, 'ScopesSupported', FScopesSupported);
 
-    FLenientModernPing := IniFile.ReadBool('Protocol', 'LenientModernPing', FLenientModernPing);
-    FDiscoverListsLegacyVersions := IniFile.ReadBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
-    FDiscoverTtlMs := IniFile.ReadInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+    FLenientModernPing := IniFile.ReadBool(SECTION_PROTOCOL, 'LenientModernPing', FLenientModernPing);
+    FDiscoverListsLegacyVersions := IniFile.ReadBool(SECTION_PROTOCOL, 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    FDiscoverTtlMs := IniFile.ReadInteger(SECTION_PROTOCOL, 'DiscoverTtlMs', FDiscoverTtlMs);
 
-    FCorsEnabled := IniFile.ReadBool('CORS', 'Enabled', FCorsEnabled);
-    FCorsAllowedOrigins := IniFile.ReadString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
+    FCorsEnabled := IniFile.ReadBool(SECTION_CORS, 'Enabled', FCorsEnabled);
+    FCorsAllowedOrigins := IniFile.ReadString(SECTION_CORS, 'AllowedOrigins', FCorsAllowedOrigins);
 
-    FSSLEnabled := IniFile.ReadBool('SSL', 'Enabled', FSSLEnabled);
-    FSSLCertFile := IniFile.ReadString('SSL', 'CertFile', FSSLCertFile);
-    FSSLKeyFile := IniFile.ReadString('SSL', 'KeyFile', FSSLKeyFile);
-    FSSLRootCertFile := IniFile.ReadString('SSL', 'RootCertFile', FSSLRootCertFile);
+    FSSLEnabled := IniFile.ReadBool(SECTION_SSL, 'Enabled', FSSLEnabled);
+    FSSLCertFile := IniFile.ReadString(SECTION_SSL, 'CertFile', FSSLCertFile);
+    FSSLKeyFile := IniFile.ReadString(SECTION_SSL, 'KeyFile', FSSLKeyFile);
+    FSSLRootCertFile := IniFile.ReadString(SECTION_SSL, 'RootCertFile', FSSLRootCertFile);
 
     TLogger.Info('Settings loaded from: ' + FSettingsFile);
     TLogger.Info('Server: ' + Protocol + '://' + FHost + ':' + IntToStr(FPort));
@@ -354,44 +363,44 @@ var
 begin
   IniFile := TIniFile.Create(FSettingsFile);
   try
-    IniFile.WriteInteger('Server', 'Port', FPort);
-    IniFile.WriteString('Server', 'Host', FHost);
-    IniFile.WriteString('Server', 'Name', FServerName);
-    IniFile.WriteString('Server', 'Version', FServerVersion);
-    IniFile.WriteString('Server', 'Endpoint', FEndpoint);
-    IniFile.WriteString('Server', 'Title', FServerTitle);
-    IniFile.WriteString('Server', 'Description', FServerDescription);
-    IniFile.WriteString('Server', 'WebsiteUrl', FServerWebsiteUrl);
-    IniFile.WriteString('Server', 'Instructions', FInstructions);
-    IniFile.WriteString('Server', 'BindAddress', FBindAddress);
-    IniFile.WriteString('Server', 'EndpointInfoPath', FEndpointInfoPath);
-    IniFile.WriteInteger('Server', 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
-    IniFile.WriteInteger('Server', 'MaxJsonDepth', FMaxJsonDepth);
-    IniFile.WriteInteger('Server', 'MaxConcurrentRequests', FMaxConcurrentRequests);
-    IniFile.WriteInteger('Server', 'MaxConnections', FMaxConnections);
-    IniFile.WriteBool('Server', 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
+    IniFile.WriteInteger(SECTION_SERVER, 'Port', FPort);
+    IniFile.WriteString(SECTION_SERVER, 'Host', FHost);
+    IniFile.WriteString(SECTION_SERVER, 'Name', FServerName);
+    IniFile.WriteString(SECTION_SERVER, 'Version', FServerVersion);
+    IniFile.WriteString(SECTION_SERVER, 'Endpoint', FEndpoint);
+    IniFile.WriteString(SECTION_SERVER, 'Title', FServerTitle);
+    IniFile.WriteString(SECTION_SERVER, 'Description', FServerDescription);
+    IniFile.WriteString(SECTION_SERVER, 'WebsiteUrl', FServerWebsiteUrl);
+    IniFile.WriteString(SECTION_SERVER, 'Instructions', FInstructions);
+    IniFile.WriteString(SECTION_SERVER, 'BindAddress', FBindAddress);
+    IniFile.WriteString(SECTION_SERVER, 'EndpointInfoPath', FEndpointInfoPath);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxRequestBodyBytes', FMaxRequestBodyBytes);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxJsonDepth', FMaxJsonDepth);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxConcurrentRequests', FMaxConcurrentRequests);
+    IniFile.WriteInteger(SECTION_SERVER, 'MaxConnections', FMaxConnections);
+    IniFile.WriteBool(SECTION_SERVER, 'ExposeDiagnosticsResources', FExposeDiagnosticsResources);
 
-    IniFile.WriteString('Security', 'AllowedOrigins', FSecurityAllowedOrigins);
-    IniFile.WriteString('Security', 'AllowedHosts', FAllowedHosts);
-    IniFile.WriteString('Security', 'RequestStateKey', FRequestStateKey);
-    IniFile.WriteInteger('Security', 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
+    IniFile.WriteString(SECTION_SECURITY, 'AllowedOrigins', FSecurityAllowedOrigins);
+    IniFile.WriteString(SECTION_SECURITY, 'AllowedHosts', FAllowedHosts);
+    IniFile.WriteString(SECTION_SECURITY, 'RequestStateKey', FRequestStateKey);
+    IniFile.WriteInteger(SECTION_SECURITY, 'RequestStateTtlSeconds', FRequestStateTtlSeconds);
 
-    IniFile.WriteString('Auth', 'BearerTokens', FBearerTokens);
-    IniFile.WriteString('Auth', 'AuthorizationServers', FAuthorizationServers);
-    IniFile.WriteString('Auth', 'ResourceUri', FResourceUri);
-    IniFile.WriteString('Auth', 'ScopesSupported', FScopesSupported);
+    IniFile.WriteString(SECTION_AUTH, 'BearerTokens', FBearerTokens);
+    IniFile.WriteString(SECTION_AUTH, 'AuthorizationServers', FAuthorizationServers);
+    IniFile.WriteString(SECTION_AUTH, 'ResourceUri', FResourceUri);
+    IniFile.WriteString(SECTION_AUTH, 'ScopesSupported', FScopesSupported);
 
-    IniFile.WriteBool('Protocol', 'LenientModernPing', FLenientModernPing);
-    IniFile.WriteBool('Protocol', 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
-    IniFile.WriteInteger('Protocol', 'DiscoverTtlMs', FDiscoverTtlMs);
+    IniFile.WriteBool(SECTION_PROTOCOL, 'LenientModernPing', FLenientModernPing);
+    IniFile.WriteBool(SECTION_PROTOCOL, 'DiscoverListsLegacyVersions', FDiscoverListsLegacyVersions);
+    IniFile.WriteInteger(SECTION_PROTOCOL, 'DiscoverTtlMs', FDiscoverTtlMs);
 
-    IniFile.WriteBool('CORS', 'Enabled', FCorsEnabled);
-    IniFile.WriteString('CORS', 'AllowedOrigins', FCorsAllowedOrigins);
+    IniFile.WriteBool(SECTION_CORS, 'Enabled', FCorsEnabled);
+    IniFile.WriteString(SECTION_CORS, 'AllowedOrigins', FCorsAllowedOrigins);
 
-    IniFile.WriteBool('SSL', 'Enabled', FSSLEnabled);
-    IniFile.WriteString('SSL', 'CertFile', FSSLCertFile);
-    IniFile.WriteString('SSL', 'KeyFile', FSSLKeyFile);
-    IniFile.WriteString('SSL', 'RootCertFile', FSSLRootCertFile);
+    IniFile.WriteBool(SECTION_SSL, 'Enabled', FSSLEnabled);
+    IniFile.WriteString(SECTION_SSL, 'CertFile', FSSLCertFile);
+    IniFile.WriteString(SECTION_SSL, 'KeyFile', FSSLKeyFile);
+    IniFile.WriteString(SECTION_SSL, 'RootCertFile', FSSLRootCertFile);
   finally
     IniFile.Free;
   end;

--- a/src/Http/MCPServer.Http.ResponseParser.pas
+++ b/src/Http/MCPServer.Http.ResponseParser.pas
@@ -17,12 +17,16 @@ type
 
 implementation
 
+
+const
+  KEY_SUCCESS = 'success';
+
 function TJsonResponseParser.ParseSuccess(const Response: IHttpResponse): TJSONObject;
 begin
   if Response.StatusCode = 204 then
   begin
     Result := TJSONObject.Create;
-    Result.AddPair('success', TJSONBool.Create(True));
+    Result.AddPair(KEY_SUCCESS, TJSONBool.Create(True));
     Exit;
   end;
 
@@ -40,14 +44,14 @@ begin
     else
     begin
       Result := TJSONObject.Create;
-      Result.AddPair('success', TJSONBool.Create(True));
+      Result.AddPair(KEY_SUCCESS, TJSONBool.Create(True));
       ParsedValue.Free;
     end;
   end
   else
   begin
     Result := TJSONObject.Create;
-    Result.AddPair('success', TJSONBool.Create(True));
+    Result.AddPair(KEY_SUCCESS, TJSONBool.Create(True));
   end;
 end;
 

--- a/src/Managers/MCPServer.CompletionManager.pas
+++ b/src/Managers/MCPServer.CompletionManager.pas
@@ -46,6 +46,10 @@ uses
   MCPServer.Prompt.Base,
   MCPServer.Resource.Base;
 
+const
+  CAPABILITY_NAME = 'completions';
+
+
 { TMCPCompletionManager }
 
 constructor TMCPCompletionManager.Create(const Prompts: TMCPPromptsManager; const Resources: TMCPResourcesManager);
@@ -59,17 +63,17 @@ end;
 
 function TMCPCompletionManager.GetCapabilityName: string;
 begin
-  Result := 'completions';
+  Result := CAPABILITY_NAME;
 end;
 
 function TMCPCompletionManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := Method = 'completion/complete';
+  Result := Method = MCP_METHOD_COMPLETION_COMPLETE;
 end;
 
 procedure TMCPCompletionManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
 begin
-  Capabilities.AddPair('completions', TJSONObject.Create);
+  Capabilities.AddPair(CAPABILITY_NAME, TJSONObject.Create);
 end;
 
 function TMCPCompletionManager.EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
@@ -88,7 +92,7 @@ end;
 function TMCPCompletionManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
   const Context: IMCPRequestContext): TValue;
 begin
-  if Method = 'completion/complete' then
+  if Method = MCP_METHOD_COMPLETION_COMPLETE then
     Result := Complete(Params, EraOf(Context))
   else
     raise EMCPError.MethodNotFound(Method);
@@ -100,14 +104,14 @@ var
   Template: IMCPResourceTemplate;
   Resource: IMCPResource;
 begin
-  var TypeValue := Ref.GetValue('type');
+  var TypeValue := Ref.GetValue(MCP_KEY_TYPE);
   if not (TypeValue is TJSONString) then
     raise EMCPError.InvalidParams('params.ref.type is required');
   var RefType := TJSONString(TypeValue).Value;
 
   if RefType = 'ref/prompt' then
   begin
-    var NameValue := Ref.GetValue('name');
+    var NameValue := Ref.GetValue(MCP_KEY_NAME);
     if not (NameValue is TJSONString) or (TJSONString(NameValue).Value = '') then
       raise EMCPError.InvalidParams('params.ref.name is required for ref/prompt');
     var PromptName := TJSONString(NameValue).Value;
@@ -117,7 +121,7 @@ begin
   end
   else if RefType = 'ref/resource' then
   begin
-    var UriValue := Ref.GetValue('uri');
+    var UriValue := Ref.GetValue(MCP_KEY_URI);
     if not (UriValue is TJSONString) or (TJSONString(UriValue).Value = '') then
       raise EMCPError.InvalidParams('params.ref.uri is required for ref/resource');
     var Uri := TJSONString(UriValue).Value;
@@ -138,7 +142,7 @@ begin
   var ContextValue := Params.GetValue('context');
   if not (ContextValue is TJSONObject) then
     Exit;
-  var ArgumentsValue := TJSONObject(ContextValue).GetValue('arguments');
+  var ArgumentsValue := TJSONObject(ContextValue).GetValue(MCP_KEY_ARGUMENTS);
   if not (ArgumentsValue is TJSONObject) then
     Exit;
 
@@ -186,7 +190,7 @@ begin
   if not (ArgumentValue is TJSONObject) then
     raise EMCPError.InvalidParams('params.argument is required and must be an object');
   var Argument := TJSONObject(ArgumentValue);
-  var ArgumentNameValue := Argument.GetValue('name');
+  var ArgumentNameValue := Argument.GetValue(MCP_KEY_NAME);
   if not (ArgumentNameValue is TJSONString) or (TJSONString(ArgumentNameValue).Value = '') then
     raise EMCPError.InvalidParams('params.argument.name is required and must be a non-empty string');
   var ArgumentValueValue := Argument.GetValue('value');

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -46,9 +46,6 @@ uses
   MCPServer.RequestContext,
   MCPServer.Errors;
 
-const
-  CACHE_SCOPE_PUBLIC = 'public';
-
 { TMCPCoreManager }
 
 constructor TMCPCoreManager.Create(ASettings: TMCPSettings);
@@ -74,10 +71,10 @@ end;
 
 function TMCPCoreManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'initialize') or
-            (Method = 'notifications/initialized') or
-            (Method = 'ping') or
-            (Method = 'server/discover');
+  Result := (Method = MCP_METHOD_INITIALIZE) or
+            (Method = MCP_METHOD_NOTIFICATIONS_INITIALIZED) or
+            (Method = MCP_METHOD_PING) or
+            (Method = MCP_METHOD_SERVER_DISCOVER);
 end;
 
 function TMCPCoreManager.ExecuteMethod(const Method: string; const Params: TJSONObject): TValue;
@@ -88,16 +85,16 @@ end;
 function TMCPCoreManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
   const Context: IMCPRequestContext): TValue;
 begin
-  if Method = 'initialize' then
+  if Method = MCP_METHOD_INITIALIZE then
     Result := Initialize(Params, Context)
-  else if Method = 'notifications/initialized' then
+  else if Method = MCP_METHOD_NOTIFICATIONS_INITIALIZED then
   begin
     TLogger.Info('MCP Initialized notification received');
     Result := TValue.Empty;
   end
-  else if Method = 'ping' then
+  else if Method = MCP_METHOD_PING then
     Result := Ping
-  else if Method = 'server/discover' then
+  else if Method = MCP_METHOD_SERVER_DISCOVER then
     Result := Discover(Context)
   else
     raise EMCPError.MethodNotFound(Method);
@@ -106,12 +103,12 @@ end;
 function TMCPCoreManager.BuildServerInfo: TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('name', FSettings.ServerName);
-  Result.AddPair('version', FSettings.ServerVersion);
+  Result.AddPair(MCP_KEY_NAME, FSettings.ServerName);
+  Result.AddPair(MCP_KEY_VERSION, FSettings.ServerVersion);
   if FSettings.ServerTitle <> '' then
-    Result.AddPair('title', FSettings.ServerTitle);
+    Result.AddPair(MCP_KEY_TITLE, FSettings.ServerTitle);
   if FSettings.ServerDescription <> '' then
-    Result.AddPair('description', FSettings.ServerDescription);
+    Result.AddPair(MCP_KEY_DESCRIPTION, FSettings.ServerDescription);
   if FSettings.ServerWebsiteUrl <> '' then
     Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
 end;
@@ -136,8 +133,8 @@ begin
   if not (ClientInfo is TJSONObject) then
     Exit;
 
-  var ClientName := TJSONObject(ClientInfo).GetValue('name');
-  var ClientVersion := TJSONObject(ClientInfo).GetValue('version');
+  var ClientName := TJSONObject(ClientInfo).GetValue(MCP_KEY_NAME);
+  var ClientVersion := TJSONObject(ClientInfo).GetValue(MCP_KEY_VERSION);
   if Assigned(ClientName) and Assigned(ClientVersion) then
     TLogger.Info(Format('Client: %s v%s', [ClientName.Value, ClientVersion.Value]));
 end;
@@ -165,7 +162,7 @@ begin
     var Requested := '';
     if Assigned(Params) then
     begin
-      var RequestedValue := Params.GetValue('protocolVersion');
+      var RequestedValue := Params.GetValue(MCP_KEY_PROTOCOL_VERSION);
       if RequestedValue is TJSONString then
         Requested := TJSONString(RequestedValue).Value;
     end;
@@ -175,16 +172,16 @@ begin
   if Assigned(Params) then
   begin
     LogClientInfo(Params.GetValue('clientInfo'));
-    WarnAboutDeprecatedClientCapabilities(Params.GetValue('capabilities'));
+    WarnAboutDeprecatedClientCapabilities(Params.GetValue(MCP_KEY_CAPABILITIES));
   end;
 
   var ResultJSON := TJSONObject.Create;
   try
-    ResultJSON.AddPair('protocolVersion', Negotiated);
-    ResultJSON.AddPair('capabilities', BuildCapabilities(TMCPProtocolEra.Legacy));
+    ResultJSON.AddPair(MCP_KEY_PROTOCOL_VERSION, Negotiated);
+    ResultJSON.AddPair(MCP_KEY_CAPABILITIES, BuildCapabilities(TMCPProtocolEra.Legacy));
     ResultJSON.AddPair('serverInfo', BuildServerInfo);
     if FSettings.Instructions <> '' then
-      ResultJSON.AddPair('instructions', FSettings.Instructions);
+      ResultJSON.AddPair(MCP_KEY_INSTRUCTIONS, FSettings.Instructions);
 
     if Assigned(Context) and Assigned(Context.LegacySession) then
       Context.LegacySession.ProtocolVersion := Negotiated;
@@ -203,18 +200,18 @@ begin
 
   var ResultJSON := TJSONObject.Create;
   try
-    ResultJSON.AddPair('resultType', 'complete');
+    ResultJSON.AddPair(MCP_KEY_RESULT_TYPE, 'complete');
     ResultJSON.AddPair('supportedVersions', SupportedVersions);
-    ResultJSON.AddPair('capabilities', BuildCapabilities(TMCPProtocolEra.Modern));
+    ResultJSON.AddPair(MCP_KEY_CAPABILITIES, BuildCapabilities(TMCPProtocolEra.Modern));
 
     var Meta := TJSONObject.Create;
-    ResultJSON.AddPair('_meta', Meta);
+    ResultJSON.AddPair(MCP_KEY_META, Meta);
     Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
 
     if FSettings.Instructions <> '' then
-      ResultJSON.AddPair('instructions', FSettings.Instructions);
-    ResultJSON.AddPair('ttlMs', TJSONNumber.Create(FSettings.DiscoverTtlMs));
-    ResultJSON.AddPair('cacheScope', CACHE_SCOPE_PUBLIC);
+      ResultJSON.AddPair(MCP_KEY_INSTRUCTIONS, FSettings.Instructions);
+    ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FSettings.DiscoverTtlMs));
+    ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, MCP_CACHE_SCOPE_PUBLIC);
 
     Result := TValue.From<TJSONObject>(ResultJSON);
   except

--- a/src/Managers/MCPServer.PromptsManager.pas
+++ b/src/Managers/MCPServer.PromptsManager.pas
@@ -61,6 +61,10 @@ uses
   MCPServer.RequestContext,
   MCPServer.Errors;
 
+const
+  CAPABILITY_NAME = 'prompts';
+
+
 { TMCPPromptsManager }
 
 constructor TMCPPromptsManager.Create;
@@ -84,20 +88,20 @@ end;
 
 function TMCPPromptsManager.GetCapabilityName: string;
 begin
-  Result := 'prompts';
+  Result := CAPABILITY_NAME;
 end;
 
 function TMCPPromptsManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'prompts/list') or (Method = 'prompts/get');
+  Result := (Method = MCP_METHOD_PROMPTS_LIST) or (Method = MCP_METHOD_PROMPTS_GET);
 end;
 
 procedure TMCPPromptsManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
 begin
   var Announces := Assigned(FChangeNotifier) and (Era = TMCPProtocolEra.Modern);
   var Prompts := TJSONObject.Create;
-  Prompts.AddPair('listChanged', TJSONBool.Create(Announces));
-  Capabilities.AddPair('prompts', Prompts);
+  Prompts.AddPair(MCP_KEY_LIST_CHANGED, TJSONBool.Create(Announces));
+  Capabilities.AddPair(CAPABILITY_NAME, Prompts);
 end;
 
 function TMCPPromptsManager.EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
@@ -116,9 +120,9 @@ end;
 function TMCPPromptsManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
   const Context: IMCPRequestContext): TValue;
 begin
-  if Method = 'prompts/list' then
+  if Method = MCP_METHOD_PROMPTS_LIST then
     Result := ListPrompts(Params, EraOf(Context))
-  else if Method = 'prompts/get' then
+  else if Method = MCP_METHOD_PROMPTS_GET then
     Result := GetPrompt(Params, EraOf(Context))
   else
     raise EMCPError.MethodNotFound(Method);
@@ -187,7 +191,7 @@ end;
 
 procedure TMCPPromptsManager.CheckCursor(const Params: TJSONObject);
 begin
-  if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
+  if Assigned(Params) and Assigned(Params.GetValue(MCP_KEY_CURSOR)) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;
 
@@ -196,30 +200,30 @@ var
   Metadata: IMCPPromptMetadata;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('name', Prompt.Name);
+  Result.AddPair(MCP_KEY_NAME, Prompt.Name);
   if Prompt.Title <> Prompt.Name then
-    Result.AddPair('title', Prompt.Title);
+    Result.AddPair(MCP_KEY_TITLE, Prompt.Title);
   if Prompt.Description <> '' then
-    Result.AddPair('description', Prompt.Description);
+    Result.AddPair(MCP_KEY_DESCRIPTION, Prompt.Description);
 
   var Arguments := Prompt.Arguments;
   if Length(Arguments) > 0 then
   begin
     var ArgumentsArray := TJSONArray.Create;
-    Result.AddPair('arguments', ArgumentsArray);
+    Result.AddPair(MCP_KEY_ARGUMENTS, ArgumentsArray);
     for var Arg in Arguments do
     begin
       var ArgObject := TJSONObject.Create;
       ArgumentsArray.AddElement(ArgObject);
-      ArgObject.AddPair('name', Arg.Name);
+      ArgObject.AddPair(MCP_KEY_NAME, Arg.Name);
       if Arg.Description <> '' then
-        ArgObject.AddPair('description', Arg.Description);
+        ArgObject.AddPair(MCP_KEY_DESCRIPTION, Arg.Description);
       ArgObject.AddPair('required', TJSONBool.Create(Arg.Required));
     end;
   end;
 
   if Supports(Prompt, IMCPPromptMetadata, Metadata) and Assigned(Metadata.Icons) then
-    Result.AddPair('icons', TJSONArray(Metadata.Icons.Clone));
+    Result.AddPair(MCP_KEY_ICONS, TJSONArray(Metadata.Icons.Clone));
 end;
 
 function TMCPPromptsManager.ListPrompts: TValue;
@@ -235,7 +239,7 @@ begin
   var ResultJSON := TJSONObject.Create;
   try
     var PromptsArray := TJSONArray.Create;
-    ResultJSON.AddPair('prompts', PromptsArray);
+    ResultJSON.AddPair(CAPABILITY_NAME, PromptsArray);
     FLock.Enter;
     try
       for var Name in FOrder do
@@ -248,8 +252,8 @@ begin
 
     if Era = TMCPProtocolEra.Modern then
     begin
-      ResultJSON.AddPair('ttlMs', TJSONNumber.Create(FListTtlMs));
-      ResultJSON.AddPair('cacheScope', FListCacheScope);
+      ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FListTtlMs));
+      ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, FListCacheScope);
     end;
 
     Result := TValue.From<TJSONObject>(ResultJSON);
@@ -270,12 +274,12 @@ var
 begin
   if not Assigned(Params) then
     raise EMCPError.InvalidParams('params.name is required');
-  var NameValue := Params.GetValue('name');
+  var NameValue := Params.GetValue(MCP_KEY_NAME);
   if not (NameValue is TJSONString) or (TJSONString(NameValue).Value = '') then
     raise EMCPError.InvalidParams('params.name is required and must be a non-empty string');
   var PromptName := TJSONString(NameValue).Value;
 
-  var ArgumentsValue := Params.GetValue('arguments');
+  var ArgumentsValue := Params.GetValue(MCP_KEY_ARGUMENTS);
   if Assigned(ArgumentsValue) and not (ArgumentsValue is TJSONObject) and not (ArgumentsValue is TJSONNull) then
     raise EMCPError.InvalidParams('params.arguments must be an object');
   var OwnedArguments: TJSONObject := nil;
@@ -307,7 +311,7 @@ begin
       var ResultJSON := TJSONObject.Create;
       try
         if Description <> '' then
-          ResultJSON.AddPair('description', Description);
+          ResultJSON.AddPair(MCP_KEY_DESCRIPTION, Description);
         ResultJSON.AddPair('messages', Messages.ToJson);
         Result := TValue.From<TJSONObject>(ResultJSON);
       except

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -74,6 +74,10 @@ uses
   MCPServer.Mrtr,
   MCPServer.ContentBlocks;
 
+const
+  CAPABILITY_NAME = 'resources';
+
+
 { TMCPResourcesManager }
 
 constructor TMCPResourcesManager.Create;
@@ -100,23 +104,23 @@ end;
 
 function TMCPResourcesManager.GetCapabilityName: string;
 begin
-  Result := 'resources';
+  Result := CAPABILITY_NAME;
 end;
 
 function TMCPResourcesManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'resources/list') or
-            (Method = 'resources/read') or
-            (Method = 'resources/templates/list');
+  Result := (Method = MCP_METHOD_RESOURCES_LIST) or
+            (Method = MCP_METHOD_RESOURCES_READ) or
+            (Method = MCP_METHOD_RESOURCES_TEMPLATES_LIST);
 end;
 
 procedure TMCPResourcesManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
 begin
   var Announces := Assigned(FChangeNotifier) and (Era = TMCPProtocolEra.Modern);
   var Resources := TJSONObject.Create;
-  Resources.AddPair('subscribe', TJSONBool.Create(Announces));
-  Resources.AddPair('listChanged', TJSONBool.Create(Announces));
-  Capabilities.AddPair('resources', Resources);
+  Resources.AddPair(MCP_KEY_SUBSCRIBE, TJSONBool.Create(Announces));
+  Resources.AddPair(MCP_KEY_LIST_CHANGED, TJSONBool.Create(Announces));
+  Capabilities.AddPair(CAPABILITY_NAME, Resources);
 end;
 
 function TMCPResourcesManager.EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
@@ -135,11 +139,11 @@ end;
 function TMCPResourcesManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
   const Context: IMCPRequestContext): TValue;
 begin
-  if Method = 'resources/list' then
+  if Method = MCP_METHOD_RESOURCES_LIST then
     Result := ListResources(Params, EraOf(Context))
-  else if Method = 'resources/read' then
+  else if Method = MCP_METHOD_RESOURCES_READ then
     Result := ReadResource(Params, EraOf(Context))
-  else if Method = 'resources/templates/list' then
+  else if Method = MCP_METHOD_RESOURCES_TEMPLATES_LIST then
     Result := ListResourceTemplates(Params, EraOf(Context))
   else
     raise EMCPError.MethodNotFound(Method);
@@ -290,7 +294,7 @@ end;
 
 procedure TMCPResourcesManager.CheckCursor(const Params: TJSONObject);
 begin
-  if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
+  if Assigned(Params) and Assigned(Params.GetValue(MCP_KEY_CURSOR)) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;
 
@@ -298,8 +302,8 @@ procedure TMCPResourcesManager.AddListCacheHints(const ResultJSON: TJSONObject; 
 begin
   if Era = TMCPProtocolEra.Modern then
   begin
-    ResultJSON.AddPair('ttlMs', TJSONNumber.Create(FListTtlMs));
-    ResultJSON.AddPair('cacheScope', FListCacheScope);
+    ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FListTtlMs));
+    ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, FListCacheScope);
   end;
 end;
 
@@ -308,24 +312,24 @@ var
   Metadata: IMCPResourceMetadata;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('uri', Resource.URI);
-  Result.AddPair('name', Resource.Name);
+  Result.AddPair(MCP_KEY_URI, Resource.URI);
+  Result.AddPair(MCP_KEY_NAME, Resource.Name);
 
   if Supports(Resource, IMCPResourceMetadata, Metadata) then
   begin
     if Metadata.Title <> '' then
-      Result.AddPair('title', Metadata.Title);
+      Result.AddPair(MCP_KEY_TITLE, Metadata.Title);
   end;
   if Resource.Description <> '' then
-    Result.AddPair('description', Resource.Description);
+    Result.AddPair(MCP_KEY_DESCRIPTION, Resource.Description);
   if Resource.MimeType <> '' then
-    Result.AddPair('mimeType', Resource.MimeType);
+    Result.AddPair(MCP_KEY_MIME_TYPE, Resource.MimeType);
   if Assigned(Metadata) then
   begin
     if Metadata.Size >= 0 then
       Result.AddPair('size', TJSONNumber.Create(Metadata.Size));
     if Assigned(Metadata.Annotations) then
-      Result.AddPair('annotations', TJSONObject(Metadata.Annotations.Clone));
+      Result.AddPair(MCP_KEY_ANNOTATIONS, TJSONObject(Metadata.Annotations.Clone));
   end;
 end;
 
@@ -333,13 +337,13 @@ function TMCPResourcesManager.CreateResourceTemplateJSON(const Template: IMCPRes
 begin
   Result := TJSONObject.Create;
   Result.AddPair('uriTemplate', Template.UriTemplate);
-  Result.AddPair('name', Template.Name);
+  Result.AddPair(MCP_KEY_NAME, Template.Name);
   if Template.Title <> '' then
-    Result.AddPair('title', Template.Title);
+    Result.AddPair(MCP_KEY_TITLE, Template.Title);
   if Template.Description <> '' then
-    Result.AddPair('description', Template.Description);
+    Result.AddPair(MCP_KEY_DESCRIPTION, Template.Description);
   if Template.MimeType <> '' then
-    Result.AddPair('mimeType', Template.MimeType);
+    Result.AddPair(MCP_KEY_MIME_TYPE, Template.MimeType);
 end;
 
 function TMCPResourcesManager.CreateContentsItem(const Resource: IMCPResource): TJSONObject;
@@ -348,14 +352,14 @@ var
 begin
   Result := TJSONObject.Create;
   try
-    Result.AddPair('uri', Resource.URI);
+    Result.AddPair(MCP_KEY_URI, Resource.URI);
     if Resource.MimeType <> '' then
-      Result.AddPair('mimeType', Resource.MimeType);
+      Result.AddPair(MCP_KEY_MIME_TYPE, Resource.MimeType);
 
     if Supports(Resource, IMCPBinaryResource, Binary) then
       Result.AddPair('blob', TMCPContentBlock.EncodeBlob(Binary.ReadBinary))
     else
-      Result.AddPair('text', Resource.Read);
+      Result.AddPair(MCP_KEY_TEXT, Resource.Read);
   except
     Result.Free;
     raise;
@@ -375,7 +379,7 @@ begin
   var ResultJSON := TJSONObject.Create;
   try
     var ResourcesArray := TJSONArray.Create;
-    ResultJSON.AddPair('resources', ResourcesArray);
+    ResultJSON.AddPair(CAPABILITY_NAME, ResourcesArray);
     FLock.Enter;
     try
       for var URI in FOrder do
@@ -406,7 +410,7 @@ var
 begin
   if not Assigned(Params) then
     raise EMCPError.InvalidParams('params.uri is required');
-  var URIValue := Params.GetValue('uri');
+  var URIValue := Params.GetValue(MCP_KEY_URI);
   if not (URIValue is TJSONString) or (TJSONString(URIValue).Value = '') then
     raise EMCPError.InvalidParams('params.uri is required and must be a non-empty string');
   var URI := TJSONString(URIValue).Value;
@@ -443,8 +447,8 @@ begin
         TtlMs := Cacheable.TtlMs;
         CacheScope := Cacheable.CacheScope;
       end;
-      ResultJSON.AddPair('ttlMs', TJSONNumber.Create(TtlMs));
-      ResultJSON.AddPair('cacheScope', CacheScope);
+      ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(TtlMs));
+      ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, CacheScope);
     end;
 
     Result := TValue.From<TJSONObject>(ResultJSON);

--- a/src/Managers/MCPServer.SubscriptionsManager.pas
+++ b/src/Managers/MCPServer.SubscriptionsManager.pas
@@ -78,7 +78,6 @@ uses
   MCPServer.Logger;
 
 const
-  JSONRPC_VERSION = '2.0';
   FILTER_TOOLS = 'toolsListChanged';
   FILTER_PROMPTS = 'promptsListChanged';
   FILTER_RESOURCES = 'resourcesListChanged';
@@ -213,12 +212,12 @@ end;
 function TMCPSubscription.Notification(const Method: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('jsonrpc', JSONRPC_VERSION);
-  Result.AddPair('method', Method);
+  Result.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+  Result.AddPair(MCP_KEY_METHOD, Method);
   var Params := TJSONObject.Create;
-  Result.AddPair('params', Params);
+  Result.AddPair(MCP_KEY_PARAMS, Params);
   var Meta := TJSONObject.Create;
-  Params.AddPair('_meta', Meta);
+  Params.AddPair(MCP_KEY_META, Meta);
   Meta.AddPair(MCP_META_SUBSCRIPTION_ID, TJSONValue(FId.Clone));
 end;
 
@@ -277,7 +276,7 @@ procedure TMCPSubscriptionsManager.Acknowledge(const Subscription: IMCPSubscript
 begin
   var Notification := Subscription.Notification(MCP_METHOD_NOTIFICATIONS_SUBSCRIPTIONS_ACKNOWLEDGED);
   try
-    TJSONObject(Notification.GetValue('params')).AddPair(PARAM_NOTIFICATIONS, Subscription.Filter.ToJson);
+    TJSONObject(Notification.GetValue(MCP_KEY_PARAMS)).AddPair(PARAM_NOTIFICATIONS, Subscription.Filter.ToJson);
     Subscription.Sink.Send(Notification.ToJSON);
   finally
     Notification.Free;
@@ -289,7 +288,7 @@ begin
   var Notification := Subscription.Notification('');
   try
     Result := TJSONObject.Create;
-    Result.AddPair('_meta', TJSONObject(Notification.FindValue('params._meta').Clone));
+    Result.AddPair(MCP_KEY_META, TJSONObject(Notification.FindValue('params._meta').Clone));
   finally
     Notification.Free;
   end;
@@ -361,7 +360,7 @@ begin
     var Notification := Subscription.Notification(Method);
     try
       if Uri <> '' then
-        TJSONObject(Notification.GetValue('params')).AddPair('uri', Uri);
+        TJSONObject(Notification.GetValue(MCP_KEY_PARAMS)).AddPair(MCP_KEY_URI, Uri);
       Subscription.Sink.Send(Notification.ToJSON);
     finally
       Notification.Free;

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -77,6 +77,10 @@ uses
   MCPServer.Schema.Validator;
 
 const
+  CAPABILITY_NAME = 'tools';
+
+
+const
   TOOL_NAME_PATTERN = '^[A-Za-z0-9_.\-]{1,128}$';
 
 {$IFDEF DEBUG}
@@ -121,20 +125,20 @@ end;
 
 function TMCPToolsManager.GetCapabilityName: string;
 begin
-  Result := 'tools';
+  Result := CAPABILITY_NAME;
 end;
 
 function TMCPToolsManager.HandlesMethod(const Method: string): Boolean;
 begin
-  Result := (Method = 'tools/list') or (Method = 'tools/call');
+  Result := (Method = MCP_METHOD_TOOLS_LIST) or (Method = MCP_METHOD_TOOLS_CALL);
 end;
 
 procedure TMCPToolsManager.DescribeCapabilities(const Capabilities: TJSONObject; Era: TMCPProtocolEra);
 begin
   var Announces := Assigned(FChangeNotifier) and (Era = TMCPProtocolEra.Modern);
   var Tools := TJSONObject.Create;
-  Tools.AddPair('listChanged', TJSONBool.Create(Announces));
-  Capabilities.AddPair('tools', Tools);
+  Tools.AddPair(MCP_KEY_LIST_CHANGED, TJSONBool.Create(Announces));
+  Capabilities.AddPair(CAPABILITY_NAME, Tools);
 end;
 
 function TMCPToolsManager.EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
@@ -153,9 +157,9 @@ end;
 function TMCPToolsManager.ExecuteMethodWithContext(const Method: string; const Params: TJSONObject;
   const Context: IMCPRequestContext): TValue;
 begin
-  if Method = 'tools/list' then
+  if Method = MCP_METHOD_TOOLS_LIST then
     Result := ListTools(Params, EraOf(Context))
-  else if Method = 'tools/call' then
+  else if Method = MCP_METHOD_TOOLS_CALL then
     Result := CallTool(Params, EraOf(Context))
   else
     raise EMCPError.MethodNotFound(Method);
@@ -251,7 +255,7 @@ end;
 
 procedure TMCPToolsManager.CheckCursor(const Params: TJSONObject);
 begin
-  if Assigned(Params) and Assigned(Params.GetValue('cursor')) then
+  if Assigned(Params) and Assigned(Params.GetValue(MCP_KEY_CURSOR)) then
     raise EMCPError.InvalidParams('Invalid cursor');
 end;
 
@@ -280,7 +284,7 @@ begin
   if ResultValue.IsType<TJSONArray> then
   begin
     Result := TJSONObject.Create;
-    Result.AddPair('content', ResultValue.AsType<TJSONArray>);
+    Result.AddPair(MCP_KEY_CONTENT, ResultValue.AsType<TJSONArray>);
     Exit;
   end;
 
@@ -296,7 +300,7 @@ begin
     begin
       var Structured := ResultValue.AsType<TJSONObject>;
       ToolResult.SetStructuredContent(Structured);
-      var ErrorValue := Structured.GetValue('error');
+      var ErrorValue := Structured.GetValue(MCP_KEY_ERROR);
       ToolResult.IsError := Assigned(ErrorValue) and (ErrorValue.Value <> '');
     end
     else if not ResultValue.IsEmpty then
@@ -352,10 +356,10 @@ var
   Metadata: IMCPToolMetadata;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('name', Tool.Name);
+  Result.AddPair(MCP_KEY_NAME, Tool.Name);
   if Tool.Title <> Tool.Name then
-    Result.AddPair('title', Tool.Title);
-  Result.AddPair('description', Tool.Description);
+    Result.AddPair(MCP_KEY_TITLE, Tool.Title);
+  Result.AddPair(MCP_KEY_DESCRIPTION, Tool.Description);
 
   var Schema := Tool.InputSchema;
   if Assigned(Schema) then
@@ -368,9 +372,9 @@ begin
   if Supports(Tool, IMCPToolMetadata, Metadata) then
   begin
     if Assigned(Metadata.Annotations) then
-      Result.AddPair('annotations', TJSONObject(Metadata.Annotations.Clone));
+      Result.AddPair(MCP_KEY_ANNOTATIONS, TJSONObject(Metadata.Annotations.Clone));
     if Assigned(Metadata.Icons) then
-      Result.AddPair('icons', TJSONArray(Metadata.Icons.Clone));
+      Result.AddPair(MCP_KEY_ICONS, TJSONArray(Metadata.Icons.Clone));
   end;
 end;
 
@@ -378,7 +382,7 @@ function TMCPToolsManager.BuildToolListResponse(Era: TMCPProtocolEra): TJSONObje
 begin
   Result := TJSONObject.Create;
   var ToolsArray := TJSONArray.Create;
-  Result.AddPair('tools', ToolsArray);
+  Result.AddPair(CAPABILITY_NAME, ToolsArray);
 
   FLock.Enter;
   try
@@ -392,8 +396,8 @@ begin
 
   if Era = TMCPProtocolEra.Modern then
   begin
-    Result.AddPair('ttlMs', TJSONNumber.Create(FListTtlMs));
-    Result.AddPair('cacheScope', FListCacheScope);
+    Result.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FListTtlMs));
+    Result.AddPair(MCP_KEY_CACHE_SCOPE, FListCacheScope);
   end;
 end;
 
@@ -421,12 +425,12 @@ begin
   if not Assigned(Params) then
     raise EMCPError.InvalidParams('params.name is required');
 
-  var NameValue := Params.GetValue('name');
+  var NameValue := Params.GetValue(MCP_KEY_NAME);
   if not (NameValue is TJSONString) or (TJSONString(NameValue).Value = '') then
     raise EMCPError.InvalidParams('params.name is required and must be a non-empty string');
   var ToolName := TJSONString(NameValue).Value;
 
-  var ArgumentsValue := Params.GetValue('arguments');
+  var ArgumentsValue := Params.GetValue(MCP_KEY_ARGUMENTS);
   if Assigned(ArgumentsValue) and not (ArgumentsValue is TJSONObject) and not (ArgumentsValue is TJSONNull) then
     raise EMCPError.InvalidParams('params.arguments must be an object');
   var Arguments: TJSONObject := nil;

--- a/src/Prompts/MCPServer.Prompt.Base.pas
+++ b/src/Prompts/MCPServer.Prompt.Base.pas
@@ -119,11 +119,11 @@ function TMCPPromptMessages.AddMessage(const Role: string; const Content: TJSONO
 begin
   var Message := TJSONObject.Create;
   Message.AddPair('role', Role);
-  Message.AddPair('content', Content);
+  Message.AddPair(MCP_KEY_CONTENT, Content);
   FMessages.AddElement(Message);
   if Assigned(FPendingAnnotations) then
   begin
-    Content.AddPair('annotations', FPendingAnnotations);
+    Content.AddPair(MCP_KEY_ANNOTATIONS, FPendingAnnotations);
     FPendingAnnotations := nil;
   end;
   Result := Self;
@@ -189,7 +189,7 @@ begin
   if HasMessage then
   begin
     const LastMessage = TJSONObject(FMessages.Items[FMessages.Count - 1]);
-    TJSONObject(LastMessage.GetValue('content')).AddPair('annotations', Annotations);
+    TJSONObject(LastMessage.GetValue(MCP_KEY_CONTENT)).AddPair(MCP_KEY_ANNOTATIONS, Annotations);
   end
   else
   begin

--- a/src/Prompts/MCPServer.Prompt.ContentSamples.pas
+++ b/src/Prompts/MCPServer.Prompt.ContentSamples.pas
@@ -73,6 +73,12 @@ uses
   MCPServer.Registration;
 
 const
+  ROLE_USER = 'user';
+  PROMPT_SIMPLE = 'test_simple_prompt';
+  PROMPT_WITH_ARGUMENTS = 'test_prompt_with_arguments';
+  PROMPT_WITH_EMBEDDED_RESOURCE = 'test_prompt_with_embedded_resource';
+  PROMPT_WITH_IMAGE = 'test_prompt_with_image';
+  PROMPT_INPUT_REQUIRED = 'test_input_required_result_prompt';
   KEY_USER_CONTEXT = 'user_context';
   FIELD_CONTEXT = 'context';
 
@@ -81,13 +87,13 @@ const
 constructor TSimplePrompt.Create;
 begin
   inherited;
-  FName := 'test_simple_prompt';
+  FName := PROMPT_SIMPLE;
   FDescription := 'A simple prompt with no arguments';
 end;
 
 function TSimplePrompt.ExecuteWithParams(const Params: TNoParams; Messages: TMCPPromptMessages): string;
 begin
-  Messages.AddText('user', 'This is a simple prompt for testing.');
+  Messages.AddText(ROLE_USER, 'This is a simple prompt for testing.');
   Result := 'Simple prompt';
 end;
 
@@ -96,14 +102,14 @@ end;
 constructor TArgumentsPrompt.Create;
 begin
   inherited;
-  FName := 'test_prompt_with_arguments';
+  FName := PROMPT_WITH_ARGUMENTS;
   FDescription := 'A prompt that substitutes its arguments into the message';
 end;
 
 function TArgumentsPrompt.ExecuteWithParams(const Params: TArgumentsPromptParams;
   Messages: TMCPPromptMessages): string;
 begin
-  Messages.AddText('user', Format('Prompt with arguments: arg1=''%s'', arg2=''%s''', [Params.Arg1, Params.Arg2]));
+  Messages.AddText(ROLE_USER, Format('Prompt with arguments: arg1=''%s'', arg2=''%s''', [Params.Arg1, Params.Arg2]));
   Result := 'Prompt with arguments';
 end;
 
@@ -112,15 +118,15 @@ end;
 constructor TEmbeddedResourcePrompt.Create;
 begin
   inherited;
-  FName := 'test_prompt_with_embedded_resource';
+  FName := PROMPT_WITH_EMBEDDED_RESOURCE;
   FDescription := 'A prompt that embeds the resource named by its argument';
 end;
 
 function TEmbeddedResourcePrompt.ExecuteWithParams(const Params: TEmbeddedResourcePromptParams;
   Messages: TMCPPromptMessages): string;
 begin
-  Messages.AddEmbeddedText('user', Params.ResourceUri, 'text/plain', 'Embedded resource content for testing.');
-  Messages.AddText('user', 'Please process the embedded resource above.');
+  Messages.AddEmbeddedText(ROLE_USER, Params.ResourceUri, 'text/plain', 'Embedded resource content for testing.');
+  Messages.AddText(ROLE_USER, 'Please process the embedded resource above.');
   Result := 'Prompt with embedded resource';
 end;
 
@@ -129,14 +135,14 @@ end;
 constructor TImagePrompt.Create;
 begin
   inherited;
-  FName := 'test_prompt_with_image';
+  FName := PROMPT_WITH_IMAGE;
   FDescription := 'A prompt that returns an image content block';
 end;
 
 function TImagePrompt.ExecuteWithParams(const Params: TNoParams; Messages: TMCPPromptMessages): string;
 begin
-  Messages.AddImage('user', SAMPLE_PNG_BASE64, 'image/png');
-  Messages.AddText('user', 'Please analyze the image above.');
+  Messages.AddImage(ROLE_USER, SAMPLE_PNG_BASE64, 'image/png');
+  Messages.AddText(ROLE_USER, 'Please analyze the image above.');
   Result := 'Prompt with image';
 end;
 
@@ -145,7 +151,7 @@ end;
 constructor TInputRequiredPrompt.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_prompt';
+  FName := PROMPT_INPUT_REQUIRED;
   FDescription := 'Asks the client which context to use before it renders';
 end;
 
@@ -161,32 +167,32 @@ begin
     raise EMCPInputRequired.Create(TMCPInputRequests.Create.AddElicitation(KEY_USER_CONTEXT,
       'What context should the prompt use?', TMCPInputRequests.FieldSchema(FIELD_CONTEXT)));
 
-  Messages.AddText('user', Format('Use this context: %s', [UserContext]));
+  Messages.AddText(ROLE_USER, Format('Use this context: %s', [UserContext]));
   Result := 'Prompt with client-provided context';
 end;
 
 initialization
-  TMCPRegistry.RegisterPrompt('test_simple_prompt',
+  TMCPRegistry.RegisterPrompt(PROMPT_SIMPLE,
     function: IMCPPrompt
     begin
       Result := TSimplePrompt.Create;
     end);
-  TMCPRegistry.RegisterPrompt('test_prompt_with_arguments',
+  TMCPRegistry.RegisterPrompt(PROMPT_WITH_ARGUMENTS,
     function: IMCPPrompt
     begin
       Result := TArgumentsPrompt.Create;
     end);
-  TMCPRegistry.RegisterPrompt('test_prompt_with_embedded_resource',
+  TMCPRegistry.RegisterPrompt(PROMPT_WITH_EMBEDDED_RESOURCE,
     function: IMCPPrompt
     begin
       Result := TEmbeddedResourcePrompt.Create;
     end);
-  TMCPRegistry.RegisterPrompt('test_prompt_with_image',
+  TMCPRegistry.RegisterPrompt(PROMPT_WITH_IMAGE,
     function: IMCPPrompt
     begin
       Result := TImagePrompt.Create;
     end);
-  TMCPRegistry.RegisterPrompt('test_input_required_result_prompt',
+  TMCPRegistry.RegisterPrompt(PROMPT_INPUT_REQUIRED,
     function: IMCPPrompt
     begin
       Result := TInputRequiredPrompt.Create;

--- a/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
+++ b/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
@@ -35,12 +35,17 @@ uses
   MCPServer.Resource.Logs,
   System.NetEncoding;
 
+const
+  ROLE_USER = 'user';
+  PROMPT_NAME = 'summarize_logs';
+
+
 { TSummarizeLogsPrompt }
 
 constructor TSummarizeLogsPrompt.Create;
 begin
   inherited;
-  FName := 'summarize_logs';
+  FName := PROMPT_NAME;
   FDescription := 'Summarizes the server''s recent log entries, optionally filtered by level';
 end;
 
@@ -52,12 +57,12 @@ var
 begin
   if Params.Level = '' then
   begin
-    Messages.AddText('user', 'Summarize the server''s recent log entries, calling out anything unusual.');
+    Messages.AddText(ROLE_USER, 'Summarize the server''s recent log entries, calling out anything unusual.');
     ResourceUri := 'logs://recent';
   end
   else
   begin
-    Messages.AddText('user', Format(
+    Messages.AddText(ROLE_USER, Format(
       'Summarize the server''s recent "%s" log entries, calling out anything unusual.', [Params.Level]));
     ResourceUri := Format('logs://%s', [TNetEncoding.URL.Encode(Params.Level)]);
   end;
@@ -77,7 +82,7 @@ begin
     Entries.Free;
   end;
 
-  Messages.AddEmbeddedText('user', ResourceUri, 'text/plain', ResourceText);
+  Messages.AddEmbeddedText(ROLE_USER, ResourceUri, 'text/plain', ResourceText);
   Result := 'Log summary request';
 end;
 
@@ -106,7 +111,7 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterPrompt('summarize_logs',
+  TMCPRegistry.RegisterPrompt(PROMPT_NAME,
     function: IMCPPrompt
     begin
       Result := TSummarizeLogsPrompt.Create;

--- a/src/Protocol/MCPServer.Capabilities.pas
+++ b/src/Protocol/MCPServer.Capabilities.pas
@@ -23,12 +23,12 @@ uses
 class procedure TMCPCapabilityBuilder.AddDefaultCapabilities(const Capabilities: TJSONObject);
 begin
   var Tools := TJSONObject.Create;
-  Tools.AddPair('listChanged', TJSONBool.Create(False));
+  Tools.AddPair(MCP_KEY_LIST_CHANGED, TJSONBool.Create(False));
   Capabilities.AddPair('tools', Tools);
 
   var Resources := TJSONObject.Create;
-  Resources.AddPair('subscribe', TJSONBool.Create(False));
-  Resources.AddPair('listChanged', TJSONBool.Create(False));
+  Resources.AddPair(MCP_KEY_SUBSCRIBE, TJSONBool.Create(False));
+  Resources.AddPair(MCP_KEY_LIST_CHANGED, TJSONBool.Create(False));
   Capabilities.AddPair('resources', Resources);
 end;
 

--- a/src/Protocol/MCPServer.ContentBlocks.pas
+++ b/src/Protocol/MCPServer.ContentBlocks.pas
@@ -4,7 +4,8 @@ interface
 
 uses
   System.SysUtils,
-  System.JSON;
+  System.JSON,
+  MCPServer.Types;
 
 type
   TMCPContentBlock = record
@@ -23,6 +24,11 @@ implementation
 uses
   System.NetEncoding;
 
+const
+  BLOCK_TYPE_RESOURCE = 'resource';
+  KEY_DATA = 'data';
+
+
 { TMCPContentBlock }
 
 class function TMCPContentBlock.EncodeBlob(const Data: TBytes): string;
@@ -38,58 +44,58 @@ end;
 class function TMCPContentBlock.Text(const Value: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'text');
-  Result.AddPair('text', Value);
+  Result.AddPair(MCP_KEY_TYPE, 'text');
+  Result.AddPair(MCP_KEY_TEXT, Value);
 end;
 
 class function TMCPContentBlock.Image(const Base64Data, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'image');
-  Result.AddPair('data', Base64Data);
-  Result.AddPair('mimeType', MimeType);
+  Result.AddPair(MCP_KEY_TYPE, 'image');
+  Result.AddPair(KEY_DATA, Base64Data);
+  Result.AddPair(MCP_KEY_MIME_TYPE, MimeType);
 end;
 
 class function TMCPContentBlock.Audio(const Base64Data, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'audio');
-  Result.AddPair('data', Base64Data);
-  Result.AddPair('mimeType', MimeType);
+  Result.AddPair(MCP_KEY_TYPE, 'audio');
+  Result.AddPair(KEY_DATA, Base64Data);
+  Result.AddPair(MCP_KEY_MIME_TYPE, MimeType);
 end;
 
 class function TMCPContentBlock.ResourceLink(const Uri, Name, Description, MimeType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'resource_link');
-  Result.AddPair('uri', Uri);
-  Result.AddPair('name', Name);
+  Result.AddPair(MCP_KEY_TYPE, 'resource_link');
+  Result.AddPair(MCP_KEY_URI, Uri);
+  Result.AddPair(MCP_KEY_NAME, Name);
   if Description <> '' then
-    Result.AddPair('description', Description);
+    Result.AddPair(MCP_KEY_DESCRIPTION, Description);
   if MimeType <> '' then
-    Result.AddPair('mimeType', MimeType);
+    Result.AddPair(MCP_KEY_MIME_TYPE, MimeType);
 end;
 
 class function TMCPContentBlock.EmbeddedText(const Uri, MimeType, Text: string): TJSONObject;
 begin
   var Resource := TJSONObject.Create;
-  Resource.AddPair('uri', Uri);
-  Resource.AddPair('mimeType', MimeType);
-  Resource.AddPair('text', Text);
+  Resource.AddPair(MCP_KEY_URI, Uri);
+  Resource.AddPair(MCP_KEY_MIME_TYPE, MimeType);
+  Resource.AddPair(MCP_KEY_TEXT, Text);
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'resource');
-  Result.AddPair('resource', Resource);
+  Result.AddPair(MCP_KEY_TYPE, BLOCK_TYPE_RESOURCE);
+  Result.AddPair(BLOCK_TYPE_RESOURCE, Resource);
 end;
 
 class function TMCPContentBlock.EmbeddedBlob(const Uri, MimeType, Base64Blob: string): TJSONObject;
 begin
   var Resource := TJSONObject.Create;
-  Resource.AddPair('uri', Uri);
-  Resource.AddPair('mimeType', MimeType);
+  Resource.AddPair(MCP_KEY_URI, Uri);
+  Resource.AddPair(MCP_KEY_MIME_TYPE, MimeType);
   Resource.AddPair('blob', Base64Blob);
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'resource');
-  Result.AddPair('resource', Resource);
+  Result.AddPair(MCP_KEY_TYPE, BLOCK_TYPE_RESOURCE);
+  Result.AddPair(BLOCK_TYPE_RESOURCE, Resource);
 end;
 
 end.

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -58,6 +58,10 @@ const
 
 implementation
 
+const
+  KEY_REQUIRED_SCOPE = 'requiredScope';
+  MESSAGE_RESOURCE_NOT_FOUND = 'Resource not found';
+
 { EMCPError }
 
 constructor EMCPError.Create(ACode: Integer; const AMessage: string; AData: TJSONValue; AHttpStatus: Integer);
@@ -136,14 +140,14 @@ end;
 class function EMCPError.UnknownTool(const Name: string): EMCPError;
 begin
   var Data := TJSONObject.Create;
-  Data.AddPair('name', Name);
+  Data.AddPair(MCP_KEY_NAME, Name);
   Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, 'Unknown tool: ' + Name, Data);
 end;
 
 class function EMCPError.UnknownPrompt(const Name: string): EMCPError;
 begin
   var Data := TJSONObject.Create;
-  Data.AddPair('name', Name);
+  Data.AddPair(MCP_KEY_NAME, Name);
   Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, 'Unknown prompt: ' + Name, Data);
 end;
 
@@ -151,24 +155,24 @@ function EMCPError.RequiredScope: string;
 begin
   Result := '';
   if Data is TJSONObject then
-    Result := TJSONObject(Data).GetValue<string>('requiredScope', '');
+    Result := TJSONObject(Data).GetValue<string>(KEY_REQUIRED_SCOPE, '');
 end;
 
 class function EMCPError.InsufficientScope(const Scope: string): EMCPError;
 begin
   var Data := TJSONObject.Create;
-  Data.AddPair('requiredScope', Scope);
+  Data.AddPair(KEY_REQUIRED_SCOPE, Scope);
   Result := EMCPError.Create(JSONRPC_INVALID_REQUEST, Format('The %s scope is required', [Scope]), Data, HTTP_STATUS_FORBIDDEN);
 end;
 
 class function EMCPError.ResourceNotFound(const Uri: string; Era: TMCPProtocolEra): EMCPError;
 begin
   var Data := TJSONObject.Create;
-  Data.AddPair('uri', Uri);
+  Data.AddPair(MCP_KEY_URI, Uri);
   if Era = TMCPProtocolEra.Modern then
-    Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, 'Resource not found', Data)
+    Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, MESSAGE_RESOURCE_NOT_FOUND, Data)
   else
-    Result := EMCPError.Create(MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY, 'Resource not found', Data);
+    Result := EMCPError.Create(MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY, MESSAGE_RESOURCE_NOT_FOUND, Data);
 end;
 
 end.

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -90,15 +90,18 @@ const
 
 implementation
 
+
 const
-  JSONRPC_VERSION = '2.0';
+  MESSAGE_NOT_A_JSON_RESULT = '%s answered with a %s instead of a JSON object';
+  META_PATH_PREFIX = 'params._meta.';
+  MESSAGE_PARAMS_NOT_OBJECT = 'params must be an object';
+  MESSAGE_HEADER_MISMATCH = 'Header mismatch: %s header value ''%s'' does not match body value ''%s''';
   RESULT_TYPE_COMPLETE = 'complete';
-  CACHE_SCOPE_PRIVATE = 'private';
 
   LEGACY_ONLY_METHODS: array[0..4] of string = (
-    'ping', 'initialize', 'logging/setLevel', 'resources/subscribe', 'resources/unsubscribe');
-  MODERN_ONLY_METHODS: array[0..1] of string = ('server/discover', 'subscriptions/listen');
-  INPUT_REQUIRED_METHODS: array[0..2] of string = ('tools/call', 'resources/read', 'prompts/get');
+    MCP_METHOD_PING, MCP_METHOD_INITIALIZE, MCP_METHOD_LOGGING_SET_LEVEL, MCP_METHOD_RESOURCES_SUBSCRIBE, MCP_METHOD_RESOURCES_UNSUBSCRIBE);
+  MODERN_ONLY_METHODS: array[0..1] of string = (MCP_METHOD_SERVER_DISCOVER, 'subscriptions/listen');
+  INPUT_REQUIRED_METHODS: array[0..2] of string = (MCP_METHOD_TOOLS_CALL, MCP_METHOD_RESOURCES_READ, MCP_METHOD_PROMPTS_GET);
   PARAM_INPUT_RESPONSES = 'inputResponses';
   PARAM_REQUEST_STATE = 'requestState';
 
@@ -155,12 +158,12 @@ end;
 function TMCPJsonRpcProcessor.BuildServerInfo: TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('name', FSettings.ServerName);
-  Result.AddPair('version', FSettings.ServerVersion);
+  Result.AddPair(MCP_KEY_NAME, FSettings.ServerName);
+  Result.AddPair(MCP_KEY_VERSION, FSettings.ServerVersion);
   if FSettings.ServerTitle <> '' then
-    Result.AddPair('title', FSettings.ServerTitle);
+    Result.AddPair(MCP_KEY_TITLE, FSettings.ServerTitle);
   if FSettings.ServerDescription <> '' then
-    Result.AddPair('description', FSettings.ServerDescription);
+    Result.AddPair(MCP_KEY_DESCRIPTION, FSettings.ServerDescription);
   if FSettings.ServerWebsiteUrl <> '' then
     Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
 end;
@@ -168,7 +171,7 @@ end;
 function TMCPJsonRpcProcessor.IsLegacyOnlyMethod(const Method: string): Boolean;
 begin
   Result := TMCPStrings.Contains(Method, LEGACY_ONLY_METHODS);
-  if Result and (Method = 'ping') and FSettings.LenientModernPing then
+  if Result and (Method = MCP_METHOD_PING) and FSettings.LenientModernPing then
     Result := False;
 end;
 
@@ -239,7 +242,7 @@ begin
   if (Result = TMCPProtocolEra.Modern) or not Assigned(Params) then
     Exit;
 
-  var MetaValue := Params.GetValue('_meta');
+  var MetaValue := Params.GetValue(MCP_KEY_META);
   if (MetaValue is TJSONObject) and (TJSONObject(MetaValue).GetValue(MCP_META_PROTOCOL_VERSION) is TJSONString) then
     Result := TMCPProtocolEra.Modern;
 end;
@@ -250,7 +253,7 @@ begin
   if not Assigned(Params) then
     Exit;
 
-  var MetaValue := Params.GetValue('_meta');
+  var MetaValue := Params.GetValue(MCP_KEY_META);
   if not Assigned(MetaValue) then
     Exit;
   if not (MetaValue is TJSONObject) then
@@ -263,18 +266,18 @@ begin
   var Capabilities := Meta.GetValue(MCP_META_CLIENT_CAPABILITIES);
   if not (Capabilities is TJSONObject) then
     raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
-      'params._meta.' + MCP_META_CLIENT_CAPABILITIES + ' is required and must be an object',
+      META_PATH_PREFIX + MCP_META_CLIENT_CAPABILITIES + ' is required and must be an object',
       nil, HTTP_STATUS_BAD_REQUEST);
 
   var ClientInfo := Meta.GetValue(MCP_META_CLIENT_INFO);
   if Assigned(ClientInfo) and not (ClientInfo is TJSONObject) then
     raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
-      'params._meta.' + MCP_META_CLIENT_INFO + ' must be an object', nil, HTTP_STATUS_BAD_REQUEST);
+      META_PATH_PREFIX + MCP_META_CLIENT_INFO + ' must be an object', nil, HTTP_STATUS_BAD_REQUEST);
 
   var LogLevel := Meta.GetValue(MCP_META_LOG_LEVEL);
   if Assigned(LogLevel) and (not IsJsonString(LogLevel) or not TMCPLogLevel.IsKnown(TJSONString(LogLevel).Value)) then
     raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
-      'params._meta.' + MCP_META_LOG_LEVEL + ' must be one of debug, info, notice, warning, error, critical, alert, emergency',
+      META_PATH_PREFIX + MCP_META_LOG_LEVEL + ' must be one of debug, info, notice, warning, error, critical, alert, emergency',
       nil, HTTP_STATUS_BAD_REQUEST);
 end;
 
@@ -286,14 +289,13 @@ begin
   if not Hints.HasMethodHeader then
     raise EMCPError.HeaderMismatch('Mcp-Method header is missing');
   if Hints.MethodHeader <> Method then
-    raise EMCPError.HeaderMismatch(Format(
-      'Header mismatch: Mcp-Method header value ''%s'' does not match body value ''%s''',
-      [Hints.MethodHeader, Method]));
+    raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
+      ['Mcp-Method', Hints.MethodHeader, Method]));
 
   var SourceField := '';
-  if (Method = 'tools/call') or (Method = 'prompts/get') then
+  if (Method = MCP_METHOD_TOOLS_CALL) or (Method = MCP_METHOD_PROMPTS_GET) then
     SourceField := 'name'
-  else if Method = 'resources/read' then
+  else if Method = MCP_METHOD_RESOURCES_READ then
     SourceField := 'uri';
   if SourceField = '' then
     Exit;
@@ -311,9 +313,8 @@ begin
       BodyValue := TJSONString(Source).Value;
   end;
   if Decoded <> BodyValue then
-    raise EMCPError.HeaderMismatch(Format(
-      'Header mismatch: Mcp-Name header value ''%s'' does not match body value ''%s''',
-      [Decoded, BodyValue]));
+    raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
+      ['Mcp-Name', Decoded, BodyValue]));
 end;
 
 function TMCPJsonRpcProcessor.NewContext(Era: TMCPProtocolEra; const Version, Method: string;
@@ -344,9 +345,8 @@ begin
       if not Hints.HasProtocolVersionHeader then
         raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
       if Hints.ProtocolVersionHeader <> Version then
-        raise EMCPError.HeaderMismatch(Format(
-          'Header mismatch: MCP-Protocol-Version header value ''%s'' does not match body value ''%s''',
-          [Hints.ProtocolVersionHeader, Version]));
+        raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
+          ['MCP-Protocol-Version', Hints.ProtocolVersionHeader, Version]));
     end;
 
     if not TMCPProtocolVersion.IsModern(Version) then
@@ -374,12 +374,12 @@ begin
     Exit(NewContext(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta, Hints, InputResponses, RequestState));
   end;
 
-  if Method = 'initialize' then
+  if Method = MCP_METHOD_INITIALIZE then
   begin
     var Requested := '';
     if Assigned(Params) then
     begin
-      var RequestedValue := Params.GetValue('protocolVersion');
+      var RequestedValue := Params.GetValue(MCP_KEY_PROTOCOL_VERSION);
       if IsJsonString(RequestedValue) then
         Requested := TJSONString(RequestedValue).Value;
     end;
@@ -494,7 +494,7 @@ begin
 
   var ResultObject := TJSONObject.Create;
   try
-    ResultObject.AddPair('resultType', RESULT_TYPE_INPUT_REQUIRED);
+    ResultObject.AddPair(MCP_KEY_RESULT_TYPE, RESULT_TYPE_INPUT_REQUIRED);
     if Required.Requests.Count > 0 then
       ResultObject.AddPair('inputRequests', Required.Requests.ToJson);
     if Assigned(Required.State) then
@@ -504,9 +504,9 @@ begin
 
     const Response = TJSONObject.Create;
     try
-      Response.AddPair('jsonrpc', JSONRPC_VERSION);
-      Response.AddPair('id', Context.RequestId.ToJson);
-      Response.AddPair('result', TJSONObject(ResultObject.Clone));
+      Response.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+      Response.AddPair(MCP_KEY_ID, Context.RequestId.ToJson);
+      Response.AddPair(MCP_KEY_RESULT, TJSONObject(ResultObject.Clone));
       Result.Body := Response.ToJSON;
     finally
       Response.Free;
@@ -549,29 +549,29 @@ end;
 
 procedure TMCPJsonRpcProcessor.ApplyModernEnvelope(const ResultObject: TJSONObject; const Method: string);
 begin
-  if not Assigned(ResultObject.GetValue('resultType')) then
-    ResultObject.AddPair('resultType', RESULT_TYPE_COMPLETE);
+  if not Assigned(ResultObject.GetValue(MCP_KEY_RESULT_TYPE)) then
+    ResultObject.AddPair(MCP_KEY_RESULT_TYPE, RESULT_TYPE_COMPLETE);
 
-  var MetaValue := ResultObject.GetValue('_meta');
+  var MetaValue := ResultObject.GetValue(MCP_KEY_META);
   var Meta: TJSONObject := nil;
   if MetaValue is TJSONObject then
     Meta := TJSONObject(MetaValue)
   else if not Assigned(MetaValue) then
   begin
     Meta := TJSONObject.Create;
-    ResultObject.AddPair('_meta', Meta);
+    ResultObject.AddPair(MCP_KEY_META, Meta);
   end;
   if Assigned(Meta) and not Assigned(Meta.GetValue(MCP_META_SERVER_INFO)) then
     Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
 
-  var ResultType := ResultObject.GetValue('resultType');
+  var ResultType := ResultObject.GetValue(MCP_KEY_RESULT_TYPE);
   if IsCacheableMethod(Method) and (ResultType is TJSONString)
     and (TJSONString(ResultType).Value = RESULT_TYPE_COMPLETE) then
   begin
-    if not Assigned(ResultObject.GetValue('ttlMs')) then
-      ResultObject.AddPair('ttlMs', TJSONNumber.Create(0));
-    if not Assigned(ResultObject.GetValue('cacheScope')) then
-      ResultObject.AddPair('cacheScope', CACHE_SCOPE_PRIVATE);
+    if not Assigned(ResultObject.GetValue(MCP_KEY_TTL_MS)) then
+      ResultObject.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(0));
+    if not Assigned(ResultObject.GetValue(MCP_KEY_CACHE_SCOPE)) then
+      ResultObject.AddPair(MCP_KEY_CACHE_SCOPE, MCP_CACHE_SCOPE_PRIVATE);
   end;
 end;
 
@@ -588,7 +588,7 @@ begin
     else
     begin
       if Value.IsObject then
-        raise EMCPError.InternalError(Format('%s answered with a %s instead of a JSON object',
+        raise EMCPError.InternalError(Format(MESSAGE_NOT_A_JSON_RESULT,
           [Context.Method, Value.AsObject.ClassName]));
       Result := TJSONString.Create(Value.ToString);
     end;
@@ -601,7 +601,7 @@ begin
   else
   begin
     if Value.IsObject then
-      raise EMCPError.InternalError(Format('%s answered with a %s instead of a JSON object',
+      raise EMCPError.InternalError(Format(MESSAGE_NOT_A_JSON_RESULT,
         [Context.Method, Value.AsObject.ClassName]));
     ResultObject := TJSONObject.Create;
     if not Value.IsEmpty then
@@ -646,11 +646,11 @@ begin
 
   var Response := TJSONObject.Create;
   try
-    Response.AddPair('jsonrpc', JSONRPC_VERSION);
-    Response.AddPair('id', RequestId.ToJson);
+    Response.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+    Response.AddPair(MCP_KEY_ID, RequestId.ToJson);
 
     var ErrorObject := TJSONObject.Create;
-    Response.AddPair('error', ErrorObject);
+    Response.AddPair(MCP_KEY_ERROR, ErrorObject);
     ErrorObject.AddPair('code', TJSONNumber.Create(Error.Code));
     ErrorObject.AddPair('message', Error.Message);
     if Assigned(Error.Data) then
@@ -714,7 +714,7 @@ begin
 
       var Request := TJSONObject(Message);
 
-      RequestId := TMCPRequestId.FromJson(Request.GetValue('id'));
+      RequestId := TMCPRequestId.FromJson(Request.GetValue(MCP_KEY_ID));
       if RequestId.Kind = TMCPRequestIdKind.Null then
         raise EMCPError.InvalidRequest('id must not be null');
       if RequestId.Kind = TMCPRequestIdKind.Invalid then
@@ -723,14 +723,14 @@ begin
         raise EMCPError.InvalidRequest('id must be a string or an integer');
       end;
 
-      var JsonRpc := Request.GetValue('jsonrpc');
+      var JsonRpc := Request.GetValue(MCP_KEY_JSONRPC);
       if not IsJsonString(JsonRpc) or (TJSONString(JsonRpc).Value <> JSONRPC_VERSION) then
         raise EMCPError.InvalidRequest('jsonrpc must be "2.0"');
 
-      var MethodValue := Request.GetValue('method');
+      var MethodValue := Request.GetValue(MCP_KEY_METHOD);
       if not IsJsonString(MethodValue) then
       begin
-        if Assigned(Request.GetValue('result')) or Assigned(Request.GetValue('error')) then
+        if Assigned(Request.GetValue(MCP_KEY_RESULT)) or Assigned(Request.GetValue(MCP_KEY_ERROR)) then
         begin
           if Era = TMCPProtocolEra.Modern then
             raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
@@ -744,15 +744,15 @@ begin
       end;
       var Method := TJSONString(MethodValue).Value;
 
-      var ParamsValue := Request.GetValue('params');
+      var ParamsValue := Request.GetValue(MCP_KEY_PARAMS);
       var Params: TJSONObject := nil;
       if Assigned(ParamsValue) then
       begin
         if not (ParamsValue is TJSONObject) then
         begin
           if Era = TMCPProtocolEra.Modern then
-            raise EMCPError.Create(JSONRPC_INVALID_PARAMS, 'params must be an object', nil, HTTP_STATUS_BAD_REQUEST);
-          raise EMCPError.InvalidParams('params must be an object');
+            raise EMCPError.Create(JSONRPC_INVALID_PARAMS, MESSAGE_PARAMS_NOT_OBJECT, nil, HTTP_STATUS_BAD_REQUEST);
+          raise EMCPError.InvalidParams(MESSAGE_PARAMS_NOT_OBJECT);
         end;
         Params := TJSONObject(ParamsValue);
       end;
@@ -788,11 +788,11 @@ begin
 
       var Response := TJSONObject.Create;
       try
-        Response.AddPair('jsonrpc', JSONRPC_VERSION);
-        Response.AddPair('id', RequestId.ToJson);
+        Response.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+        Response.AddPair(MCP_KEY_ID, RequestId.ToJson);
         var ResultJson := ResultToJson(ExecuteResult, Context);
         if Assigned(ResultJson) then
-          Response.AddPair('result', ResultJson);
+          Response.AddPair(MCP_KEY_RESULT, ResultJson);
         Result.Body := Response.ToJSON;
       finally
         Response.Free;

--- a/src/Protocol/MCPServer.Mrtr.pas
+++ b/src/Protocol/MCPServer.Mrtr.pas
@@ -56,16 +56,20 @@ type
 
 implementation
 
+
+const
+  KEY_ROOTS = 'roots';
+
 { TMCPInputRequests }
 
 class function TMCPInputRequests.FieldSchema(const Field: string; const FieldType: string): TJSONObject;
 begin
   Result := TJSONObject.Create;
-  Result.AddPair('type', 'object');
+  Result.AddPair(MCP_KEY_TYPE, 'object');
   var Properties := TJSONObject.Create;
   Result.AddPair('properties', Properties);
   var Schema := TJSONObject.Create;
-  Schema.AddPair('type', FieldType);
+  Schema.AddPair(MCP_KEY_TYPE, FieldType);
   Properties.AddPair(Field, Schema);
   var Required := TJSONArray.Create;
   Required.Add(Field);
@@ -87,8 +91,8 @@ end;
 function TMCPInputRequests.AddRequest(const Key, Method: string; const Params: TJSONObject): TMCPInputRequests;
 begin
   var Request := TJSONObject.Create;
-  Request.AddPair('method', Method);
-  Request.AddPair('params', Params);
+  Request.AddPair(MCP_KEY_METHOD, Method);
+  Request.AddPair(MCP_KEY_PARAMS, Params);
   FRequests.AddPair(Key, Request);
   Result := Self;
 end;
@@ -113,9 +117,9 @@ begin
   Messages.AddElement(Message);
   Message.AddPair('role', 'user');
   var Content := TJSONObject.Create;
-  Message.AddPair('content', Content);
-  Content.AddPair('type', 'text');
-  Content.AddPair('text', UserText);
+  Message.AddPair(MCP_KEY_CONTENT, Content);
+  Content.AddPair(MCP_KEY_TYPE, 'text');
+  Content.AddPair(MCP_KEY_TEXT, UserText);
   if SystemPrompt <> '' then
     Params.AddPair('systemPrompt', SystemPrompt);
   Params.AddPair('maxTokens', TJSONNumber.Create(MaxTokens));
@@ -136,7 +140,7 @@ function TMCPInputRequests.Methods: TArray<string>;
 begin
   Result := nil;
   for var Pair in FRequests do
-    Result := Result + [TJSONObject(Pair.JsonValue).GetValue<string>('method')];
+    Result := Result + [TJSONObject(Pair.JsonValue).GetValue<string>(MCP_KEY_METHOD)];
 end;
 
 class function TMCPInputRequests.RequiredCapability(const Method: string): string;
@@ -146,7 +150,7 @@ begin
   else if Method = MCP_METHOD_SAMPLING_CREATE_MESSAGE then
     Result := 'sampling'
   else if Method = MCP_METHOD_ROOTS_LIST then
-    Result := 'roots'
+    Result := KEY_ROOTS
   else
     Result := '';
 end;
@@ -165,7 +169,7 @@ begin
     Exit;
 
   var Action := Response.GetValue('action');
-  var Content := Response.GetValue('content');
+  var Content := Response.GetValue(MCP_KEY_CONTENT);
   var Accepted := IsJsonString(Action) and (TJSONString(Action).Value = ELICITATION_ACTION_ACCEPT);
   if Accepted and (Content is TJSONObject) then
     Result := TJSONObject(Content);
@@ -191,10 +195,10 @@ begin
   if not Assigned(Response) then
     Exit;
 
-  var Content := Response.GetValue('content');
+  var Content := Response.GetValue(MCP_KEY_CONTENT);
   if not (Content is TJSONObject) then
     Exit;
-  var Text := TJSONObject(Content).GetValue('text');
+  var Text := TJSONObject(Content).GetValue(MCP_KEY_TEXT);
   if IsJsonString(Text) then
     Result := TJSONString(Text).Value;
 end;
@@ -205,7 +209,7 @@ begin
   if not Assigned(Response) then
     Exit;
 
-  var Value := Response.GetValue('roots');
+  var Value := Response.GetValue(KEY_ROOTS);
   if Value is TJSONArray then
     Result := TJSONArray(Value);
 end;

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -370,8 +370,6 @@ begin
 end;
 
 procedure TMCPRequestContext.ReportProgress(const Progress, Total: Double; const Message: string);
-const
-  JSON_RPC_VERSION = '2.0';
 begin
   if not Assigned(FSink) or not HasProgressToken or IsCancelled then
     Exit;
@@ -382,10 +380,10 @@ begin
 
   var Notification := TJSONObject.Create;
   try
-    Notification.AddPair('jsonrpc', JSON_RPC_VERSION);
-    Notification.AddPair('method', MCP_METHOD_NOTIFICATIONS_PROGRESS);
+    Notification.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+    Notification.AddPair(MCP_KEY_METHOD, MCP_METHOD_NOTIFICATIONS_PROGRESS);
     var Params := TJSONObject.Create;
-    Notification.AddPair('params', Params);
+    Notification.AddPair(MCP_KEY_PARAMS, Params);
     Params.AddPair(MCP_META_PROGRESS_TOKEN, TJSONValue(GetProgressToken.Clone));
     Params.AddPair('progress', TJSONNumber.Create(Progress));
     if Total >= 0 then
@@ -404,8 +402,6 @@ begin
 end;
 
 procedure TMCPRequestContext.LogJson(const Level: string; const Data: TJSONValue; const Logger: string);
-const
-  JSON_RPC_VERSION = '2.0';
 begin
   var Threshold := GetLogLevel;
   var Wanted := Assigned(FSink) and (Threshold <> '') and not IsCancelled
@@ -418,10 +414,10 @@ begin
 
   var Notification := TJSONObject.Create;
   try
-    Notification.AddPair('jsonrpc', JSON_RPC_VERSION);
-    Notification.AddPair('method', MCP_METHOD_NOTIFICATIONS_MESSAGE);
+    Notification.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+    Notification.AddPair(MCP_KEY_METHOD, MCP_METHOD_NOTIFICATIONS_MESSAGE);
     var Params := TJSONObject.Create;
-    Notification.AddPair('params', Params);
+    Notification.AddPair(MCP_KEY_PARAMS, Params);
     Params.AddPair('level', Level);
     if Logger <> '' then
       Params.AddPair('logger', Logger);

--- a/src/Protocol/MCPServer.RequestState.pas
+++ b/src/Protocol/MCPServer.RequestState.pas
@@ -53,6 +53,10 @@ uses
   MCPServer.Logger;
 
 const
+  MESSAGE_INTEGRITY_FAILED = 'requestState failed integrity verification';
+
+
+const
   KEY_BYTES = 32;
   URANDOM_DEVICE = '/dev/urandom';
   TOKEN_SEPARATOR = '.';
@@ -261,14 +265,14 @@ begin
   if (Separator <= 0) or not TryFromBase64Url(Token.Substring(0, Separator), PayloadBytes)
     or not TryFromBase64Url(Token.Substring(Separator + 1), SignatureBytes)
     or not TMCPConstantTime.SameBytes(SignatureBytes, Signature(PayloadBytes)) then
-    raise EMCPError.InvalidParams('requestState failed integrity verification');
+    raise EMCPError.InvalidParams(MESSAGE_INTEGRITY_FAILED);
 
   const Parsed = TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes));
   const IsPayloadObject = (Parsed is TJSONObject);
   if not IsPayloadObject then
   begin
     Parsed.Free;
-    raise EMCPError.InvalidParams('requestState failed integrity verification');
+    raise EMCPError.InvalidParams(MESSAGE_INTEGRITY_FAILED);
   end;
 
   const Payload = TJSONObject(Parsed);

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -34,6 +34,21 @@ uses
   System.Generics.Collections,
   MCPServer.Types;
 
+const
+  SCHEMA_KEY_ADDITIONAL_PROPERTIES = 'additionalProperties';
+  SCHEMA_TYPE_STRING = 'string';
+  SCHEMA_TYPE_ARRAY = 'array';
+  SCHEMA_TYPE_OBJECT = 'object';
+  SCHEMA_TYPE_INTEGER = 'integer';
+  SCHEMA_TYPE_NUMBER = 'number';
+  SCHEMA_TYPE_BOOLEAN = 'boolean';
+  SCHEMA_KEY_FORMAT = 'format';
+  SCHEMA_KEY_ENUM = 'enum';
+  SCHEMA_KEY_ITEMS = 'items';
+  SCHEMA_KEY_PROPERTIES = 'properties';
+  SCHEMA_KEY_REQUIRED = 'required';
+
+
 { TMCPSchemaGenerator }
 
 class constructor TMCPSchemaGenerator.Create;
@@ -101,77 +116,77 @@ begin
   try
     case RttiType.TypeKind of
       tkInteger, tkInt64:
-        Result.AddPair('type', 'integer');
+        Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_INTEGER);
 
       tkFloat:
         if RttiType.Handle = TypeInfo(TDateTime) then
         begin
-          Result.AddPair('type', 'string');
-          Result.AddPair('format', 'date-time');
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+          Result.AddPair(SCHEMA_KEY_FORMAT, 'date-time');
         end
         else if RttiType.Handle = TypeInfo(TDate) then
         begin
-          Result.AddPair('type', 'string');
-          Result.AddPair('format', 'date');
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+          Result.AddPair(SCHEMA_KEY_FORMAT, 'date');
         end
         else if RttiType.Handle = TypeInfo(TTime) then
         begin
-          Result.AddPair('type', 'string');
-          Result.AddPair('format', 'time');
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+          Result.AddPair(SCHEMA_KEY_FORMAT, 'time');
         end
         else
-          Result.AddPair('type', 'number');
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_NUMBER);
 
       tkString, tkLString, tkWString, tkUString, tkChar, tkWChar:
-        Result.AddPair('type', 'string');
+        Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
 
       tkEnumeration:
         if RttiType.Handle = TypeInfo(Boolean) then
-          Result.AddPair('type', 'boolean')
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_BOOLEAN)
         else
         begin
-          Result.AddPair('type', 'string');
-          Result.AddPair('enum', CreateEnumValuesArray(RttiType));
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+          Result.AddPair(SCHEMA_KEY_ENUM, CreateEnumValuesArray(RttiType));
         end;
 
       tkSet:
         begin
-          Result.AddPair('type', 'array');
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
           var Items := TJSONObject.Create;
-          Result.AddPair('items', Items);
-          Items.AddPair('type', 'string');
+          Result.AddPair(SCHEMA_KEY_ITEMS, Items);
+          Items.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
           var ElementType := TRttiSetType(RttiType).ElementType;
           var Names := CreateEnumValuesArray(ElementType);
           if Assigned(Names) then
-            Items.AddPair('enum', Names);
+            Items.AddPair(SCHEMA_KEY_ENUM, Names);
         end;
 
       tkDynArray:
         begin
-          Result.AddPair('type', 'array');
-          Result.AddPair('items', TypeSchema(TRttiDynamicArrayType(RttiType).ElementType, Depth + 1));
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(TRttiDynamicArrayType(RttiType).ElementType, Depth + 1));
         end;
 
       tkArray:
         begin
-          Result.AddPair('type', 'array');
-          Result.AddPair('items', TypeSchema(TRttiArrayType(RttiType).ElementType, Depth + 1));
+          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(TRttiArrayType(RttiType).ElementType, Depth + 1));
         end;
 
       tkClass:
         begin
           var Metaclass := TRttiInstanceType(RttiType).MetaclassType;
           if Metaclass.InheritsFrom(TJSONArray) then
-            Result.AddPair('type', 'array')
+            Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY)
           else if Metaclass.InheritsFrom(TJSONValue) then
-            Result.AddPair('type', 'object')
+            Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT)
           else
           begin
             var ItemType := ListItemType(RttiType);
             if Assigned(ItemType) then
             begin
-              Result.AddPair('type', 'array');
-              Result.AddPair('items', TypeSchema(ItemType, Depth + 1));
+              Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+              Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ItemType, Depth + 1));
             end
             else if Depth < MAX_NESTING_DEPTH then
             begin
@@ -179,11 +194,11 @@ begin
               Result := ObjectSchema(RttiType, Depth + 1);
             end
             else
-              Result.AddPair('type', 'object');
+              Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
           end;
         end;
     else
-      Result.AddPair('type', 'string');
+      Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
     end;
   except
     Result.Free;
@@ -204,13 +219,13 @@ begin
   for var Attr in Prop.GetAttributes do
   begin
     if Attr is SchemaDescriptionAttribute then
-      PropSchema.AddPair('description', SchemaDescriptionAttribute(Attr).Description)
+      PropSchema.AddPair(MCP_KEY_DESCRIPTION, SchemaDescriptionAttribute(Attr).Description)
     else if Attr is SchemaTitleAttribute then
-      PropSchema.AddPair('title', SchemaTitleAttribute(Attr).Title)
+      PropSchema.AddPair(MCP_KEY_TITLE, SchemaTitleAttribute(Attr).Title)
     else if Attr is SchemaFormatAttribute then
     begin
-      PropSchema.RemovePair('format').Free;
-      PropSchema.AddPair('format', SchemaFormatAttribute(Attr).Format);
+      PropSchema.RemovePair(SCHEMA_KEY_FORMAT).Free;
+      PropSchema.AddPair(SCHEMA_KEY_FORMAT, SchemaFormatAttribute(Attr).Format);
     end
     else if Attr is SchemaMinimumAttribute then
       PropSchema.AddPair('minimum', NumberValue(SchemaMinimumAttribute(Attr).Minimum))
@@ -218,11 +233,11 @@ begin
       PropSchema.AddPair('maximum', NumberValue(SchemaMaximumAttribute(Attr).Maximum))
     else if Attr is SchemaEnumAttribute then
     begin
-      PropSchema.RemovePair('enum').Free;
+      PropSchema.RemovePair(SCHEMA_KEY_ENUM).Free;
       var EnumArray := TJSONArray.Create;
       for var Value in SchemaEnumAttribute(Attr).Values do
         EnumArray.Add(Value);
-      PropSchema.AddPair('enum', EnumArray);
+      PropSchema.AddPair(SCHEMA_KEY_ENUM, EnumArray);
     end
     else if Attr is SchemaMinLengthAttribute then
       PropSchema.AddPair('minLength', TJSONNumber.Create(SchemaMinLengthAttribute(Attr).MinLength))
@@ -250,9 +265,9 @@ begin
         if Attr is SchemaDialectAttribute then
           Result.AddPair('$schema', SchemaDialectAttribute(Attr).Uri);
 
-    Result.AddPair('type', 'object');
+    Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
     var Properties := TJSONObject.Create;
-    Result.AddPair('properties', Properties);
+    Result.AddPair(SCHEMA_KEY_PROPERTIES, Properties);
     var RequiredArray := TJSONArray.Create;
 
     for var RttiProp in RttiType.GetProperties do
@@ -270,7 +285,7 @@ begin
     end;
 
     if RequiredArray.Count > 0 then
-      Result.AddPair('required', RequiredArray)
+      Result.AddPair(SCHEMA_KEY_REQUIRED, RequiredArray)
     else
       RequiredArray.Free;
 
@@ -278,12 +293,12 @@ begin
     for var Attr in RttiType.GetAttributes do
       if Attr is SchemaAdditionalPropertiesAttribute then
       begin
-        Result.AddPair('additionalProperties', TJSONBool.Create(SchemaAdditionalPropertiesAttribute(Attr).Allowed));
+        Result.AddPair(SCHEMA_KEY_ADDITIONAL_PROPERTIES, TJSONBool.Create(SchemaAdditionalPropertiesAttribute(Attr).Allowed));
         ExplicitAdditionalProperties := True;
       end;
 
     if not ExplicitAdditionalProperties and (Properties.Count = 0) then
-      Result.AddPair('additionalProperties', TJSONBool.Create(False));
+      Result.AddPair(SCHEMA_KEY_ADDITIONAL_PROPERTIES, TJSONBool.Create(False));
   except
     Result.Free;
     raise;

--- a/src/Protocol/MCPServer.Schema.Validator.pas
+++ b/src/Protocol/MCPServer.Schema.Validator.pas
@@ -69,7 +69,7 @@ class function TMCPSchemaValidator.TryCheckType(const Schema: TJSONObject; const
 begin
   Result := True;
   ErrorMessage := '';
-  var TypeValue := Schema.GetValue('type');
+  var TypeValue := Schema.GetValue(MCP_KEY_TYPE);
   if not Assigned(TypeValue) then
     Exit;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -52,6 +52,10 @@ uses
   System.DateUtils,
   MCPServer.Types;
 
+const
+  MESSAGE_EXPECTED_INTEGER = 'expected an integer';
+
+
 { TMCPSerializer }
 
 class constructor TMCPSerializer.Create;
@@ -224,10 +228,10 @@ begin
     tkInteger, tkInt64:
       begin
         if not (JsonValue is TJSONNumber) then
-          raise EArgumentException.Create('expected an integer');
+          raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
         var Number := TJSONNumber(JsonValue);
         if Frac(Number.AsDouble) <> 0 then
-          raise EArgumentException.Create('expected an integer');
+          raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
         if RttiType.TypeKind = tkInt64 then
           Result := Number.AsInt64
         else

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -52,15 +52,6 @@ const
   MCP_CACHE_SCOPE_PUBLIC = 'public';
   MCP_CACHE_SCOPE_PRIVATE = 'private';
 
-  MCP_CACHEABLE_METHODS: array[0..5] of string = (
-    'server/discover',
-    'tools/list',
-    'prompts/list',
-    'resources/list',
-    'resources/templates/list',
-    'resources/read'
-  );
-
   MCP_METHOD_NOTIFICATIONS_MESSAGE = 'notifications/message';
   MCP_SCOPE_ANY = '*';
   MCP_METHOD_SUBSCRIPTIONS_LISTEN = 'subscriptions/listen';
@@ -69,6 +60,66 @@ const
   MCP_METHOD_NOTIFICATIONS_PROMPTS_LIST_CHANGED = 'notifications/prompts/list_changed';
   MCP_METHOD_NOTIFICATIONS_RESOURCES_LIST_CHANGED = 'notifications/resources/list_changed';
   MCP_METHOD_NOTIFICATIONS_RESOURCES_UPDATED = 'notifications/resources/updated';
+  MCP_METHOD_INITIALIZE = 'initialize';
+  MCP_METHOD_NOTIFICATIONS_INITIALIZED = 'notifications/initialized';
+  MCP_METHOD_PING = 'ping';
+  MCP_METHOD_SERVER_DISCOVER = 'server/discover';
+  MCP_METHOD_LOGGING_SET_LEVEL = 'logging/setLevel';
+  MCP_METHOD_TOOLS_LIST = 'tools/list';
+  MCP_METHOD_TOOLS_CALL = 'tools/call';
+  MCP_METHOD_PROMPTS_LIST = 'prompts/list';
+  MCP_METHOD_PROMPTS_GET = 'prompts/get';
+  MCP_METHOD_RESOURCES_LIST = 'resources/list';
+  MCP_METHOD_RESOURCES_READ = 'resources/read';
+  MCP_METHOD_RESOURCES_TEMPLATES_LIST = 'resources/templates/list';
+  MCP_METHOD_RESOURCES_SUBSCRIBE = 'resources/subscribe';
+  MCP_METHOD_RESOURCES_UNSUBSCRIBE = 'resources/unsubscribe';
+  MCP_METHOD_COMPLETION_COMPLETE = 'completion/complete';
+
+  JSONRPC_VERSION = '2.0';
+  MEDIA_TYPE_JSON = 'application/json';
+  MEDIA_TYPE_EVENT_STREAM = 'text/event-stream';
+  CHARSET_UTF8 = 'utf-8';
+
+  MCP_KEY_JSONRPC = 'jsonrpc';
+  MCP_KEY_ID = 'id';
+  MCP_KEY_METHOD = 'method';
+  MCP_KEY_PARAMS = 'params';
+  MCP_KEY_RESULT = 'result';
+  MCP_KEY_ERROR = 'error';
+  MCP_KEY_META = '_meta';
+  MCP_KEY_INPUT_RESPONSES = 'inputResponses';
+  MCP_KEY_REQUEST_STATE = 'requestState';
+  MCP_KEY_RESULT_TYPE = 'resultType';
+  MCP_KEY_TTL_MS = 'ttlMs';
+  MCP_KEY_CACHE_SCOPE = 'cacheScope';
+  MCP_KEY_NAME = 'name';
+  MCP_KEY_TITLE = 'title';
+  MCP_KEY_DESCRIPTION = 'description';
+  MCP_KEY_URI = 'uri';
+  MCP_KEY_MIME_TYPE = 'mimeType';
+  MCP_KEY_TYPE = 'type';
+  MCP_KEY_TEXT = 'text';
+  MCP_KEY_CONTENT = 'content';
+  MCP_KEY_CURSOR = 'cursor';
+  MCP_KEY_ARGUMENTS = 'arguments';
+  MCP_KEY_ANNOTATIONS = 'annotations';
+  MCP_KEY_ICONS = 'icons';
+  MCP_KEY_CAPABILITIES = 'capabilities';
+  MCP_KEY_PROTOCOL_VERSION = 'protocolVersion';
+  MCP_KEY_INSTRUCTIONS = 'instructions';
+  MCP_KEY_VERSION = 'version';
+  MCP_KEY_LIST_CHANGED = 'listChanged';
+  MCP_KEY_SUBSCRIBE = 'subscribe';
+
+  MCP_CACHEABLE_METHODS: array[0..5] of string = (
+    MCP_METHOD_SERVER_DISCOVER,
+    MCP_METHOD_TOOLS_LIST,
+    MCP_METHOD_PROMPTS_LIST,
+    MCP_METHOD_RESOURCES_LIST,
+    MCP_METHOD_RESOURCES_TEMPLATES_LIST,
+    MCP_METHOD_RESOURCES_READ
+  );
   MCP_LOG_LEVELS: array[0..7] of string = (
     'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency');
 

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -92,6 +92,12 @@ uses
   MCPServer.Registration;
 
 const
+  MIME_TYPE_JSON = 'application/json';
+  LEVEL_INFO = 'INFO';
+  CATEGORY_SYSTEM = 'SYSTEM';
+  URI_RECENT = 'logs://recent';
+  URI_TEMPLATE_BY_LEVEL = 'logs://{level}';
+  TEMPLATE_VARIABLE_LEVEL = 'level';
   MAX_RECENT_LOG_ENTRIES = 100;
 
 { TLogEntries }
@@ -212,10 +218,10 @@ end;
 constructor TLogsRecentResource.Create;
 begin
   inherited;
-  FURI := 'logs://recent';
+  FURI := URI_RECENT;
   FName := 'Recent Logs';
   FDescription := 'Recent log entries from all categories';
-  FMimeType := 'application/json';
+  FMimeType := MIME_TYPE_JSON;
   FTtlMs := 0;
   FCacheScope := MCP_CACHE_SCOPE_PRIVATE;
 end;
@@ -250,7 +256,7 @@ begin
   FURI := AUri;
   FName := 'Recent logs (' + ALevel + ')';
   FDescription := 'Recent log entries at level ' + ALevel;
-  FMimeType := 'application/json';
+  FMimeType := MIME_TYPE_JSON;
   FTtlMs := 0;
   FCacheScope := MCP_CACHE_SCOPE_PRIVATE;
 end;
@@ -281,21 +287,21 @@ end;
 constructor TLogsByLevelTemplate.Create;
 begin
   inherited;
-  FUriTemplate := 'logs://{level}';
+  FUriTemplate := URI_TEMPLATE_BY_LEVEL;
   FName := 'Recent logs by level';
   FDescription := 'Recent log entries at the given level, e.g. logs://INFO';
-  FMimeType := 'application/json';
+  FMimeType := MIME_TYPE_JSON;
 end;
 
 function TLogsByLevelTemplate.CreateResource(const URI: string; Vars: TMCPTemplateVars): IMCPResource;
 begin
-  Result := TLogsByLevelResource.CreateForLevel(URI, Vars['level']);
+  Result := TLogsByLevelResource.CreateForLevel(URI, Vars[TEMPLATE_VARIABLE_LEVEL]);
 end;
 
 function TLogsByLevelTemplate.Complete(const ArgumentName, Value: string;
   const Context: TArray<TPair<string, string>>): TMCPCompletion;
 begin
-  if ArgumentName <> 'level' then
+  if ArgumentName <> TEMPLATE_VARIABLE_LEVEL then
     Exit(TMCPCompletion.Create(nil));
 
   var Levels := TStringList.Create;
@@ -319,20 +325,20 @@ end;
 initialization
   TLogBuffer.FLock := TCriticalSection.Create;
 
-  TLogBuffer.Instance.AddLog('INFO', 'MCP Server started', 'SYSTEM');
-  TLogBuffer.Instance.AddLog('INFO', 'Resources manager initialized', 'SYSTEM');
-  TLogBuffer.Instance.AddLog('INFO', 'Tools manager initialized', 'SYSTEM');
+  TLogBuffer.Instance.AddLog(LEVEL_INFO, 'MCP Server started', CATEGORY_SYSTEM);
+  TLogBuffer.Instance.AddLog(LEVEL_INFO, 'Resources manager initialized', CATEGORY_SYSTEM);
+  TLogBuffer.Instance.AddLog(LEVEL_INFO, 'Tools manager initialized', CATEGORY_SYSTEM);
   TLogBuffer.Instance.AddLog('WARNING', 'Debug mode is enabled', 'CONFIG');
-  TLogBuffer.Instance.AddLog('INFO', 'Server listening on port 8080', 'SERVER');
+  TLogBuffer.Instance.AddLog(LEVEL_INFO, 'Server listening on port 8080', 'SERVER');
 
-  TMCPRegistry.RegisterResource('logs://recent',
+  TMCPRegistry.RegisterResource(URI_RECENT,
     function: IMCPResource
     begin
       Result := TLogsRecentResource.Create;
     end
   );
 
-  TMCPRegistry.RegisterResourceTemplate('logs://{level}',
+  TMCPRegistry.RegisterResourceTemplate(URI_TEMPLATE_BY_LEVEL,
     function: IMCPResourceTemplate
     begin
       Result := TLogsByLevelTemplate.Create;

--- a/src/Resources/MCPServer.Resource.Project.pas
+++ b/src/Resources/MCPServer.Resource.Project.pas
@@ -65,6 +65,10 @@ uses
   MCPServer.Registration;
 
 const
+  FENCE = '```';
+  FENCE_BASH = '```bash';
+  URI_INFO = 'project://info';
+  URI_README = 'project://readme';
   PROJECT_RESOURCE_TTL_MS = 3600000;
 
 { TProjectInfo }
@@ -86,7 +90,7 @@ end;
 constructor TProjectInfoResource.Create;
 begin
   inherited;
-  FURI := 'project://info';
+  FURI := URI_INFO;
   FName := 'Project Information';
   FDescription := 'Basic information about the Delphi MCP Server project';
   FMimeType := 'application/json';
@@ -118,7 +122,7 @@ end;
 constructor TProjectReadmeResource.Create;
 begin
   inherited;
-  FURI := 'project://readme';
+  FURI := URI_README;
   FName := 'Project README';
   FDescription := 'README.md file contents';
   FMimeType := 'text/markdown';
@@ -142,31 +146,31 @@ begin
 '- CORS support for cross-origin requests' + sLineBreak +
 '' + sLineBreak +
 '## Building' + sLineBreak +
-'```bash' + sLineBreak +
+FENCE_BASH + sLineBreak +
 'build.bat' + sLineBreak +
-'```' + sLineBreak +
+FENCE + sLineBreak +
 '' + sLineBreak +
 '## Running' + sLineBreak +
-'```bash' + sLineBreak +
+FENCE_BASH + sLineBreak +
 'Win32\Debug\MCPServer.exe' + sLineBreak +
-'```' + sLineBreak +
+FENCE + sLineBreak +
 '' + sLineBreak +
 '## Testing' + sLineBreak +
-'```bash' + sLineBreak +
+FENCE_BASH + sLineBreak +
 'npx @wong2/mcp-cli --url http://localhost:8080/mcp' + sLineBreak +
-'```' + sLineBreak +
+FENCE + sLineBreak +
 '''';
 end;
 
 initialization
-  TMCPRegistry.RegisterResource('project://info',
+  TMCPRegistry.RegisterResource(URI_INFO,
     function: IMCPResource
     begin
       Result := TProjectInfoResource.Create;
     end
   );
 
-  TMCPRegistry.RegisterResource('project://readme',
+  TMCPRegistry.RegisterResource(URI_README,
     function: IMCPResource
     begin
       Result := TProjectReadmeResource.Create;

--- a/src/Resources/MCPServer.Resource.Samples.pas
+++ b/src/Resources/MCPServer.Resource.Samples.pas
@@ -64,6 +64,10 @@ uses
   MCPServer.Tool.ContentSamples;
 
 const
+  MIME_TYPE_JSON = 'application/json';
+  URI_STATIC_BINARY = 'test://static-binary';
+  TEMPLATE_DATA_TITLE = 'Template data';
+  URI_TEMPLATE_DATA = 'test://template/{id}/data';
   SAMPLE_RESOURCE_TTL_MS = 3600000;
 
 { TStaticTextResource }
@@ -91,7 +95,7 @@ end;
 constructor TStaticBinaryResource.Create;
 begin
   inherited;
-  FURI := 'test://static-binary';
+  FURI := URI_STATIC_BINARY;
   FName := 'Static binary';
   FTitle := 'Static binary resource';
   FDescription := 'A fixed PNG image';
@@ -118,9 +122,9 @@ begin
   inherited Create;
   FId := AId;
   FURI := AUri;
-  FName := 'Template data';
+  FName := TEMPLATE_DATA_TITLE;
   FDescription := 'Data keyed by the id captured from the template';
-  FMimeType := 'application/json';
+  FMimeType := MIME_TYPE_JSON;
 end;
 
 function TTemplateDataResource.GetResourceData: TTemplateData;
@@ -136,10 +140,10 @@ end;
 constructor TTemplateDataResourceTemplate.Create;
 begin
   inherited;
-  FUriTemplate := 'test://template/{id}/data';
-  FName := 'Template data';
+  FUriTemplate := URI_TEMPLATE_DATA;
+  FName := TEMPLATE_DATA_TITLE;
   FDescription := 'Data keyed by an id path segment';
-  FMimeType := 'application/json';
+  FMimeType := MIME_TYPE_JSON;
 end;
 
 function TTemplateDataResourceTemplate.CreateResource(const URI: string; Vars: TMCPTemplateVars): IMCPResource;
@@ -153,12 +157,12 @@ initialization
     begin
       Result := TStaticTextResource.Create;
     end);
-  TMCPRegistry.RegisterResource('test://static-binary',
+  TMCPRegistry.RegisterResource(URI_STATIC_BINARY,
     function: IMCPResource
     begin
       Result := TStaticBinaryResource.Create;
     end);
-  TMCPRegistry.RegisterResourceTemplate('test://template/{id}/data',
+  TMCPRegistry.RegisterResourceTemplate(URI_TEMPLATE_DATA,
     function: IMCPResourceTemplate
     begin
       Result := TTemplateDataResourceTemplate.Create;

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -50,6 +50,12 @@ implementation
 uses
   System.NetEncoding;
 
+const
+  SCHEME_HTTP = 'http';
+  SCHEME_HTTPS = 'https';
+  AUTHORITY_FORMAT = 'http://%s';
+
+
 { TMCPHeaderValue }
 
 class function TMCPHeaderValue.IsHeaderSafe(const Value: string): Boolean;
@@ -168,9 +174,9 @@ end;
 
 function TMCPOriginParts.DefaultPort: string;
 begin
-  if Scheme = 'https' then
+  if Scheme = SCHEME_HTTPS then
     Result := '443'
-  else if Scheme = 'http' then
+  else if Scheme = SCHEME_HTTP then
     Result := '80'
   else
     Result := '';
@@ -179,7 +185,7 @@ end;
 class function TMCPOriginPolicy.IsLoopback(const Origin: string): Boolean;
 begin
   const Parts = TMCPOriginParts.Parse(Origin);
-  const IsHttp = ((Parts.Scheme = 'http') or (Parts.Scheme = 'https'));
+  const IsHttp = ((Parts.Scheme = SCHEME_HTTP) or (Parts.Scheme = SCHEME_HTTPS));
   const IsLocal = ((Parts.Host = 'localhost') or (Parts.Host = '127.0.0.1') or (Parts.Host = '[::1]'));
   Result := IsHttp and IsLocal;
 end;
@@ -228,8 +234,8 @@ begin
   if Pattern.Trim = TMCPOriginPolicy.ALLOW_ALL then
     Exit(True);
 
-  const Wanted = TMCPOriginParts.Parse(Format('http://%s', [HostHeader.Trim]));
-  const Allowed = TMCPOriginParts.Parse(Format('http://%s', [Pattern.Trim]));
+  const Wanted = TMCPOriginParts.Parse(Format(AUTHORITY_FORMAT, [HostHeader.Trim]));
+  const Allowed = TMCPOriginParts.Parse(Format(AUTHORITY_FORMAT, [Pattern.Trim]));
   const SameHost = ((Wanted.Host <> '') and (Allowed.Host <> '') and (Wanted.Host = Allowed.Host));
   if not SameHost then
     Exit(False);

--- a/src/Server/MCPServer.HttpStream.pas
+++ b/src/Server/MCPServer.HttpStream.pas
@@ -11,8 +11,6 @@ uses
 
 type
   TMCPHttpResponseStream = class(TInterfacedObject, IMCPMessageSink, IMCPRequestTracker, IMCPKeepAlive)
-  public
-    const MEDIA_TYPE_EVENT_STREAM = 'text/event-stream';
   strict private
     FConnection: TIdContext;
     FResponseInfo: TIdHTTPResponseInfo;
@@ -55,8 +53,6 @@ const
   SSE_EVENT_SUFFIX = #10#10;
   CHUNK_TERMINATOR = '0'#13#10#13#10;
   SSE_KEEP_ALIVE_COMMENT = ': keep-alive'#10#10;
-  CHARSET_UTF8 = 'utf-8';
-  HTTP_STATUS_OK = 200;
 
 { TMCPHttpResponseStream }
 

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -111,6 +111,11 @@ uses
   MCPServer.Logger;
 
 const
+  HOST_LOCALHOST = 'localhost';
+  DEFAULT_ENDPOINT = '/mcp';
+  HEADER_ALLOW_ORIGIN = 'Access-Control-Allow-Origin';
+  MESSAGE_NO_CERTIFICATE = 'SSL certificate file not found: %s';
+  MESSAGE_NO_KEY = 'SSL key file not found: %s';
   DEFAULT_MCP_PORT = 3000;
 
   HTTP_NO_CONTENT = 204;
@@ -139,8 +144,6 @@ const
   HEADER_METHOD = 'Mcp-Method';
   HEADER_NAME = 'Mcp-Name';
 
-  MEDIA_TYPE_JSON = 'application/json';
-  MEDIA_TYPE_EVENT_STREAM = 'text/event-stream';
 
   LOOPBACK_IPV4 = '127.0.0.1';
   LOOPBACK_IPV6 = '::1';
@@ -272,7 +275,7 @@ begin
   FHTTPServer.Bindings.Clear;
 
   var Address := '';
-  var Host := 'localhost';
+  var Host := HOST_LOCALHOST;
   if Assigned(FSettings) then
   begin
     Address := FSettings.BindAddress.Trim;
@@ -290,7 +293,7 @@ begin
     Exit;
   end;
 
-  if SameText(Host, 'localhost') or (Host = LOOPBACK_IPV4) or (Host = LOOPBACK_IPV6) then
+  if SameText(Host, HOST_LOCALHOST) or (Host = LOOPBACK_IPV4) or (Host = LOOPBACK_IPV6) then
   begin
     AddBinding(LOOPBACK_IPV4, Id_IPv4);
     if GStack.SupportsIPv6 then
@@ -309,14 +312,14 @@ procedure TMCPIdHTTPServer.ConfigureSSL;
 begin
   if not TFile.Exists(FSettings.SSLCertFile) then
   begin
-    TLogger.Error(Format('SSL certificate file not found: %s', [FSettings.SSLCertFile]));
-    raise EMCPConfigurationError.CreateFmt('SSL certificate file not found: %s', [FSettings.SSLCertFile]);
+    TLogger.Error(Format(MESSAGE_NO_CERTIFICATE, [FSettings.SSLCertFile]));
+    raise EMCPConfigurationError.CreateFmt(MESSAGE_NO_CERTIFICATE, [FSettings.SSLCertFile]);
   end;
 
   if not TFile.Exists(FSettings.SSLKeyFile) then
   begin
-    TLogger.Error(Format('SSL key file not found: %s', [FSettings.SSLKeyFile]));
-    raise EMCPConfigurationError.CreateFmt('SSL key file not found: %s', [FSettings.SSLKeyFile]);
+    TLogger.Error(Format(MESSAGE_NO_KEY, [FSettings.SSLKeyFile]));
+    raise EMCPConfigurationError.CreateFmt(MESSAGE_NO_KEY, [FSettings.SSLKeyFile]);
   end;
 
   {$IFDEF USE_TAURUS_TLS}
@@ -406,7 +409,7 @@ begin
     if not ValidateHost(RequestInfo, ResponseInfo) or not ValidateOrigin(RequestInfo, ResponseInfo) then
       Exit;
 
-    var Endpoint := '/mcp';
+    var Endpoint := DEFAULT_ENDPOINT;
     var EndpointInfoPath := '';
     if Assigned(FSettings) then
     begin
@@ -505,9 +508,9 @@ begin
       AllowAll := True;
 
   if (Origin = '') or AllowAll then
-    ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := TMCPOriginPolicy.ALLOW_ALL
+    ResponseInfo.CustomHeaders.Values[HEADER_ALLOW_ORIGIN] := TMCPOriginPolicy.ALLOW_ALL
   else
-    ResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := Origin;
+    ResponseInfo.CustomHeaders.Values[HEADER_ALLOW_ORIGIN] := Origin;
 
   var AllowHeaders := CORS_ALLOW_HEADERS;
   for var Requested in HeaderValue(RequestInfo, 'Access-Control-Request-Headers').Split([',']) do
@@ -544,7 +547,7 @@ end;
 
 function TMCPIdHTTPServer.IsProtectedResourceMetadataPath(const Document: string): Boolean;
 begin
-  var Endpoint := '/mcp';
+  var Endpoint := DEFAULT_ENDPOINT;
   if Assigned(FSettings) then
     Endpoint := FSettings.Endpoint;
   Result := (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH)
@@ -748,7 +751,7 @@ procedure TMCPIdHTTPServer.SendSse(ResponseInfo: TIdHTTPResponseInfo; const Body
 begin
   ResponseInfo.ResponseNo := HTTP_STATUS_OK;
   ResponseInfo.ContentType := MEDIA_TYPE_EVENT_STREAM;
-  ResponseInfo.CharSet := 'utf-8';
+  ResponseInfo.CharSet := CHARSET_UTF8;
   ResponseInfo.CustomHeaders.Values['Cache-Control'] := 'no-cache';
   ResponseInfo.CustomHeaders.Values['X-Accel-Buffering'] := 'no';
   ResponseInfo.ContentStream := TStringStream.Create(TMCPHttpResponseStream.EventText(Body), TEncoding.UTF8);
@@ -759,9 +762,9 @@ procedure TMCPIdHTTPServer.SendJsonRpcError(ResponseInfo: TIdHTTPResponseInfo; S
 begin
   var Response := TJSONObject.Create;
   try
-    Response.AddPair('jsonrpc', '2.0');
+    Response.AddPair(MCP_KEY_JSONRPC, '2.0');
     var Error := TJSONObject.Create;
-    Response.AddPair('error', Error);
+    Response.AddPair(MCP_KEY_ERROR, Error);
     Error.AddPair('code', TJSONNumber.Create(Code));
     Error.AddPair('message', Message);
     SendJson(ResponseInfo, Status, Response.ToJSON);

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -89,6 +89,10 @@ implementation
 uses
   MCPServer.Errors;
 
+const
+  REASON_STDIN_CLOSED = 'stdin closed';
+
+
 type
   TMCPStdioWorker = class(TThread)
   strict private
@@ -319,13 +323,13 @@ begin
     if Message is TJSONObject then
     begin
       var Request := TJSONObject(Message);
-      var RequestId := TMCPRequestId.FromJson(Request.GetValue('id'));
-      var MethodValue := Request.GetValue('method');
+      var RequestId := TMCPRequestId.FromJson(Request.GetValue(MCP_KEY_ID));
+      var MethodValue := Request.GetValue(MCP_KEY_METHOD);
       var Method := '';
       if MethodValue is TJSONString then
         Method := TJSONString(MethodValue).Value;
 
-      if RequestId.IsPresent and (Method <> '') and (Method <> 'ping') then
+      if RequestId.IsPresent and (Method <> '') and (Method <> MCP_METHOD_PING) then
       begin
         if not FTracker.Reserve(RequestId) then
         begin
@@ -368,7 +372,7 @@ end;
 
 procedure TMCPStdioTransport.ProcessQueued(const Message: TJSONValue);
 begin
-  var RequestId := TMCPRequestId.FromJson(TJSONObject(Message).GetValue('id'));
+  var RequestId := TMCPRequestId.FromJson(TJSONObject(Message).GetValue(MCP_KEY_ID));
   try
     var Outcome := FJsonRpcProcessor.ProcessRequestEx(Message, Hints);
     if Outcome.Cancelled then
@@ -408,7 +412,7 @@ begin
   var Deadline := TThread.GetTickCount64 + UInt64(FShutdownDrainMs);
   repeat
     if Assigned(Hub) then
-      Hub.CloseAll('stdin closed');
+      Hub.CloseAll(REASON_STDIN_CLOSED);
     if AtomicCmpExchange(FListeners, 0, 0) = 0 then
       Break;
     Sleep(LISTENER_POLL_MS);
@@ -460,7 +464,7 @@ begin
   const Drained = (FWorkersDone.WaitFor(Cardinal(FShutdownDrainMs)) = TWaitResult.wrSignaled);
   if not Drained then
   begin
-    FTracker.CancelAll('stdin closed');
+    FTracker.CancelAll(REASON_STDIN_CLOSED);
     FWorkersDone.WaitFor(SHUTDOWN_CANCEL_GRACE_MS);
   end;
   CloseSubscriptions;

--- a/src/Tools/MCPServer.Tool.Calculate.pas
+++ b/src/Tools/MCPServer.Tool.Calculate.pas
@@ -40,12 +40,16 @@ implementation
 uses
   MCPServer.Registration;
 
+const
+  TOOL_NAME = 'calculate';
+
+
 { TCalculateTool }
 
 constructor TCalculateTool.Create;
 begin
   inherited;
-  FName := 'calculate';
+  FName := TOOL_NAME;
   FDescription := 'Perform basic arithmetic calculations';
 end;
 
@@ -81,7 +85,7 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('calculate',
+  TMCPRegistry.RegisterTool(TOOL_NAME,
     function: IMCPTool
     begin
       Result := TCalculateTool.Create;

--- a/src/Tools/MCPServer.Tool.ContentSamples.pas
+++ b/src/Tools/MCPServer.Tool.ContentSamples.pas
@@ -109,12 +109,26 @@ uses
   MCPServer.Registration,
   MCPServer.Tool.Result;
 
+const
+  TOOL_SIMPLE_TEXT = 'test_simple_text';
+  TOOL_IMAGE_CONTENT = 'test_image_content';
+  TOOL_AUDIO_CONTENT = 'test_audio_content';
+  TOOL_EMBEDDED_RESOURCE = 'test_embedded_resource';
+  TOOL_MULTIPLE_CONTENT_TYPES = 'test_multiple_content_types';
+  TOOL_ERROR_HANDLING = 'test_error_handling';
+  TOOL_WITH_PROGRESS = 'test_tool_with_progress';
+  TOOL_LOGGING = 'test_logging_tool';
+  TOOL_JSON_SCHEMA = 'json_schema_2020_12_tool';
+  MIME_TYPE_PNG = 'image/png';
+  MIME_TYPE_TEXT = 'text/plain';
+
+
 { TSimpleTextTool }
 
 constructor TSimpleTextTool.Create;
 begin
   inherited;
-  FName := 'test_simple_text';
+  FName := TOOL_SIMPLE_TEXT;
   FDescription := 'Returns a plain text result';
   FAnnotations := TJSONObject.Create;
   FAnnotations.AddPair('readOnlyHint', TJSONBool.Create(True));
@@ -130,13 +144,13 @@ end;
 constructor TImageContentTool.Create;
 begin
   inherited;
-  FName := 'test_image_content';
+  FName := TOOL_IMAGE_CONTENT;
   FDescription := 'Returns an image content block';
 end;
 
 function TImageContentTool.ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue;
 begin
-  Result := TMCPToolResult.Create.AddImage(SAMPLE_PNG_BASE64, 'image/png');
+  Result := TMCPToolResult.Create.AddImage(SAMPLE_PNG_BASE64, MIME_TYPE_PNG);
 end;
 
 { TAudioContentTool }
@@ -144,7 +158,7 @@ end;
 constructor TAudioContentTool.Create;
 begin
   inherited;
-  FName := 'test_audio_content';
+  FName := TOOL_AUDIO_CONTENT;
   FDescription := 'Returns an audio content block';
 end;
 
@@ -158,13 +172,13 @@ end;
 constructor TEmbeddedResourceTool.Create;
 begin
   inherited;
-  FName := 'test_embedded_resource';
+  FName := TOOL_EMBEDDED_RESOURCE;
   FDescription := 'Returns an embedded resource content block';
 end;
 
 function TEmbeddedResourceTool.ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue;
 begin
-  Result := TMCPToolResult.Create.AddEmbeddedText(SAMPLE_TEXT_RESOURCE_URI, 'text/plain', SAMPLE_TEXT_RESOURCE_CONTENT);
+  Result := TMCPToolResult.Create.AddEmbeddedText(SAMPLE_TEXT_RESOURCE_URI, MIME_TYPE_TEXT, SAMPLE_TEXT_RESOURCE_CONTENT);
 end;
 
 { TMultipleContentTypesTool }
@@ -172,7 +186,7 @@ end;
 constructor TMultipleContentTypesTool.Create;
 begin
   inherited;
-  FName := 'test_multiple_content_types';
+  FName := TOOL_MULTIPLE_CONTENT_TYPES;
   FDescription := 'Returns text, image and embedded resource content in one result';
 end;
 
@@ -180,8 +194,8 @@ function TMultipleContentTypesTool.ExecuteWithContext(const Params: TNoParams; c
 begin
   Result := TMCPToolResult.Create
     .AddText('Multiple content types example')
-    .AddImage(SAMPLE_PNG_BASE64, 'image/png')
-    .AddEmbeddedText(SAMPLE_TEXT_RESOURCE_URI, 'text/plain', SAMPLE_TEXT_RESOURCE_CONTENT);
+    .AddImage(SAMPLE_PNG_BASE64, MIME_TYPE_PNG)
+    .AddEmbeddedText(SAMPLE_TEXT_RESOURCE_URI, MIME_TYPE_TEXT, SAMPLE_TEXT_RESOURCE_CONTENT);
 end;
 
 { TErrorHandlingTool }
@@ -189,7 +203,7 @@ end;
 constructor TErrorHandlingTool.Create;
 begin
   inherited;
-  FName := 'test_error_handling';
+  FName := TOOL_ERROR_HANDLING;
   FDescription := 'Always fails with a tool execution error';
 end;
 
@@ -203,7 +217,7 @@ end;
 constructor TProgressTool.Create;
 begin
   inherited;
-  FName := 'test_tool_with_progress';
+  FName := TOOL_WITH_PROGRESS;
   FDescription := 'Runs a few steps and reports progress for each; honours cancellation';
 end;
 
@@ -237,7 +251,7 @@ end;
 constructor TJsonSchema202012Tool.Create;
 begin
   inherited;
-  FName := 'json_schema_2020_12_tool';
+  FName := TOOL_JSON_SCHEMA;
   FDescription := 'Tool with JSON Schema 2020-12 features';
 end;
 
@@ -274,7 +288,7 @@ end;
 constructor TLoggingTool.Create;
 begin
   inherited;
-  FName := 'test_logging_tool';
+  FName := TOOL_LOGGING;
   FDescription := 'Emits log notifications at every level; the client sees those at or above its requested level';
 end;
 
@@ -282,53 +296,53 @@ function TLoggingTool.ExecuteWithContext(const Params: TNoParams; const Context:
 begin
   for var Level in MCP_LOG_LEVELS do
   begin
-    Context.Log(Level, Format('%s message from test_logging_tool', [Level]), 'test_logging_tool');
+    Context.Log(Level, Format('%s message from test_logging_tool', [Level]), TOOL_LOGGING);
   end;
   Result := TMCPToolResult.Text('Logged a message at every level');
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('test_simple_text',
+  TMCPRegistry.RegisterTool(TOOL_SIMPLE_TEXT,
     function: IMCPTool
     begin
       Result := TSimpleTextTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_image_content',
+  TMCPRegistry.RegisterTool(TOOL_IMAGE_CONTENT,
     function: IMCPTool
     begin
       Result := TImageContentTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_audio_content',
+  TMCPRegistry.RegisterTool(TOOL_AUDIO_CONTENT,
     function: IMCPTool
     begin
       Result := TAudioContentTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_embedded_resource',
+  TMCPRegistry.RegisterTool(TOOL_EMBEDDED_RESOURCE,
     function: IMCPTool
     begin
       Result := TEmbeddedResourceTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_multiple_content_types',
+  TMCPRegistry.RegisterTool(TOOL_MULTIPLE_CONTENT_TYPES,
     function: IMCPTool
     begin
       Result := TMultipleContentTypesTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_tool_with_progress',
+  TMCPRegistry.RegisterTool(TOOL_WITH_PROGRESS,
     function: IMCPTool
     begin
       Result := TProgressTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_error_handling',
+  TMCPRegistry.RegisterTool(TOOL_ERROR_HANDLING,
     function: IMCPTool
     begin
       Result := TErrorHandlingTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_logging_tool',
+  TMCPRegistry.RegisterTool(TOOL_LOGGING,
     function: IMCPTool
     begin
       Result := TLoggingTool.Create;
     end);
-  TMCPRegistry.RegisterTool('json_schema_2020_12_tool',
+  TMCPRegistry.RegisterTool(TOOL_JSON_SCHEMA,
     function: IMCPTool
     begin
       Result := TJsonSchema202012Tool.Create;

--- a/src/Tools/MCPServer.Tool.Echo.pas
+++ b/src/Tools/MCPServer.Tool.Echo.pas
@@ -29,12 +29,16 @@ implementation
 uses
   MCPServer.Registration;
 
+const
+  TOOL_NAME = 'echo';
+
+
 { TEchoTool }
 
 constructor TEchoTool.Create;
 begin
   inherited;
-  FName := 'echo';
+  FName := TOOL_NAME;
   FDescription := 'Echo a message back to the user';
 end;
 
@@ -44,7 +48,7 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('echo',
+  TMCPRegistry.RegisterTool(TOOL_NAME,
     function: IMCPTool
     begin
       Result := TEchoTool.Create;

--- a/src/Tools/MCPServer.Tool.GetTime.pas
+++ b/src/Tools/MCPServer.Tool.GetTime.pas
@@ -24,12 +24,16 @@ implementation
 uses
   MCPServer.Registration;
 
+const
+  TOOL_NAME = 'get_time';
+
+
 { TGetTimeTool }
 
 constructor TGetTimeTool.Create;
 begin
   inherited;
-  FName := 'get_time';
+  FName := TOOL_NAME;
   FDescription := 'Get the current server time in ISO format';
 end;
 
@@ -39,7 +43,7 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('get_time',
+  TMCPRegistry.RegisterTool(TOOL_NAME,
     function: IMCPTool
     begin
       Result := TGetTimeTool.Create;

--- a/src/Tools/MCPServer.Tool.InputRequiredSamples.pas
+++ b/src/Tools/MCPServer.Tool.InputRequiredSamples.pas
@@ -94,6 +94,21 @@ uses
   MCPServer.Tool.Result;
 
 const
+  ASK_STEP_ONE = 'Step 1: What is your name?';
+  ASK_STEP_TWO = 'Step 2: What is your favorite color?';
+  TOOL_ELICITATION = 'test_input_required_result_elicitation';
+  TOOL_SAMPLING = 'test_input_required_result_sampling';
+  TOOL_LIST_ROOTS = 'test_input_required_result_list_roots';
+  TOOL_REQUEST_STATE = 'test_input_required_result_request_state';
+  TOOL_MULTIPLE_INPUTS = 'test_input_required_result_multiple_inputs';
+  TOOL_MULTI_ROUND = 'test_input_required_result_multi_round';
+  TOOL_TAMPERED_STATE = 'test_input_required_result_tampered_state';
+  TOOL_CAPABILITIES = 'test_input_required_result_capabilities';
+  TOOL_MISSING_CAPABILITY = 'test_missing_capability';
+  TOOL_STREAMING_ELICITATION = 'test_streaming_elicitation';
+  ASK_CONFIRM = 'Please confirm';
+  SCHEMA_TYPE_BOOLEAN = 'boolean';
+  VALUE_TRUE = 'true';
   KEY_USER_NAME = 'user_name';
   KEY_CAPITAL_QUESTION = 'capital_question';
   KEY_CLIENT_ROOTS = 'client_roots';
@@ -125,7 +140,7 @@ begin
     for var Root in Roots do
     begin
       if Root is TJSONObject then
-        Uris := Uris + [TJSONObject(Root).GetValue<string>('uri', '')];
+        Uris := Uris + [TJSONObject(Root).GetValue<string>(MCP_KEY_URI, '')];
     end;
   end;
   Result := Format('Roots: %s', [string.Join(', ', Uris)]);
@@ -142,7 +157,7 @@ end;
 constructor TElicitationInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_elicitation';
+  FName := TOOL_ELICITATION;
   FDescription := 'Asks the client for a name through an elicitation input request, then greets it';
 end;
 
@@ -165,7 +180,7 @@ end;
 constructor TSamplingInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_sampling';
+  FName := TOOL_SAMPLING;
   FDescription := 'Asks the client to sample an answer, then returns that answer';
 end;
 
@@ -188,7 +203,7 @@ end;
 constructor TListRootsInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_list_roots';
+  FName := TOOL_LIST_ROOTS;
   FDescription := 'Asks the client for its roots, then lists them';
 end;
 
@@ -208,7 +223,7 @@ end;
 constructor TRequestStateInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_request_state';
+  FName := TOOL_REQUEST_STATE;
   FDescription := 'Asks for a confirmation and carries a signed requestState across the round trip';
 end;
 
@@ -217,14 +232,14 @@ var
   Response: TJSONObject;
 begin
   var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = 'true');
+    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   var HasState := Assigned(Context.RequestState) and Assigned(Context.RequestState.GetValue(STATE_NONCE));
   if not Confirmed or not HasState then
   begin
     var State := TJSONObject.Create;
     State.AddPair(STATE_NONCE, TGUID.NewGuid.ToString);
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_CONFIRM, 'Please confirm', TMCPInputRequests.FieldSchema(FIELD_OK, 'boolean')), State);
+      .AddElicitation(KEY_CONFIRM, ASK_CONFIRM, TMCPInputRequests.FieldSchema(FIELD_OK, SCHEMA_TYPE_BOOLEAN)), State);
   end;
 
   Result := TMCPToolResult.Text(Format('state-ok: confirmed with nonce %s',
@@ -236,7 +251,7 @@ end;
 constructor TMultipleInputsTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_multiple_inputs';
+  FName := TOOL_MULTIPLE_INPUTS;
   FDescription := 'Asks for a name, a sampled greeting and the client roots in one round trip';
 end;
 
@@ -265,7 +280,7 @@ end;
 constructor TMultiRoundInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_multi_round';
+  FName := TOOL_MULTI_ROUND;
   FDescription := 'Asks for a name and then a colour in two consecutive round trips';
 end;
 
@@ -279,7 +294,7 @@ begin
 
   if Round < 1 then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_STEP1, 'Step 1: What is your name?', TMCPInputRequests.FieldSchema(FIELD_NAME)), TInputSample.NewState(1));
+      .AddElicitation(KEY_STEP1, ASK_STEP_ONE, TMCPInputRequests.FieldSchema(FIELD_NAME)), TInputSample.NewState(1));
 
   if Round = 1 then
   begin
@@ -288,12 +303,12 @@ begin
       Name := TMCPInputResponse.ElicitationField(Response, FIELD_NAME);
     if Name = '' then
       raise EMCPInputRequired.Create(TMCPInputRequests.Create
-        .AddElicitation(KEY_STEP1, 'Step 1: What is your name?', TMCPInputRequests.FieldSchema(FIELD_NAME)), TInputSample.NewState(1));
+        .AddElicitation(KEY_STEP1, ASK_STEP_ONE, TMCPInputRequests.FieldSchema(FIELD_NAME)), TInputSample.NewState(1));
 
     var State := TInputSample.NewState(2);
     State.AddPair(STATE_NAME, Name);
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_STEP2, 'Step 2: What is your favorite color?', TMCPInputRequests.FieldSchema(FIELD_COLOR)), State);
+      .AddElicitation(KEY_STEP2, ASK_STEP_TWO, TMCPInputRequests.FieldSchema(FIELD_COLOR)), State);
   end;
 
   var Color := '';
@@ -304,7 +319,7 @@ begin
     var State := TInputSample.NewState(2);
     State.AddPair(STATE_NAME, Context.RequestState.GetValue<string>(STATE_NAME, ''));
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_STEP2, 'Step 2: What is your favorite color?', TMCPInputRequests.FieldSchema(FIELD_COLOR)), State);
+      .AddElicitation(KEY_STEP2, ASK_STEP_TWO, TMCPInputRequests.FieldSchema(FIELD_COLOR)), State);
   end;
 
   Result := TMCPToolResult.Text(Format('Hello, %s! Your favorite color is %s.',
@@ -316,7 +331,7 @@ end;
 constructor TTamperedStateInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_tampered_state';
+  FName := TOOL_TAMPERED_STATE;
   FDescription := 'Asks for a confirmation with a signed requestState that must come back unchanged';
 end;
 
@@ -325,10 +340,10 @@ var
   Response: TJSONObject;
 begin
   var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = 'true');
+    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   if not Confirmed or not Assigned(Context.RequestState) then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_CONFIRM, 'Please confirm', TMCPInputRequests.FieldSchema(FIELD_OK, 'boolean')), TInputSample.NewState(1));
+      .AddElicitation(KEY_CONFIRM, ASK_CONFIRM, TMCPInputRequests.FieldSchema(FIELD_OK, SCHEMA_TYPE_BOOLEAN)), TInputSample.NewState(1));
 
   Result := TMCPToolResult.Text('state-ok: the requestState verified');
 end;
@@ -338,7 +353,7 @@ end;
 constructor TCapabilityAwareInputTool.Create;
 begin
   inherited;
-  FName := 'test_input_required_result_capabilities';
+  FName := TOOL_CAPABILITIES;
   FDescription := 'Asks only for the kinds of input the client declared it can provide';
 end;
 
@@ -391,7 +406,7 @@ end;
 constructor TMissingCapabilityTool.Create;
 begin
   inherited;
-  FName := 'test_missing_capability';
+  FName := TOOL_MISSING_CAPABILITY;
   FDescription := 'Requires the sampling client capability and fails with -32021 when it is absent';
 end;
 
@@ -406,7 +421,7 @@ end;
 constructor TStreamingElicitationTool.Create;
 begin
   inherited;
-  FName := 'test_streaming_elicitation';
+  FName := TOOL_STREAMING_ELICITATION;
   FDescription := 'Logs to the response stream, then asks the client for a confirmation';
 end;
 
@@ -414,63 +429,63 @@ function TStreamingElicitationTool.ExecuteWithContext(const Params: TNoParams; c
 var
   Response: TJSONObject;
 begin
-  Context.Log('info', 'Asking the client to confirm', 'test_streaming_elicitation');
+  Context.Log('info', 'Asking the client to confirm', TOOL_STREAMING_ELICITATION);
   var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = 'true');
+    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   if not Confirmed then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
-      .AddElicitation(KEY_CONFIRM, 'Please confirm', TMCPInputRequests.FieldSchema(FIELD_OK, 'boolean')));
+      .AddElicitation(KEY_CONFIRM, ASK_CONFIRM, TMCPInputRequests.FieldSchema(FIELD_OK, SCHEMA_TYPE_BOOLEAN)));
 
   Result := TMCPToolResult.Text('Confirmed');
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('test_input_required_result_elicitation',
+  TMCPRegistry.RegisterTool(TOOL_ELICITATION,
     function: IMCPTool
     begin
       Result := TElicitationInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_sampling',
+  TMCPRegistry.RegisterTool(TOOL_SAMPLING,
     function: IMCPTool
     begin
       Result := TSamplingInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_list_roots',
+  TMCPRegistry.RegisterTool(TOOL_LIST_ROOTS,
     function: IMCPTool
     begin
       Result := TListRootsInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_request_state',
+  TMCPRegistry.RegisterTool(TOOL_REQUEST_STATE,
     function: IMCPTool
     begin
       Result := TRequestStateInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_multiple_inputs',
+  TMCPRegistry.RegisterTool(TOOL_MULTIPLE_INPUTS,
     function: IMCPTool
     begin
       Result := TMultipleInputsTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_multi_round',
+  TMCPRegistry.RegisterTool(TOOL_MULTI_ROUND,
     function: IMCPTool
     begin
       Result := TMultiRoundInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_tampered_state',
+  TMCPRegistry.RegisterTool(TOOL_TAMPERED_STATE,
     function: IMCPTool
     begin
       Result := TTamperedStateInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_input_required_result_capabilities',
+  TMCPRegistry.RegisterTool(TOOL_CAPABILITIES,
     function: IMCPTool
     begin
       Result := TCapabilityAwareInputTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_missing_capability',
+  TMCPRegistry.RegisterTool(TOOL_MISSING_CAPABILITY,
     function: IMCPTool
     begin
       Result := TMissingCapabilityTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_streaming_elicitation',
+  TMCPRegistry.RegisterTool(TOOL_STREAMING_ELICITATION,
     function: IMCPTool
     begin
       Result := TStreamingElicitationTool.Create;

--- a/src/Tools/MCPServer.Tool.ListFiles.pas
+++ b/src/Tools/MCPServer.Tool.ListFiles.pas
@@ -37,12 +37,16 @@ implementation
 uses
   MCPServer.Registration;
 
+const
+  TOOL_NAME = 'list_files';
+
+
 { TListFilesTool }
 
 constructor TListFilesTool.Create;
 begin
   inherited;
-  FName := 'list_files';
+  FName := TOOL_NAME;
   FDescription := 'List files in a directory';
 end;
 
@@ -96,7 +100,7 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('list_files',
+  TMCPRegistry.RegisterTool(TOOL_NAME,
     function: IMCPTool
     begin
       Result := TListFilesTool.Create;

--- a/src/Tools/MCPServer.Tool.Result.pas
+++ b/src/Tools/MCPServer.Tool.Result.pas
@@ -118,7 +118,7 @@ begin
   FContent.AddElement(Block);
   if Assigned(FPendingAnnotations) then
   begin
-    Block.AddPair('annotations', FPendingAnnotations);
+    Block.AddPair(MCP_KEY_ANNOTATIONS, FPendingAnnotations);
     FPendingAnnotations := nil;
   end;
 end;
@@ -127,7 +127,7 @@ function TMCPToolResult.WithAnnotations(const Annotations: TJSONObject): TMCPToo
 begin
   const HasBlock = (FContent.Count > 0);
   if HasBlock then
-    TJSONObject(FContent.Items[FContent.Count - 1]).AddPair('annotations', Annotations)
+    TJSONObject(FContent.Items[FContent.Count - 1]).AddPair(MCP_KEY_ANNOTATIONS, Annotations)
   else
   begin
     FPendingAnnotations.Free;
@@ -173,8 +173,8 @@ begin
   if (Result.Count = 0) and Assigned(FStructuredContent) then
   begin
     var Block := TJSONObject.Create;
-    Block.AddPair('type', 'text');
-    Block.AddPair('text', FStructuredContent.ToJSON);
+    Block.AddPair(MCP_KEY_TYPE, 'text');
+    Block.AddPair(MCP_KEY_TEXT, FStructuredContent.ToJSON);
     Result.AddElement(Block);
   end;
 end;
@@ -183,7 +183,7 @@ function TMCPToolResult.ToJson(Era: TMCPProtocolEra): TJSONObject;
 begin
   Result := TJSONObject.Create;
   try
-    Result.AddPair('content', BuildContent(Era));
+    Result.AddPair(MCP_KEY_CONTENT, BuildContent(Era));
 
     if Assigned(FStructuredContent)
       and ((Era = TMCPProtocolEra.Modern) or (FStructuredContent is TJSONObject)) then
@@ -193,7 +193,7 @@ begin
       Result.AddPair('isError', TJSONBool.Create(True));
 
     if Assigned(FMeta) then
-      Result.AddPair('_meta', TJSONObject(FMeta.Clone));
+      Result.AddPair(MCP_KEY_META, TJSONObject(FMeta.Clone));
   except
     Result.Free;
     raise;

--- a/src/Tools/MCPServer.Tool.SubscriptionSamples.pas
+++ b/src/Tools/MCPServer.Tool.SubscriptionSamples.pas
@@ -56,6 +56,11 @@ uses
   MCPServer.Tool.Result;
 
 const
+  TOOL_TRIGGER_TOOL_CHANGE = 'test_trigger_tool_change';
+  TOOL_TRIGGER_PROMPT_CHANGE = 'test_trigger_prompt_change';
+  TOOL_TRIGGER_RESOURCE_CHANGE = 'test_trigger_resource_change';
+  MESSAGE_REMOVED = 'Removed %s';
+  MESSAGE_ADDED = 'Added %s';
   DYNAMIC_TOOL_NAME = 'test_dynamic_tool';
   DYNAMIC_PROMPT_NAME = 'test_dynamic_prompt';
   UPDATED_RESOURCE_URI = 'test://static-text';
@@ -89,13 +94,13 @@ end;
 constructor TTriggerToolChangeTool.Create;
 begin
   inherited;
-  FName := 'test_trigger_tool_change';
+  FName := TOOL_TRIGGER_TOOL_CHANGE;
   FDescription := 'Adds or removes test_dynamic_tool, which notifies subscribed clients that the tool list changed';
 end;
 
 function TTriggerToolChangeTool.ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue;
 begin
-  var Manager := Context.ManagerRegistry.GetManagerForMethod('tools/list') as TObject;
+  var Manager := Context.ManagerRegistry.GetManagerForMethod(MCP_METHOD_TOOLS_LIST) as TObject;
   if not (Manager is TMCPToolsManager) then
     raise EMCPError.InternalError('No tools manager to change');
 
@@ -103,12 +108,12 @@ begin
   if Tools.HasTool(DYNAMIC_TOOL_NAME) then
   begin
     Tools.RemoveTool(DYNAMIC_TOOL_NAME);
-    Result := TMCPToolResult.Text(Format('Removed %s', [DYNAMIC_TOOL_NAME]));
+    Result := TMCPToolResult.Text(Format(MESSAGE_REMOVED, [DYNAMIC_TOOL_NAME]));
   end
   else
   begin
     Tools.AddTool(TDynamicTool.Create);
-    Result := TMCPToolResult.Text(Format('Added %s', [DYNAMIC_TOOL_NAME]));
+    Result := TMCPToolResult.Text(Format(MESSAGE_ADDED, [DYNAMIC_TOOL_NAME]));
   end;
 end;
 
@@ -117,13 +122,13 @@ end;
 constructor TTriggerPromptChangeTool.Create;
 begin
   inherited;
-  FName := 'test_trigger_prompt_change';
+  FName := TOOL_TRIGGER_PROMPT_CHANGE;
   FDescription := 'Adds or removes test_dynamic_prompt, which notifies subscribed clients that the prompt list changed';
 end;
 
 function TTriggerPromptChangeTool.ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue;
 begin
-  var Manager := Context.ManagerRegistry.GetManagerForMethod('prompts/list') as TObject;
+  var Manager := Context.ManagerRegistry.GetManagerForMethod(MCP_METHOD_PROMPTS_LIST) as TObject;
   if not (Manager is TMCPPromptsManager) then
     raise EMCPError.InternalError('No prompts manager to change');
 
@@ -131,12 +136,12 @@ begin
   if Prompts.HasPrompt(DYNAMIC_PROMPT_NAME) then
   begin
     Prompts.RemovePrompt(DYNAMIC_PROMPT_NAME);
-    Result := TMCPToolResult.Text(Format('Removed %s', [DYNAMIC_PROMPT_NAME]));
+    Result := TMCPToolResult.Text(Format(MESSAGE_REMOVED, [DYNAMIC_PROMPT_NAME]));
   end
   else
   begin
     Prompts.AddPrompt(TDynamicPrompt.Create);
-    Result := TMCPToolResult.Text(Format('Added %s', [DYNAMIC_PROMPT_NAME]));
+    Result := TMCPToolResult.Text(Format(MESSAGE_ADDED, [DYNAMIC_PROMPT_NAME]));
   end;
 end;
 
@@ -145,13 +150,13 @@ end;
 constructor TTriggerResourceChangeTool.Create;
 begin
   inherited;
-  FName := 'test_trigger_resource_change';
+  FName := TOOL_TRIGGER_RESOURCE_CHANGE;
   FDescription := 'Reports test://static-text as updated to the clients subscribed to it';
 end;
 
 function TTriggerResourceChangeTool.ExecuteWithContext(const Params: TNoParams; const Context: IMCPRequestContext): TValue;
 begin
-  var Manager := Context.ManagerRegistry.GetManagerForMethod('resources/list') as TObject;
+  var Manager := Context.ManagerRegistry.GetManagerForMethod(MCP_METHOD_RESOURCES_LIST) as TObject;
   if not (Manager is TMCPResourcesManager) then
     raise EMCPError.InternalError('No resources manager to change');
 
@@ -160,17 +165,17 @@ begin
 end;
 
 initialization
-  TMCPRegistry.RegisterTool('test_trigger_tool_change',
+  TMCPRegistry.RegisterTool(TOOL_TRIGGER_TOOL_CHANGE,
     function: IMCPTool
     begin
       Result := TTriggerToolChangeTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_trigger_prompt_change',
+  TMCPRegistry.RegisterTool(TOOL_TRIGGER_PROMPT_CHANGE,
     function: IMCPTool
     begin
       Result := TTriggerPromptChangeTool.Create;
     end);
-  TMCPRegistry.RegisterTool('test_trigger_resource_change',
+  TMCPRegistry.RegisterTool(TOOL_TRIGGER_RESOURCE_CHANGE,
     function: IMCPTool
     begin
       Result := TTriggerResourceChangeTool.Create;


### PR DESCRIPTION
## Summary

- `MCPServer.Types` now carries the method names (`MCP_METHOD_*`), the JSON-RPC envelope and member keys (`MCP_KEY_*`), the media types and the JSON-RPC version, so values that lived in three or four units exist once. `CACHE_SCOPE_PRIVATE`, `CACHE_SCOPE_PUBLIC`, `SCOPE_ANY`, `MEDIA_TYPE_EVENT_STREAM`, `CHARSET_UTF8` and `HTTP_STATUS_OK` no longer have local copies.
- Every source unit that used a literal twice now names it: capability names, tool, prompt and resource names, schema keywords, ini section names, and the recurring error and log messages.

## Verification

- DUnitX: 376/376 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 and Release build clean.
- HTTP goldens, conformance (155 and 59), Inspector smoke and stdio smoke unchanged.