### PR TITLE
Shorter methods and a server application class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,9 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `MCPServer.Application` holds the wiring the executable used to repeat for
+  each transport: `TMCPServerApplication.RunHttp` and `RunStdio` build the
+  managers once and the program file is the command-line entry point only.
 - The content block helpers, the protocol version helpers and the redaction
   helpers are class functions on `TMCPContentBlock`, `TMCPProtocolVersion` and
   `TLogger`; `MCPServer.Schema.Generator` keeps its RTTI context in a class

--- a/src/Core/MCPServer.Application.pas
+++ b/src/Core/MCPServer.Application.pas
@@ -1,0 +1,154 @@
+unit MCPServer.Application;
+
+interface
+
+uses
+  System.SysUtils,
+  System.SyncObjs,
+  MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.ToolsManager,
+  MCPServer.ResourcesManager,
+  MCPServer.PromptsManager,
+  MCPServer.SubscriptionsManager;
+
+type
+  TMCPServerApplication = class
+  strict private
+    FSettings: TMCPSettings;
+    FManagerRegistry: IMCPManagerRegistry;
+    FCoreManager: IMCPCapabilityManager;
+    FToolsManager: TMCPToolsManager;
+    FResourcesManager: TMCPResourcesManager;
+    FPromptsManager: TMCPPromptsManager;
+    FSubscriptionsManager: TMCPSubscriptionsManager;
+    procedure BuildManagers;
+    procedure HideDiagnosticsResources;
+    procedure LogBanner(const Transport: string);
+  public
+    constructor Create(const WriteSettingsFile: Boolean);
+    destructor Destroy; override;
+
+    procedure RunHttp(const Shutdown: TEvent);
+    procedure RunStdio;
+
+    property Settings: TMCPSettings read FSettings;
+    property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
+    property CoreManager: IMCPCapabilityManager read FCoreManager;
+  end;
+
+implementation
+
+uses
+  MCPServer.Logger,
+  MCPServer.Authorization,
+  MCPServer.ManagerRegistry,
+  MCPServer.CoreManager,
+  MCPServer.CompletionManager,
+  MCPServer.IdHTTPServer,
+  MCPServer.StdioTransport;
+
+const
+  BANNER_RULE = '================================';
+  BANNER_TITLE = 'Model Context Protocol Server';
+  URI_LOGS_RECENT = 'logs://recent';
+  URI_SERVER_STATUS = 'server://status';
+  URI_TEMPLATE_LOGS_BY_LEVEL = 'logs://{level}';
+
+{ TMCPServerApplication }
+
+constructor TMCPServerApplication.Create(const WriteSettingsFile: Boolean);
+begin
+  inherited Create;
+  FSettings := TMCPSettings.Create('', WriteSettingsFile);
+  BuildManagers;
+end;
+
+destructor TMCPServerApplication.Destroy;
+begin
+  FCoreManager := nil;
+  FManagerRegistry := nil;
+  FSettings.Free;
+  inherited;
+end;
+
+procedure TMCPServerApplication.BuildManagers;
+begin
+  FManagerRegistry := TMCPManagerRegistry.Create;
+  FCoreManager := TMCPCoreManager.Create(FSettings);
+  FToolsManager := TMCPToolsManager.Create;
+  FResourcesManager := TMCPResourcesManager.Create;
+  FPromptsManager := TMCPPromptsManager.Create;
+  FSubscriptionsManager := TMCPSubscriptionsManager.Create;
+
+  if not FSettings.ExposeDiagnosticsResources then
+    HideDiagnosticsResources;
+
+  FToolsManager.ChangeNotifier := FSubscriptionsManager;
+  FResourcesManager.ChangeNotifier := FSubscriptionsManager;
+  FPromptsManager.ChangeNotifier := FSubscriptionsManager;
+
+  FManagerRegistry.RegisterManager(FCoreManager);
+  FManagerRegistry.RegisterManager(FToolsManager);
+  FManagerRegistry.RegisterManager(FResourcesManager);
+  FManagerRegistry.RegisterManager(FPromptsManager);
+  FManagerRegistry.RegisterManager(TMCPCompletionManager.Create(FPromptsManager, FResourcesManager));
+  FManagerRegistry.RegisterManager(FSubscriptionsManager);
+end;
+
+procedure TMCPServerApplication.HideDiagnosticsResources;
+begin
+  FResourcesManager.RemoveResource(URI_LOGS_RECENT);
+  FResourcesManager.RemoveResource(URI_SERVER_STATUS);
+  FResourcesManager.RemoveResourceTemplate(URI_TEMPLATE_LOGS_BY_LEVEL);
+end;
+
+procedure TMCPServerApplication.LogBanner(const Transport: string);
+begin
+  TLogger.Info(Format('Delphi MCP Server v%s', [FSettings.ServerVersion]));
+  TLogger.Info(BANNER_RULE);
+  TLogger.Info(BANNER_TITLE);
+  TLogger.Info(Format('Transport: %s', [Transport]));
+end;
+
+procedure TMCPServerApplication.RunHttp(const Shutdown: TEvent);
+begin
+  LogBanner('HTTP');
+  TLogger.Info(Format('Listening on port %d', [FSettings.Port]));
+
+  const Server = TMCPIdHTTPServer.Create(nil);
+  try
+    Server.Settings := FSettings;
+    Server.ManagerRegistry := FManagerRegistry;
+    Server.CoreManager := FCoreManager;
+
+    const RequiresToken = (Length(FSettings.BearerTokenList) > 0);
+    if RequiresToken then
+      Server.Authorizer := TMCPStaticBearerAuthorizer.Create(FSettings.BearerTokenList);
+
+    Server.Start;
+    TLogger.Info('Server started. Press CTRL+C to stop...');
+    Shutdown.WaitFor(INFINITE);
+
+    TLogger.Info('Shutting down server...');
+    Server.Stop;
+    TLogger.Info('Server stopped successfully');
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TMCPServerApplication.RunStdio;
+begin
+  LogBanner('STDIO');
+
+  const Transport = TMCPStdioTransport.Create(FManagerRegistry, FCoreManager);
+  try
+    Transport.Settings := FSettings;
+    Transport.Run;
+  finally
+    Transport.Free;
+  end;
+end;
+
+end.

--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -326,7 +326,10 @@ function TMCPOAuthResourceServerAuthorizer.AudienceMatches(const Claims: TJSONOb
 begin
   var Audience := Claims.GetValue(CLAIM_AUDIENCE);
   if IsJsonString(Audience) then
-    Exit(SameText(TJSONString(Audience).Value, FExpectedAudience));
+    begin
+      Result := SameText(TJSONString(Audience).Value, FExpectedAudience);
+      Exit;
+    end;
   if Audience is TJSONArray then
   begin
     for var Item in TJSONArray(Audience) do
@@ -351,7 +354,10 @@ begin
   Result := nil;
   var Scope := Claims.GetValue(CLAIM_SCOPE);
   if IsJsonString(Scope) then
-    Exit(TJSONString(Scope).Value.Split([SCOPE_SEPARATOR], TStringSplitOptions.ExcludeEmpty));
+    begin
+      Result := TJSONString(Scope).Value.Split([SCOPE_SEPARATOR], TStringSplitOptions.ExcludeEmpty);
+      Exit;
+    end;
 
   var ScopeArray := Claims.GetValue(CLAIM_SCOPE_ARRAY);
   if ScopeArray is TJSONArray then

--- a/src/Core/MCPServer.Logger.pas
+++ b/src/Core/MCPServer.Logger.pas
@@ -327,7 +327,10 @@ class function TLogger.RedactJson(const Json: string): string;
 begin
   var Parsed := TJSONObject.ParseJSONValue(Json);
   if not Assigned(Parsed) then
-    Exit(Format('<%d characters, not JSON>', [Length(Json)]));
+    begin
+      Result := Format('<%d characters, not JSON>', [Length(Json)]);
+      Exit;
+    end;
 
   try
     RedactValue(Parsed);

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -23,6 +23,7 @@ uses
   MCPServer.ContentBlocks in 'Protocol\MCPServer.ContentBlocks.pas',
   MCPServer.Logger in 'Core\MCPServer.Logger.pas',
   MCPServer.Settings in 'Core\MCPServer.Settings.pas',
+  MCPServer.Application in 'Core\MCPServer.Application.pas',
   MCPServer.Authorization in 'Core\MCPServer.Authorization.pas',
   MCPServer.Registration in 'Core\MCPServer.Registration.pas',
   MCPServer.ManagerRegistry in 'Core\MCPServer.ManagerRegistry.pas',
@@ -55,15 +56,6 @@ uses
   MCPServer.Prompt.ContentSamples in 'Prompts\MCPServer.Prompt.ContentSamples.pas';
 
 var
-  Server: TMCPIdHTTPServer;
-  Settings: TMCPSettings;
-  ManagerRegistry: IMCPManagerRegistry;
-  CoreManager: IMCPCapabilityManager;
-  ToolsManager: TMCPToolsManager;
-  ResourcesManager: TMCPResourcesManager;
-  PromptsManager: TMCPPromptsManager;
-  CompletionManager: IMCPCapabilityManager;
-  SubscriptionsManager: TMCPSubscriptionsManager;
   ShutdownEvent: TEvent;
 
 {$IFDEF MSWINDOWS}
@@ -94,107 +86,16 @@ begin
 end;
 {$ENDIF}
   
-procedure RunHTTPServer;
+procedure RunServer(const UseStdio: Boolean);
 begin
-  Settings := TMCPSettings.Create;
-
-  TLogger.Info('Delphi MCP Server v' + Settings.ServerVersion);
-  TLogger.Info('================================');
-  TLogger.Info('Model Context Protocol Server');
-  TLogger.Info('Transport: HTTP');
-  TLogger.Info('Listening on port ' + Settings.Port.ToString);
-
-  ManagerRegistry := TMCPManagerRegistry.Create;
-  CoreManager := TMCPCoreManager.Create(Settings);
-  ToolsManager := TMCPToolsManager.Create;
-  ResourcesManager := TMCPResourcesManager.Create;
-  if not Settings.ExposeDiagnosticsResources then
-  begin
-    ResourcesManager.RemoveResource('logs://recent');
-    ResourcesManager.RemoveResource('server://status');
-    ResourcesManager.RemoveResourceTemplate('logs://{level}');
-  end;
-  PromptsManager := TMCPPromptsManager.Create;
-  CompletionManager := TMCPCompletionManager.Create(PromptsManager, ResourcesManager);
-  SubscriptionsManager := TMCPSubscriptionsManager.Create;
-  ToolsManager.ChangeNotifier := SubscriptionsManager;
-  ResourcesManager.ChangeNotifier := SubscriptionsManager;
-  PromptsManager.ChangeNotifier := SubscriptionsManager;
-
-  ManagerRegistry.RegisterManager(CoreManager);
-  ManagerRegistry.RegisterManager(ToolsManager);
-  ManagerRegistry.RegisterManager(ResourcesManager);
-  ManagerRegistry.RegisterManager(PromptsManager);
-  ManagerRegistry.RegisterManager(CompletionManager);
-  ManagerRegistry.RegisterManager(SubscriptionsManager);
-
-  Server := TMCPIdHTTPServer.Create(nil);
+  const Application = TMCPServerApplication.Create(not UseStdio);
   try
-    Server.Settings := Settings;
-    Server.ManagerRegistry := ManagerRegistry;
-    Server.CoreManager := CoreManager;
-    if Length(Settings.BearerTokenList) > 0 then
-      Server.Authorizer := TMCPStaticBearerAuthorizer.Create(Settings.BearerTokenList);
-
-    Server.Start;
-
-    TLogger.Info('Server started. Press CTRL+C to stop...');
-
-    ShutdownEvent.WaitFor(INFINITE);
-
-    TLogger.Info('Shutting down server...');
-    Server.Stop;
-    TLogger.Info('Server stopped successfully');
+    if UseStdio then
+      Application.RunStdio
+    else
+      Application.RunHttp(ShutdownEvent);
   finally
-    Server.Free;
-    Settings.Free;
-  end;
-end;
-
-procedure RunStdioServer;
-var
-  StdioTransport: TMCPStdioTransport;
-begin
-  // A stdio server is spawned by its client; it reads settings.ini when
-  // present but never writes one next to the executable.
-  Settings := TMCPSettings.Create('', False);
-
-  TLogger.Info('Delphi MCP Server v' + Settings.ServerVersion);
-  TLogger.Info('================================');
-  TLogger.Info('Model Context Protocol Server');
-  TLogger.Info('Transport: STDIO');
-
-  ManagerRegistry := TMCPManagerRegistry.Create;
-  CoreManager := TMCPCoreManager.Create(Settings);
-  ToolsManager := TMCPToolsManager.Create;
-  ResourcesManager := TMCPResourcesManager.Create;
-  if not Settings.ExposeDiagnosticsResources then
-  begin
-    ResourcesManager.RemoveResource('logs://recent');
-    ResourcesManager.RemoveResource('server://status');
-    ResourcesManager.RemoveResourceTemplate('logs://{level}');
-  end;
-  PromptsManager := TMCPPromptsManager.Create;
-  CompletionManager := TMCPCompletionManager.Create(PromptsManager, ResourcesManager);
-  SubscriptionsManager := TMCPSubscriptionsManager.Create;
-  ToolsManager.ChangeNotifier := SubscriptionsManager;
-  ResourcesManager.ChangeNotifier := SubscriptionsManager;
-  PromptsManager.ChangeNotifier := SubscriptionsManager;
-
-  ManagerRegistry.RegisterManager(CoreManager);
-  ManagerRegistry.RegisterManager(ToolsManager);
-  ManagerRegistry.RegisterManager(ResourcesManager);
-  ManagerRegistry.RegisterManager(PromptsManager);
-  ManagerRegistry.RegisterManager(CompletionManager);
-  ManagerRegistry.RegisterManager(SubscriptionsManager);
-
-  StdioTransport := TMCPStdioTransport.Create(ManagerRegistry, CoreManager);
-  try
-    StdioTransport.Settings := Settings;
-    StdioTransport.Run;
-  finally
-    StdioTransport.Free;
-    Settings.Free;
+    Application.Free;
   end;
 end;
 
@@ -216,26 +117,17 @@ begin
 end;
 
 begin
-  // Check if running in STDIO mode before any logging
   if HasStdioFlag then
     TLogger.UseStdErr := True;
-
-  // Configure logger
   TLogger.LogToConsole := True;
   TLogger.MinLogLevel := TLogLevel.Info;
 
   {$IFDEF DEBUG}
-  // The leak report is a dialog on Windows; a stdio server has no place for it.
   ReportMemoryLeaksOnShutdown := not HasStdioFlag;
   {$ENDIF}
   IsMultiThread := True;
-  
-  // Create shutdown event
   ShutdownEvent := TEvent.Create(nil, True, False, '');
   try
-    // Set up signal handlers. Over stdio the client ends the server by
-    // closing stdin; a signal keeps its default meaning (terminate) instead
-    // of setting an event nobody waits on.
     {$IFDEF MSWINDOWS}
     if not HasStdioFlag then
       SetConsoleCtrlHandler(@ConsoleCtrlHandler, True);
@@ -251,10 +143,7 @@ begin
     
     try
     
-      if HasStdioFlag then
-        RunStdioServer
-      else
-        RunHTTPServer;
+      RunServer(HasStdioFlag);
 
     except
       on E: Exception do

--- a/src/MCPServer.dproj
+++ b/src/MCPServer.dproj
@@ -140,6 +140,7 @@
         <DCCReference Include="Protocol\MCPServer.ContentBlocks.pas"/>
         <DCCReference Include="Core\MCPServer.Logger.pas"/>
         <DCCReference Include="Core\MCPServer.Settings.pas"/>
+        <DCCReference Include="Core\MCPServer.Application.pas"/>
         <DCCReference Include="Core\MCPServer.Authorization.pas"/>
         <DCCReference Include="Core\MCPServer.Registration.pas"/>
         <DCCReference Include="Core\MCPServer.ManagerRegistry.pas"/>

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -284,7 +284,10 @@ begin
     for var Template in Templates do
     begin
       if Template.Matches(URI, Vars) then
-        Exit(Template.CreateResource(URI, Vars));
+        begin
+          Result := Template.CreateResource(URI, Vars);
+          Exit;
+        end;
     end;
   finally
     Vars.Free;

--- a/src/Managers/MCPServer.SubscriptionsManager.pas
+++ b/src/Managers/MCPServer.SubscriptionsManager.pas
@@ -48,6 +48,10 @@ type
     function Snapshot: TArray<IMCPSubscription>;
     procedure Deliver(const Method, Uri: string);
     function Listen(const Params: TJSONObject; const Context: IMCPRequestContext): TValue;
+    function NewSubscription(const Context: IMCPRequestContext; const Notifications: TJSONValue): IMCPSubscription;
+    procedure Add(const Subscription: IMCPSubscription);
+    procedure Remove(const Subscription: IMCPSubscription);
+    procedure WaitUntilClosed(const Context: IMCPRequestContext; const Subscription: IMCPSubscription);
     procedure Acknowledge(const Subscription: IMCPSubscription);
     function CompletionResult(const Subscription: IMCPSubscription): TJSONObject;
   public
@@ -295,8 +299,6 @@ begin
 end;
 
 function TMCPSubscriptionsManager.Listen(const Params: TJSONObject; const Context: IMCPRequestContext): TValue;
-var
-  KeepAlive: IMCPKeepAlive;
 begin
   if not Assigned(Context) or not Assigned(Context.Sink) then
     raise EMCPError.InvalidRequest(Format(
@@ -308,46 +310,69 @@ begin
   if Assigned(Notifications) and not (Notifications is TJSONObject) then
     raise EMCPError.InvalidParams(Format('params.%s must be an object', [PARAM_NOTIFICATIONS]));
 
-  var Id := Context.RequestId.ToJson;
-  var Subscription: IMCPSubscription;
+  const Subscription = NewSubscription(Context, Notifications);
+  Add(Subscription);
   try
-    Subscription := TMCPSubscription.Create(Id, TMCPSubscriptionFilter.FromJson(Notifications), Context.Sink);
+    Acknowledge(Subscription);
+    TLogger.Info(Format('Subscription %s opened', [Context.RequestId.AsText]));
+    WaitUntilClosed(Context, Subscription);
+  finally
+    Remove(Subscription);
+  end;
+
+  TLogger.Info(Format('Subscription %s closed', [Context.RequestId.AsText]));
+  Result := TValue.From<TJSONObject>(CompletionResult(Subscription));
+end;
+
+function TMCPSubscriptionsManager.NewSubscription(const Context: IMCPRequestContext;
+  const Notifications: TJSONValue): IMCPSubscription;
+begin
+  const Id = Context.RequestId.ToJson;
+  try
+    const Filter = TMCPSubscriptionFilter.FromJson(Notifications);
+    Result := TMCPSubscription.Create(Id, Filter, Context.Sink);
   finally
     Id.Free;
   end;
+end;
 
+procedure TMCPSubscriptionsManager.Add(const Subscription: IMCPSubscription);
+begin
   FLock.Enter;
   try
     FSubscriptions.Add(Subscription);
   finally
     FLock.Leave;
   end;
-  try
-    Acknowledge(Subscription);
-    TLogger.Info(Format('Subscription %s opened', [Context.RequestId.AsText]));
+end;
 
-    Supports(Context.Sink, IMCPKeepAlive, KeepAlive);
-    var SinceKeepAlive := 0;
-    while not Context.IsCancelled and (Subscription.Closed.WaitFor(POLL_INTERVAL_MS) = TWaitResult.wrTimeout) do
-    begin
-      Inc(SinceKeepAlive, POLL_INTERVAL_MS);
-      if Assigned(KeepAlive) and (SinceKeepAlive >= FKeepAliveIntervalMs) then
-      begin
-        SinceKeepAlive := 0;
-        KeepAlive.KeepAlive;
-      end;
-    end;
+procedure TMCPSubscriptionsManager.Remove(const Subscription: IMCPSubscription);
+begin
+  FLock.Enter;
+  try
+    FSubscriptions.Remove(Subscription);
   finally
-    FLock.Enter;
-    try
-      FSubscriptions.Remove(Subscription);
-    finally
-      FLock.Leave;
+    FLock.Leave;
+  end;
+end;
+
+procedure TMCPSubscriptionsManager.WaitUntilClosed(const Context: IMCPRequestContext;
+  const Subscription: IMCPSubscription);
+var
+  KeepAlive: IMCPKeepAlive;
+begin
+  Supports(Context.Sink, IMCPKeepAlive, KeepAlive);
+  var SinceKeepAlive := 0;
+  while not Context.IsCancelled and (Subscription.Closed.WaitFor(POLL_INTERVAL_MS) = TWaitResult.wrTimeout) do
+  begin
+    Inc(SinceKeepAlive, POLL_INTERVAL_MS);
+    const IsQuietTooLong = (Assigned(KeepAlive) and (SinceKeepAlive >= FKeepAliveIntervalMs));
+    if IsQuietTooLong then
+    begin
+      SinceKeepAlive := 0;
+      KeepAlive.KeepAlive;
     end;
   end;
-
-  TLogger.Info(Format('Subscription %s closed', [Context.RequestId.AsText]));
-  Result := TValue.From<TJSONObject>(CompletionResult(Subscription));
 end;
 
 procedure TMCPSubscriptionsManager.Deliver(const Method, Uri: string);

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -275,7 +275,10 @@ begin
   begin
     var ToolResult := ResultValue.AsType<TMCPToolResult>;
     try
-      Exit(ToolResult.ToJson(Era));
+      begin
+        Result := ToolResult.ToJson(Era);
+        Exit;
+      end;
     finally
       ToolResult.Free;
     end;
@@ -330,9 +333,15 @@ begin
       ResultValue := Tool.Execute(EffectiveArguments);
     except
       on E: EMCPToolError do
-        Exit(ErrorResult(E.Message, Era));
+        begin
+          Result := ErrorResult(E.Message, Era);
+          Exit;
+        end;
       on E: EArgumentException do
-        Exit(ErrorResult('Invalid arguments: ' + E.Message, Era));
+        begin
+          Result := ErrorResult('Invalid arguments: ' + E.Message, Era);
+          Exit;
+        end;
       on E: EMCPError do
         raise;
       on E: EMCPRequestCancelled do
@@ -340,7 +349,10 @@ begin
       on E: EMCPInputRequired do
         raise;
       on E: Exception do
-        Exit(ErrorResult('Error executing tool: ' + E.Message, Era));
+        begin
+          Result := ErrorResult('Error executing tool: ' + E.Message, Era);
+          Exit;
+        end;
     end;
     Result := ResultToJson(ResultValue, Era);
     {$IFDEF DEBUG}

--- a/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
+++ b/src/Prompts/MCPServer.Prompt.SummarizeLogs.pas
@@ -90,7 +90,10 @@ function TSummarizeLogsPrompt.Complete(const ArgumentName, Value: string;
   const Context: TArray<TPair<string, string>>): TMCPCompletion;
 begin
   if ArgumentName <> 'level' then
-    Exit(TMCPCompletion.Create(nil));
+    begin
+      Result := TMCPCompletion.Create(nil);
+      Exit;
+    end;
 
   var Levels := TStringList.Create;
   try

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -45,6 +45,18 @@ type
     function NewContext(Era: TMCPProtocolEra; const Version, Method: string; const RequestId: TMCPRequestId;
       const Meta: TJSONObject; const Hints: TMCPTransportHints; const InputResponses: TJSONObject = nil;
       const RequestState: TJSONObject = nil): IMCPRequestContext;
+    function ModernContext(const Method: string; const Params: TJSONObject; const RequestId: TMCPRequestId;
+      const Meta: TJSONObject; const Version: string; const Hints: TMCPTransportHints): IMCPRequestContext;
+    function LegacyContext(const Method: string; const Params: TJSONObject; const RequestId: TMCPRequestId;
+      const Meta: TJSONObject; const Hints: TMCPTransportHints): IMCPRequestContext;
+    function ReadRequestObject(const Message: TJSONValue): TJSONObject;
+    function ReadRequestId(const Request: TJSONObject): TMCPRequestId;
+    function ReadMethod(const Request: TJSONObject; Era: TMCPProtocolEra; out IsClientResponse: Boolean): string;
+    function ReadParams(const Request: TJSONObject; Era: TMCPProtocolEra): TJSONObject;
+    function RunRequest(const Context: IMCPRequestContext; const Params: TJSONObject;
+      const Hints: TMCPTransportHints): TMCPProcessResult;
+    function SuccessResult(const Context: IMCPRequestContext; const Value: TValue): TMCPProcessResult;
+    function AcceptedResult(Era: TMCPProtocolEra): TMCPProcessResult;
     function InputRequiredResult(const Context: IMCPRequestContext; const Params: TJSONObject;
       const Hints: TMCPTransportHints; const Required: EMCPInputRequired): TMCPProcessResult;
     function EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
@@ -327,84 +339,105 @@ end;
 
 function TMCPJsonRpcProcessor.BuildRequestContext(const Method: string; const Params: TJSONObject;
   const RequestId: TMCPRequestId; const Hints: TMCPTransportHints): IMCPRequestContext;
-var
-  Version: string;
 begin
-  var Meta := ExtractMeta(Params);
+  const Meta = ExtractMeta(Params);
 
   var VersionValue: TJSONValue := nil;
   if Assigned(Meta) then
     VersionValue := Meta.GetValue(MCP_META_PROTOCOL_VERSION);
 
-  if VersionValue is TJSONString then
+  const CarriesModernMeta = (VersionValue is TJSONString);
+  if CarriesModernMeta then
+    begin
+      Result := ModernContext(Method, Params, RequestId, Meta, TJSONString(VersionValue).Value, Hints);
+      Exit;
+    end;
+
+  Result := LegacyContext(Method, Params, RequestId, Meta, Hints);
+end;
+
+function TMCPJsonRpcProcessor.ModernContext(const Method: string; const Params: TJSONObject;
+  const RequestId: TMCPRequestId; const Meta: TJSONObject; const Version: string;
+  const Hints: TMCPTransportHints): IMCPRequestContext;
+begin
+  if Hints.HasHeaderLayer then
   begin
-    Version := TJSONString(VersionValue).Value;
-
-    if Hints.HasHeaderLayer then
-    begin
-      if not Hints.HasProtocolVersionHeader then
-        raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
-      if Hints.ProtocolVersionHeader <> Version then
-        raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
-          ['MCP-Protocol-Version', Hints.ProtocolVersionHeader, Version]));
-    end;
-
-    if not TMCPProtocolVersion.IsModern(Version) then
-      raise EMCPError.UnsupportedProtocolVersion(Version, SupportedModernVersions);
-
-    if Hints.HasHeaderLayer then
-      ValidateMirroredHeaders(Method, Params, Hints);
-
-    ValidateModernMeta(Meta);
-
-    if IsLegacyOnlyMethod(Method) then
-    begin
-      var NotFound := EMCPError.MethodNotFound(Method);
-      NotFound.HttpStatus := HTTP_STATUS_NOT_FOUND;
-      raise NotFound;
-    end;
-
-    var InputResponses: TJSONObject := nil;
-    var RequestState: TJSONObject := nil;
-    if IsInputRequiredMethod(Method) then
-    begin
-      InputResponses := ClientInputResponses(Params);
-      RequestState := OpenClientRequestState(Method, Params, Hints);
-    end;
-    Exit(NewContext(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta, Hints, InputResponses, RequestState));
+    if not Hints.HasProtocolVersionHeader then
+      raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
+    if Hints.ProtocolVersionHeader <> Version then
+      raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
+        ['MCP-Protocol-Version', Hints.ProtocolVersionHeader, Version]));
   end;
 
+  if not TMCPProtocolVersion.IsModern(Version) then
+    raise EMCPError.UnsupportedProtocolVersion(Version, SupportedModernVersions);
+
+  if Hints.HasHeaderLayer then
+    ValidateMirroredHeaders(Method, Params, Hints);
+
+  ValidateModernMeta(Meta);
+
+  if IsLegacyOnlyMethod(Method) then
+  begin
+    const NotFound = EMCPError.MethodNotFound(Method);
+    NotFound.HttpStatus := HTTP_STATUS_NOT_FOUND;
+    raise NotFound;
+  end;
+
+  var InputResponses: TJSONObject := nil;
+  var RequestState: TJSONObject := nil;
+  if IsInputRequiredMethod(Method) then
+  begin
+    InputResponses := ClientInputResponses(Params);
+    RequestState := OpenClientRequestState(Method, Params, Hints);
+  end;
+  Result := NewContext(TMCPProtocolEra.Modern, Version, Method, RequestId, Meta, Hints, InputResponses, RequestState);
+end;
+
+function TMCPJsonRpcProcessor.LegacyContext(const Method: string; const Params: TJSONObject;
+  const RequestId: TMCPRequestId; const Meta: TJSONObject; const Hints: TMCPTransportHints): IMCPRequestContext;
+begin
   if Method = MCP_METHOD_INITIALIZE then
   begin
     var Requested := '';
     if Assigned(Params) then
     begin
-      var RequestedValue := Params.GetValue(MCP_KEY_PROTOCOL_VERSION);
+      const RequestedValue = Params.GetValue(MCP_KEY_PROTOCOL_VERSION);
       if IsJsonString(RequestedValue) then
         Requested := TJSONString(RequestedValue).Value;
     end;
-    Exit(NewContext(TMCPProtocolEra.Legacy, TMCPProtocolVersion.NegotiateLegacy(Requested), Method, RequestId, Meta, Hints));
+    const Negotiated = TMCPProtocolVersion.NegotiateLegacy(Requested);
+    begin
+      Result := NewContext(TMCPProtocolEra.Legacy, Negotiated, Method, RequestId, Meta, Hints);
+      Exit;
+    end;
   end;
 
   if IsModernOnlyMethod(Method) then
     raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
-      Format('%s requires params._meta.%s', [Method, MCP_META_PROTOCOL_VERSION]), nil, HTTP_STATUS_BAD_REQUEST);
+      Format('%s requires %s%s', [Method, META_PATH_PREFIX, MCP_META_PROTOCOL_VERSION]), nil, HTTP_STATUS_BAD_REQUEST);
 
-  if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader then
+  const HasVersionHeader = (Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader);
+  if HasVersionHeader then
   begin
-    var Header := Hints.ProtocolVersionHeader;
+    const Header = Hints.ProtocolVersionHeader;
     if TMCPProtocolVersion.IsModern(Header) then
       raise EMCPError.Create(JSONRPC_INVALID_PARAMS,
-        Format('MCP-Protocol-Version %s requires params._meta.%s', [Header, MCP_META_PROTOCOL_VERSION]),
+        Format('MCP-Protocol-Version %s requires %s%s', [Header, META_PATH_PREFIX, MCP_META_PROTOCOL_VERSION]),
         nil, HTTP_STATUS_BAD_REQUEST);
-    if not TMCPProtocolVersion.IsLegacy(Header) and (Header <> MCP_PROTOCOL_VERSION_2025_03_26) then
-      raise EMCPError.Create(JSONRPC_INVALID_REQUEST,
-        'Unsupported MCP-Protocol-Version header: ' + Header, nil, HTTP_STATUS_BAD_REQUEST);
 
-    Exit(NewContext(TMCPProtocolEra.Legacy, Header, Method, RequestId, Meta, Hints));
+    const IsKnownHeader = (TMCPProtocolVersion.IsLegacy(Header) or (Header = MCP_PROTOCOL_VERSION_2025_03_26));
+    if not IsKnownHeader then
+      raise EMCPError.Create(JSONRPC_INVALID_REQUEST,
+        Format('Unsupported MCP-Protocol-Version header: %s', [Header]), nil, HTTP_STATUS_BAD_REQUEST);
+
+    begin
+      Result := NewContext(TMCPProtocolEra.Legacy, Header, Method, RequestId, Meta, Hints);
+      Exit;
+    end;
   end;
 
-  Version := '';
+  var Version := '';
   if Assigned(Hints.LegacySession) then
     Version := Hints.LegacySession.ProtocolVersion;
   if Version = '' then
@@ -676,6 +709,132 @@ begin
     Result := EMCPError.InternalError(E.Message);
 end;
 
+function TMCPJsonRpcProcessor.ReadRequestObject(const Message: TJSONValue): TJSONObject;
+begin
+  if not Assigned(Message) then
+    raise EMCPError.ParseError('Invalid JSON');
+  if Message is TJSONArray then
+    raise EMCPError.InvalidRequest('JSON-RPC batch requests are not supported');
+  if not (Message is TJSONObject) then
+    raise EMCPError.InvalidRequest('JSON-RPC message must be an object');
+  Result := TJSONObject(Message);
+end;
+
+function TMCPJsonRpcProcessor.ReadRequestId(const Request: TJSONObject): TMCPRequestId;
+begin
+  Result := TMCPRequestId.FromJson(Request.GetValue(MCP_KEY_ID));
+  if Result.Kind = TMCPRequestIdKind.Null then
+    raise EMCPError.InvalidRequest('id must not be null');
+  if Result.Kind = TMCPRequestIdKind.Invalid then
+  begin
+    Result := TMCPRequestId.FromJson(nil);
+    raise EMCPError.InvalidRequest('id must be a string or an integer');
+  end;
+end;
+
+function TMCPJsonRpcProcessor.ReadMethod(const Request: TJSONObject; Era: TMCPProtocolEra;
+  out IsClientResponse: Boolean): string;
+begin
+  IsClientResponse := False;
+  const JsonRpc = Request.GetValue(MCP_KEY_JSONRPC);
+  const IsSupportedVersion = (IsJsonString(JsonRpc) and (TJSONString(JsonRpc).Value = JSONRPC_VERSION));
+  if not IsSupportedVersion then
+    raise EMCPError.InvalidRequest('jsonrpc must be "2.0"');
+
+  const MethodValue = Request.GetValue(MCP_KEY_METHOD);
+  if IsJsonString(MethodValue) then
+    begin
+      Result := TJSONString(MethodValue).Value;
+      Exit;
+    end;
+
+  const IsResponse = (Assigned(Request.GetValue(MCP_KEY_RESULT)) or Assigned(Request.GetValue(MCP_KEY_ERROR)));
+  if not IsResponse then
+    raise EMCPError.InvalidRequest('method must be a string');
+  if Era = TMCPProtocolEra.Modern then
+    raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
+
+  IsClientResponse := True;
+  Result := '';
+end;
+
+function TMCPJsonRpcProcessor.ReadParams(const Request: TJSONObject; Era: TMCPProtocolEra): TJSONObject;
+begin
+  Result := nil;
+  const ParamsValue = Request.GetValue(MCP_KEY_PARAMS);
+  if not Assigned(ParamsValue) then
+    Exit;
+
+  if not (ParamsValue is TJSONObject) then
+  begin
+    if Era = TMCPProtocolEra.Modern then
+      raise EMCPError.Create(JSONRPC_INVALID_PARAMS, MESSAGE_PARAMS_NOT_OBJECT, nil, HTTP_STATUS_BAD_REQUEST);
+    raise EMCPError.InvalidParams(MESSAGE_PARAMS_NOT_OBJECT);
+  end;
+  Result := TJSONObject(ParamsValue);
+end;
+
+function TMCPJsonRpcProcessor.AcceptedResult(Era: TMCPProtocolEra): TMCPProcessResult;
+begin
+  Result := Default(TMCPProcessResult);
+  Result.HttpStatus := HTTP_STATUS_ACCEPTED;
+  Result.Era := Era;
+  Result.IsNotification := True;
+end;
+
+function TMCPJsonRpcProcessor.RunRequest(const Context: IMCPRequestContext; const Params: TJSONObject;
+  const Hints: TMCPTransportHints): TMCPProcessResult;
+var
+  ExecuteResult: TValue;
+begin
+  if Assigned(Hints.Tracker) then
+    Hints.Tracker.Track(Context);
+  try
+    try
+      ExecuteResult := DispatchRequest(Context, Params);
+    except
+      on E: EMCPInputRequired do
+        begin
+          Result := InputRequiredResult(Context, Params, Hints, E);
+          Exit;
+        end;
+    end;
+  finally
+    if Assigned(Hints.Tracker) then
+      Hints.Tracker.Untrack(Context);
+  end;
+
+  if Context.IsCancelled then
+  begin
+    if ExecuteResult.IsObject then
+      ExecuteResult.AsObject.Free;
+    begin
+      Result := CancelledResult(Context.Era);
+      Exit;
+    end;
+  end;
+
+  Result := SuccessResult(Context, ExecuteResult);
+end;
+
+function TMCPJsonRpcProcessor.SuccessResult(const Context: IMCPRequestContext; const Value: TValue): TMCPProcessResult;
+begin
+  Result := Default(TMCPProcessResult);
+  const Response = TJSONObject.Create;
+  try
+    Response.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
+    Response.AddPair(MCP_KEY_ID, Context.RequestId.ToJson);
+    const ResultJson = ResultToJson(Value, Context);
+    if Assigned(ResultJson) then
+      Response.AddPair(MCP_KEY_RESULT, ResultJson);
+    Result.Body := Response.ToJSON;
+  finally
+    Response.Free;
+  end;
+  Result.HttpStatus := HTTP_STATUS_OK;
+  Result.Era := Context.Era;
+end;
+
 function TMCPJsonRpcProcessor.ProcessRequest(const RequestBody: string; const SessionID: string): string;
 begin
   Result := ProcessRequestEx(RequestBody, TMCPTransportHints.None).Body;
@@ -705,101 +864,28 @@ begin
 
   try
     try
-      if not Assigned(Message) then
-        raise EMCPError.ParseError('Invalid JSON');
-      if Message is TJSONArray then
-        raise EMCPError.InvalidRequest('JSON-RPC batch requests are not supported');
-      if not (Message is TJSONObject) then
-        raise EMCPError.InvalidRequest('JSON-RPC message must be an object');
+      const Request = ReadRequestObject(Message);
+      RequestId := ReadRequestId(Request);
 
-      var Request := TJSONObject(Message);
-
-      RequestId := TMCPRequestId.FromJson(Request.GetValue(MCP_KEY_ID));
-      if RequestId.Kind = TMCPRequestIdKind.Null then
-        raise EMCPError.InvalidRequest('id must not be null');
-      if RequestId.Kind = TMCPRequestIdKind.Invalid then
-      begin
-        RequestId := TMCPRequestId.FromJson(nil);
-        raise EMCPError.InvalidRequest('id must be a string or an integer');
-      end;
-
-      var JsonRpc := Request.GetValue(MCP_KEY_JSONRPC);
-      if not IsJsonString(JsonRpc) or (TJSONString(JsonRpc).Value <> JSONRPC_VERSION) then
-        raise EMCPError.InvalidRequest('jsonrpc must be "2.0"');
-
-      var MethodValue := Request.GetValue(MCP_KEY_METHOD);
-      if not IsJsonString(MethodValue) then
-      begin
-        if Assigned(Request.GetValue(MCP_KEY_RESULT)) or Assigned(Request.GetValue(MCP_KEY_ERROR)) then
+      var IsClientResponse := False;
+      const Method = ReadMethod(Request, Era, IsClientResponse);
+      if IsClientResponse then
         begin
-          if Era = TMCPProtocolEra.Modern then
-            raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
-          Result := Default(TMCPProcessResult);
-          Result.HttpStatus := HTTP_STATUS_ACCEPTED;
-          Result.Era := Era;
-          Result.IsNotification := True;
+          Result := AcceptedResult(Era);
           Exit;
         end;
-        raise EMCPError.InvalidRequest('method must be a string');
-      end;
-      var Method := TJSONString(MethodValue).Value;
 
-      var ParamsValue := Request.GetValue(MCP_KEY_PARAMS);
-      var Params: TJSONObject := nil;
-      if Assigned(ParamsValue) then
-      begin
-        if not (ParamsValue is TJSONObject) then
-        begin
-          if Era = TMCPProtocolEra.Modern then
-            raise EMCPError.Create(JSONRPC_INVALID_PARAMS, MESSAGE_PARAMS_NOT_OBJECT, nil, HTTP_STATUS_BAD_REQUEST);
-          raise EMCPError.InvalidParams(MESSAGE_PARAMS_NOT_OBJECT);
-        end;
-        Params := TJSONObject(ParamsValue);
-      end;
-
+      const Params = ReadParams(Request, Era);
       if RequestId.Kind = TMCPRequestIdKind.None then
-        Exit(ProcessNotification(Method, Params, Hints));
+        begin
+          Result := ProcessNotification(Method, Params, Hints);
+          Exit;
+        end;
 
       Era := EraFromMessage(Method, Params, Hints);
       Context := BuildRequestContext(Method, Params, RequestId, Hints);
       Era := Context.Era;
-
-      var ExecuteResult: TValue;
-      if Assigned(Hints.Tracker) then
-        Hints.Tracker.Track(Context);
-      try
-        try
-          ExecuteResult := DispatchRequest(Context, Params);
-        except
-          on E: EMCPInputRequired do
-            Exit(InputRequiredResult(Context, Params, Hints, E));
-        end;
-      finally
-        if Assigned(Hints.Tracker) then
-          Hints.Tracker.Untrack(Context);
-      end;
-
-      if Context.IsCancelled then
-      begin
-        if ExecuteResult.IsObject then
-          ExecuteResult.AsObject.Free;
-        Exit(CancelledResult(Era));
-      end;
-
-      var Response := TJSONObject.Create;
-      try
-        Response.AddPair(MCP_KEY_JSONRPC, JSONRPC_VERSION);
-        Response.AddPair(MCP_KEY_ID, RequestId.ToJson);
-        var ResultJson := ResultToJson(ExecuteResult, Context);
-        if Assigned(ResultJson) then
-          Response.AddPair(MCP_KEY_RESULT, ResultJson);
-        Result.Body := Response.ToJSON;
-      finally
-        Response.Free;
-      end;
-      Result.HttpStatus := HTTP_STATUS_OK;
-      Result.Era := Era;
-      Result.IsNotification := False;
+      Result := RunRequest(Context, Params, Hints);
     except
       on E: EMCPRequestCancelled do
         Result := CancelledResult(Era);

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -365,7 +365,10 @@ begin
   if not Assigned(Token) then
     Exit(False);
   if Token is TJSONNumber then
-    Exit(Frac(TJSONNumber(Token).AsDouble) = 0);
+    begin
+      Result := Frac(TJSONNumber(Token).AsDouble) = 0;
+      Exit;
+    end;
   Result := Token is TJSONString;
 end;
 

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -18,6 +18,9 @@ type
     class function CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
     class function ListItemType(RttiType: TRttiType): TRttiType;
     class function TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+    class procedure DescribeFloat(RttiType: TRttiType; const Schema: TJSONObject);
+    class procedure DescribeSet(RttiType: TRttiType; const Schema: TJSONObject);
+    class function ClassSchema(RttiType: TRttiType; Depth: Integer; const Schema: TJSONObject): TJSONObject;
     class function ObjectSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
     class function NumberValue(const Value: Double): TJSONNumber;
     class procedure ApplyAttributes(Prop: TRttiProperty; const PropSchema: TJSONObject);
@@ -75,7 +78,10 @@ class function TMCPSchemaGenerator.GetPropertyJsonName(Prop: TRttiProperty): str
 begin
   for var Attr in Prop.GetAttributes do
     if Attr is SchemaNameAttribute then
-      Exit(SchemaNameAttribute(Attr).Name);
+      begin
+        Result := SchemaNameAttribute(Attr).Name;
+        Exit;
+      end;
   Result := LowerCase(Prop.Name);
 end;
 
@@ -110,6 +116,78 @@ begin
     Result := ItemsProp.PropertyType;
 end;
 
+class procedure TMCPSchemaGenerator.DescribeFloat(RttiType: TRttiType; const Schema: TJSONObject);
+begin
+  if RttiType.Handle = TypeInfo(TDateTime) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+    Schema.AddPair(SCHEMA_KEY_FORMAT, 'date-time');
+  end
+  else if RttiType.Handle = TypeInfo(TDate) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+    Schema.AddPair(SCHEMA_KEY_FORMAT, 'date');
+  end
+  else if RttiType.Handle = TypeInfo(TTime) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+    Schema.AddPair(SCHEMA_KEY_FORMAT, 'time');
+  end
+  else
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_NUMBER);
+  end;
+end;
+
+class procedure TMCPSchemaGenerator.DescribeSet(RttiType: TRttiType; const Schema: TJSONObject);
+begin
+  Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+
+  const Items = TJSONObject.Create;
+  Schema.AddPair(SCHEMA_KEY_ITEMS, Items);
+  Items.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
+
+  const ElementType = TRttiSetType(RttiType).ElementType;
+  const Names = CreateEnumValuesArray(ElementType);
+  if Assigned(Names) then
+    Items.AddPair(SCHEMA_KEY_ENUM, Names);
+end;
+
+class function TMCPSchemaGenerator.ClassSchema(RttiType: TRttiType; Depth: Integer;
+  const Schema: TJSONObject): TJSONObject;
+begin
+  Result := Schema;
+  const Metaclass = TRttiInstanceType(RttiType).MetaclassType;
+  if Metaclass.InheritsFrom(TJSONArray) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+    Exit;
+  end;
+  if Metaclass.InheritsFrom(TJSONValue) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
+    Exit;
+  end;
+
+  const ItemType = ListItemType(RttiType);
+  if Assigned(ItemType) then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
+    Schema.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ItemType, Depth + 1));
+    Exit;
+  end;
+
+  const FitsAnotherLevel = (Depth < MAX_NESTING_DEPTH);
+  if not FitsAnotherLevel then
+  begin
+    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
+    Exit;
+  end;
+
+  Schema.Free;
+  Result := ObjectSchema(RttiType, Depth + 1);
+end;
+
 class function TMCPSchemaGenerator.TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
 begin
   Result := TJSONObject.Create;
@@ -119,23 +197,7 @@ begin
         Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_INTEGER);
 
       tkFloat:
-        if RttiType.Handle = TypeInfo(TDateTime) then
-        begin
-          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
-          Result.AddPair(SCHEMA_KEY_FORMAT, 'date-time');
-        end
-        else if RttiType.Handle = TypeInfo(TDate) then
-        begin
-          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
-          Result.AddPair(SCHEMA_KEY_FORMAT, 'date');
-        end
-        else if RttiType.Handle = TypeInfo(TTime) then
-        begin
-          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
-          Result.AddPair(SCHEMA_KEY_FORMAT, 'time');
-        end
-        else
-          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_NUMBER);
+        DescribeFloat(RttiType, Result);
 
       tkString, tkLString, tkWString, tkUString, tkChar, tkWChar:
         Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
@@ -150,53 +212,24 @@ begin
         end;
 
       tkSet:
-        begin
-          Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-          var Items := TJSONObject.Create;
-          Result.AddPair(SCHEMA_KEY_ITEMS, Items);
-          Items.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
-          var ElementType := TRttiSetType(RttiType).ElementType;
-          var Names := CreateEnumValuesArray(ElementType);
-          if Assigned(Names) then
-            Items.AddPair(SCHEMA_KEY_ENUM, Names);
-        end;
+        DescribeSet(RttiType, Result);
 
       tkDynArray:
         begin
           Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(TRttiDynamicArrayType(RttiType).ElementType, Depth + 1));
+          const ElementType = TRttiDynamicArrayType(RttiType).ElementType;
+          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ElementType, Depth + 1));
         end;
 
       tkArray:
         begin
           Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(TRttiArrayType(RttiType).ElementType, Depth + 1));
+          const ElementType = TRttiArrayType(RttiType).ElementType;
+          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ElementType, Depth + 1));
         end;
 
       tkClass:
-        begin
-          var Metaclass := TRttiInstanceType(RttiType).MetaclassType;
-          if Metaclass.InheritsFrom(TJSONArray) then
-            Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY)
-          else if Metaclass.InheritsFrom(TJSONValue) then
-            Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT)
-          else
-          begin
-            var ItemType := ListItemType(RttiType);
-            if Assigned(ItemType) then
-            begin
-              Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-              Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ItemType, Depth + 1));
-            end
-            else if Depth < MAX_NESTING_DEPTH then
-            begin
-              Result.Free;
-              Result := ObjectSchema(RttiType, Depth + 1);
-            end
-            else
-              Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
-          end;
-        end;
+        Result := ClassSchema(RttiType, Depth, Result);
     else
       Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
     end;

--- a/src/Protocol/MCPServer.Schema.Validator.pas
+++ b/src/Protocol/MCPServer.Schema.Validator.pas
@@ -20,6 +20,16 @@ type
     class function TryResolveRef(const RootSchema: TJSONObject; const Ref: string;
       out Resolved: TJSONObject): Boolean;
     class function MatchesType(const Instance: TJSONValue; const TypeName: string): Boolean;
+    class function ValidateConstAndEnum(const Schema: TJSONObject; const Instance: TJSONValue;
+      const Path: string; Errors: TStrings): Boolean;
+    class function ValidateString(const Schema: TJSONObject; const Text: string;
+      const Path: string; Errors: TStrings): Boolean;
+    class function ValidateNumber(const Schema: TJSONObject; const Value: Double;
+      const Path: string; Errors: TStrings): Boolean;
+    class function ValidateObject(const Schema: TJSONObject; const Instance: TJSONObject;
+      const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
+    class function ValidateArray(const Schema: TJSONObject; const Instance: TJSONArray;
+      const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
     class function TryCheckType(const Schema: TJSONObject; const Instance: TJSONValue;
       out ErrorMessage: string): Boolean;
     class function JsonEquals(A, B: TJSONValue): Boolean;
@@ -33,6 +43,13 @@ uses
   System.RegularExpressions,
   System.RegularExpressionsCore,
   MCPServer.Types;
+
+const
+  SCHEMA_KEY_REQUIRED = 'required';
+  SCHEMA_KEY_PROPERTIES = 'properties';
+  SCHEMA_KEY_ITEMS = 'items';
+  SCHEMA_KEY_ADDITIONAL_PROPERTIES = 'additionalProperties';
+
 
 { TMCPSchemaValidator }
 
@@ -103,15 +120,30 @@ end;
 class function TMCPSchemaValidator.JsonEquals(A, B: TJSONValue): Boolean;
 begin
   if not Assigned(A) or not Assigned(B) then
-    Exit(not Assigned(A) and not Assigned(B));
+    begin
+      Result := not Assigned(A) and not Assigned(B);
+      Exit;
+    end;
   if (A is TJSONNull) or (B is TJSONNull) then
-    Exit((A is TJSONNull) and (B is TJSONNull));
+    begin
+      Result := (A is TJSONNull) and (B is TJSONNull);
+      Exit;
+    end;
   if (A is TJSONBool) or (B is TJSONBool) then
-    Exit((A is TJSONBool) and (B is TJSONBool) and (TJSONBool(A).AsBoolean = TJSONBool(B).AsBoolean));
+    begin
+      Result := (A is TJSONBool) and (B is TJSONBool) and (TJSONBool(A).AsBoolean = TJSONBool(B).AsBoolean);
+      Exit;
+    end;
   if (A is TJSONNumber) or (B is TJSONNumber) then
-    Exit((A is TJSONNumber) and (B is TJSONNumber) and (TJSONNumber(A).AsDouble = TJSONNumber(B).AsDouble));
+    begin
+      Result := (A is TJSONNumber) and (B is TJSONNumber) and (TJSONNumber(A).AsDouble = TJSONNumber(B).AsDouble);
+      Exit;
+    end;
   if (A is TJSONString) or (B is TJSONString) then
-    Exit((A is TJSONString) and (B is TJSONString) and (TJSONString(A).Value = TJSONString(B).Value));
+    begin
+      Result := (A is TJSONString) and (B is TJSONString) and (TJSONString(A).Value = TJSONString(B).Value);
+      Exit;
+    end;
   Result := A.ToJSON = B.ToJSON;
 end;
 
@@ -148,10 +180,171 @@ begin
   Result := True;
 end;
 
-class function TMCPSchemaValidator.ValidateNode(const Schema: TJSONObject; const Instance: TJSONValue;
+class function TMCPSchemaValidator.ValidateConstAndEnum(const Schema: TJSONObject; const Instance: TJSONValue;
+  const Path: string; Errors: TStrings): Boolean;
+begin
+  Result := True;
+  const ConstValue = Schema.GetValue('const');
+  const MatchesConst = (not Assigned(ConstValue) or JsonEquals(ConstValue, Instance));
+  if not MatchesConst then
+  begin
+    AddError(Errors, Path, 'does not match const');
+    Result := False;
+  end;
+
+  const EnumValue = Schema.GetValue('enum');
+  if not (EnumValue is TJSONArray) then
+    Exit;
+
+  var Found := False;
+  for var Item in TJSONArray(EnumValue) do
+  begin
+    if JsonEquals(Item, Instance) then
+    begin
+      Found := True;
+      Break;
+    end;
+  end;
+  if not Found then
+  begin
+    AddError(Errors, Path, 'not one of the allowed values');
+    Result := False;
+  end;
+end;
+
+class function TMCPSchemaValidator.ValidateString(const Schema: TJSONObject; const Text: string;
+  const Path: string; Errors: TStrings): Boolean;
+begin
+  Result := True;
+  const MinLengthValue = Schema.GetValue('minLength');
+  const IsTooShort = ((MinLengthValue is TJSONNumber) and (Length(Text) < TJSONNumber(MinLengthValue).AsInt));
+  if IsTooShort then
+  begin
+    AddError(Errors, Path, 'shorter than minLength');
+    Result := False;
+  end;
+
+  const MaxLengthValue = Schema.GetValue('maxLength');
+  const IsTooLong = ((MaxLengthValue is TJSONNumber) and (Length(Text) > TJSONNumber(MaxLengthValue).AsInt));
+  if IsTooLong then
+  begin
+    AddError(Errors, Path, 'longer than maxLength');
+    Result := False;
+  end;
+
+  const PatternValue = Schema.GetValue('pattern');
+  if not IsJsonString(PatternValue) then
+    Exit;
+
+  var Matches: Boolean;
+  try
+    Matches := TRegEx.IsMatch(Text, TJSONString(PatternValue).Value);
+  except
+    on E: ERegularExpressionError do
+    begin
+      AddError(Errors, Path, 'has an unusable pattern');
+      Exit(False);
+    end;
+  end;
+  if not Matches then
+  begin
+    AddError(Errors, Path, 'does not match pattern');
+    Result := False;
+  end;
+end;
+
+class function TMCPSchemaValidator.ValidateNumber(const Schema: TJSONObject; const Value: Double;
+  const Path: string; Errors: TStrings): Boolean;
+begin
+  Result := True;
+  const MinimumValue = Schema.GetValue('minimum');
+  const IsBelowMinimum = ((MinimumValue is TJSONNumber) and (Value < TJSONNumber(MinimumValue).AsDouble));
+  if IsBelowMinimum then
+  begin
+    AddError(Errors, Path, 'less than minimum');
+    Result := False;
+  end;
+
+  const MaximumValue = Schema.GetValue('maximum');
+  const IsAboveMaximum = ((MaximumValue is TJSONNumber) and (Value > TJSONNumber(MaximumValue).AsDouble));
+  if IsAboveMaximum then
+  begin
+    AddError(Errors, Path, 'greater than maximum');
+    Result := False;
+  end;
+end;
+
+class function TMCPSchemaValidator.ValidateObject(const Schema: TJSONObject; const Instance: TJSONObject;
   const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
 begin
   Result := True;
+  const RequiredValue = Schema.GetValue(SCHEMA_KEY_REQUIRED);
+  if RequiredValue is TJSONArray then
+  begin
+    for var Item in TJSONArray(RequiredValue) do
+    begin
+      const IsMissing = (IsJsonString(Item) and not Assigned(Instance.GetValue(TJSONString(Item).Value)));
+      if IsMissing then
+      begin
+        AddError(Errors, Path, Format('missing required property "%s"', [TJSONString(Item).Value]));
+        Result := False;
+      end;
+    end;
+  end;
+
+  var PropertySchemas: TJSONObject := nil;
+  const PropertiesValue = Schema.GetValue(SCHEMA_KEY_PROPERTIES);
+  if PropertiesValue is TJSONObject then
+    PropertySchemas := TJSONObject(PropertiesValue);
+
+  if Assigned(PropertySchemas) then
+  begin
+    for var Pair in Instance do
+    begin
+      const PropertySchema = PropertySchemas.GetValue(Pair.JsonString.Value);
+      if not (PropertySchema is TJSONObject) then
+        Continue;
+      const MemberPath = Format('%s.%s', [Path, Pair.JsonString.Value]);
+      if not ValidateNode(TJSONObject(PropertySchema), Pair.JsonValue, MemberPath, Depth + 1, RootSchema, Errors) then
+        Result := False;
+    end;
+  end;
+
+  const AdditionalValue = Schema.GetValue(SCHEMA_KEY_ADDITIONAL_PROPERTIES);
+  const ForbidsExtras = ((AdditionalValue is TJSONBool) and not TJSONBool(AdditionalValue).AsBoolean);
+  if not ForbidsExtras then
+    Exit;
+
+  for var Pair in Instance do
+  begin
+    const IsKnown = (Assigned(PropertySchemas) and Assigned(PropertySchemas.GetValue(Pair.JsonString.Value)));
+    if not IsKnown then
+    begin
+      AddError(Errors, Path, Format('unexpected property "%s"', [Pair.JsonString.Value]));
+      Result := False;
+    end;
+  end;
+end;
+
+class function TMCPSchemaValidator.ValidateArray(const Schema: TJSONObject; const Instance: TJSONArray;
+  const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
+begin
+  Result := True;
+  const ItemsValue = Schema.GetValue(SCHEMA_KEY_ITEMS);
+  if not (ItemsValue is TJSONObject) then
+    Exit;
+
+  for var Index := 0 to Instance.Count - 1 do
+  begin
+    const ItemPath = Format('%s[%d]', [Path, Index]);
+    if not ValidateNode(TJSONObject(ItemsValue), Instance.Items[Index], ItemPath, Depth + 1, RootSchema, Errors) then
+      Result := False;
+  end;
+end;
+
+class function TMCPSchemaValidator.ValidateNode(const Schema: TJSONObject; const Instance: TJSONValue;
+  const Path: string; Depth: Integer; const RootSchema: TJSONObject; Errors: TStrings): Boolean;
+begin
   if Depth > MAX_DEPTH then
   begin
     AddError(Errors, Path, 'schema nested too deeply');
@@ -159,39 +352,17 @@ begin
   end;
 
   var ResolvedSchema := Schema;
-  var RefValue := Schema.GetValue('$ref');
-  if (RefValue is TJSONString) and not (RefValue is TJSONNumber) then
+  const RefValue = Schema.GetValue('$ref');
+  if IsJsonString(RefValue) then
   begin
     if not TryResolveRef(RootSchema, TJSONString(RefValue).Value, ResolvedSchema) then
     begin
-      AddError(Errors, Path, 'unsupported $ref "' + TJSONString(RefValue).Value + '"');
+      AddError(Errors, Path, Format('unsupported $ref "%s"', [TJSONString(RefValue).Value]));
       Exit(False);
     end;
   end;
 
-  var ConstValue := ResolvedSchema.GetValue('const');
-  if Assigned(ConstValue) and not JsonEquals(ConstValue, Instance) then
-  begin
-    AddError(Errors, Path, 'does not match const');
-    Result := False;
-  end;
-
-  var EnumValue := ResolvedSchema.GetValue('enum');
-  if EnumValue is TJSONArray then
-  begin
-    var Found := False;
-    for var Item in TJSONArray(EnumValue) do
-      if JsonEquals(Item, Instance) then
-      begin
-        Found := True;
-        Break;
-      end;
-    if not Found then
-    begin
-      AddError(Errors, Path, 'not one of the allowed values');
-      Result := False;
-    end;
-  end;
+  Result := ValidateConstAndEnum(ResolvedSchema, Instance, Path, Errors);
 
   var TypeError: string;
   if not TryCheckType(ResolvedSchema, Instance, TypeError) then
@@ -200,107 +371,25 @@ begin
     Exit(False);
   end;
 
-  if (Instance is TJSONString) and not (Instance is TJSONNumber) then
+  if IsJsonString(Instance) then
   begin
-    var Text := TJSONString(Instance).Value;
-    var MinLengthValue := ResolvedSchema.GetValue('minLength');
-    if (MinLengthValue is TJSONNumber) and (Length(Text) < TJSONNumber(MinLengthValue).AsInt) then
-    begin
-      AddError(Errors, Path, 'shorter than minLength');
+    if not ValidateString(ResolvedSchema, TJSONString(Instance).Value, Path, Errors) then
       Result := False;
-    end;
-    var MaxLengthValue := ResolvedSchema.GetValue('maxLength');
-    if (MaxLengthValue is TJSONNumber) and (Length(Text) > TJSONNumber(MaxLengthValue).AsInt) then
-    begin
-      AddError(Errors, Path, 'longer than maxLength');
-      Result := False;
-    end;
-    const PatternValue = ResolvedSchema.GetValue('pattern');
-    if IsJsonString(PatternValue) then
-    begin
-      var Matches := False;
-      try
-        Matches := TRegEx.IsMatch(Text, TJSONString(PatternValue).Value);
-      except
-        on E: ERegularExpressionError do
-        begin
-          AddError(Errors, Path, 'has an unusable pattern');
-          Exit(False);
-        end;
-      end;
-      const PatternMatched = Matches;
-      if not PatternMatched then
-      begin
-        AddError(Errors, Path, 'does not match pattern');
-        Result := False;
-      end;
-    end;
-  end;
-
-  if Instance is TJSONNumber then
+  end
+  else if Instance is TJSONNumber then
   begin
-    var NumberValue := TJSONNumber(Instance).AsDouble;
-    var MinimumValue := ResolvedSchema.GetValue('minimum');
-    if (MinimumValue is TJSONNumber) and (NumberValue < TJSONNumber(MinimumValue).AsDouble) then
-    begin
-      AddError(Errors, Path, 'less than minimum');
+    if not ValidateNumber(ResolvedSchema, TJSONNumber(Instance).AsDouble, Path, Errors) then
       Result := False;
-    end;
-    var MaximumValue := ResolvedSchema.GetValue('maximum');
-    if (MaximumValue is TJSONNumber) and (NumberValue > TJSONNumber(MaximumValue).AsDouble) then
-    begin
-      AddError(Errors, Path, 'greater than maximum');
+  end
+  else if Instance is TJSONObject then
+  begin
+    if not ValidateObject(ResolvedSchema, TJSONObject(Instance), Path, Depth, RootSchema, Errors) then
       Result := False;
-    end;
-  end;
-
-  if Instance is TJSONObject then
+  end
+  else if Instance is TJSONArray then
   begin
-    var Obj := TJSONObject(Instance);
-
-    var RequiredValue := ResolvedSchema.GetValue('required');
-    if RequiredValue is TJSONArray then
-      for var Item in TJSONArray(RequiredValue) do
-        if (Item is TJSONString) and not (Item is TJSONNumber)
-          and not Assigned(Obj.GetValue(TJSONString(Item).Value)) then
-        begin
-          AddError(Errors, Path, 'missing required property "' + TJSONString(Item).Value + '"');
-          Result := False;
-        end;
-
-    var PropSchemas: TJSONObject := nil;
-    var PropertiesValue := ResolvedSchema.GetValue('properties');
-    if PropertiesValue is TJSONObject then
-      PropSchemas := TJSONObject(PropertiesValue);
-
-    if Assigned(PropSchemas) then
-      for var Pair in Obj do
-      begin
-        var PropSchemaValue := PropSchemas.GetValue(Pair.JsonString.Value);
-        if PropSchemaValue is TJSONObject then
-          if not ValidateNode(TJSONObject(PropSchemaValue), Pair.JsonValue, Path + '.' + Pair.JsonString.Value,
-            Depth + 1, RootSchema, Errors) then
-            Result := False;
-      end;
-
-    var AdditionalValue := ResolvedSchema.GetValue('additionalProperties');
-    if (AdditionalValue is TJSONBool) and not TJSONBool(AdditionalValue).AsBoolean then
-      for var Pair in Obj do
-        if not (Assigned(PropSchemas) and Assigned(PropSchemas.GetValue(Pair.JsonString.Value))) then
-        begin
-          AddError(Errors, Path, 'unexpected property "' + Pair.JsonString.Value + '"');
-          Result := False;
-        end;
-  end;
-
-  if Instance is TJSONArray then
-  begin
-    var ItemsValue := ResolvedSchema.GetValue('items');
-    if ItemsValue is TJSONObject then
-      for var I := 0 to TJSONArray(Instance).Count - 1 do
-        if not ValidateNode(TJSONObject(ItemsValue), TJSONArray(Instance).Items[I], Format('%s[%d]', [Path, I]),
-          Depth + 1, RootSchema, Errors) then
-          Result := False;
+    if not ValidateArray(ResolvedSchema, TJSONArray(Instance), Path, Depth, RootSchema, Errors) then
+      Result := False;
   end;
 end;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -19,6 +19,9 @@ type
     class function DeserializeArray(RttiType: TRttiType; const JsonArray: TJSONArray): TValue;
 
     class function ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToInteger(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToFloat(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToClass(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
     class function ConvertValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
@@ -171,7 +174,10 @@ class function TMCPSerializer.GetWireName(const Prop: TRttiProperty): string;
 begin
   for var Attr in Prop.GetAttributes do
     if Attr is SchemaNameAttribute then
-      Exit(SchemaNameAttribute(Attr).Name);
+      begin
+        Result := SchemaNameAttribute(Attr).Name;
+        Exit;
+      end;
   Result := LowerCase(Prop.Name);
 end;
 
@@ -215,56 +221,89 @@ begin
   end;
 end;
 
-class function TMCPSerializer.ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
-var
-  NestedInstance: TObject;
+class function TMCPSerializer.ConvertJsonToInteger(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+begin
+  if not (JsonValue is TJSONNumber) then
+    raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
+
+  const Number = TJSONNumber(JsonValue);
+  const IsWhole = (Frac(Number.AsDouble) = 0);
+  if not IsWhole then
+    raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
+
+  if RttiType.TypeKind = tkInt64 then
+    Exit(Number.AsInt64);
+
+  const Ordinal = TRttiOrdinalType(RttiType);
+  const InRange = ((Number.AsInt64 >= Ordinal.MinValue) and (Number.AsInt64 <= Ordinal.MaxValue));
+  if not InRange then
+    raise EArgumentException.CreateFmt('%d is outside the range of %s', [Number.AsInt64, RttiType.Name]);
+  Result := TValue.FromOrdinal(RttiType.Handle, Number.AsInt64);
+end;
+
+class function TMCPSerializer.ConvertJsonToFloat(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+begin
+  const IsDateTime = (RttiType.Handle = TypeInfo(TDateTime));
+  if not IsDateTime then
+  begin
+    if not (JsonValue is TJSONNumber) then
+      raise EArgumentException.Create('expected a number');
+    begin
+      Result := TJSONNumber(JsonValue).AsDouble;
+      Exit;
+    end;
+  end;
+
+  if not IsJsonString(JsonValue) then
+    raise EArgumentException.Create('expected a date-time string');
+  try
+    Result := TValue.From<TDateTime>(ISO8601ToDate(JsonValue.Value, False));
+  except
+    on E: EConvertError do
+      raise EArgumentException.Create('expected an ISO 8601 date-time');
+  end;
+end;
+
+class function TMCPSerializer.ConvertJsonToClass(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
 begin
   Result := TValue.Empty;
+  if JsonValue is TJSONArray then
+    begin
+      Result := DeserializeArray(RttiType, TJSONArray(JsonValue));
+      Exit;
+    end;
+  if not (JsonValue is TJSONObject) then
+    raise EArgumentException.Create('expected an object');
 
+  const NestedInstance = CreateInstanceFromType(RttiType);
+  if not Assigned(NestedInstance) then
+    Exit;
+
+  try
+    DeserializeObject(NestedInstance, TJSONObject(JsonValue));
+  except
+    NestedInstance.Free;
+    raise;
+  end;
+  Result := NestedInstance;
+end;
+
+class function TMCPSerializer.ConvertJsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+begin
+  Result := TValue.Empty;
   if not Assigned(JsonValue) then
     Exit;
 
   case RttiType.TypeKind of
     tkInteger, tkInt64:
-      begin
-        if not (JsonValue is TJSONNumber) then
-          raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
-        var Number := TJSONNumber(JsonValue);
-        if Frac(Number.AsDouble) <> 0 then
-          raise EArgumentException.Create(MESSAGE_EXPECTED_INTEGER);
-        if RttiType.TypeKind = tkInt64 then
-          Result := Number.AsInt64
-        else
-        begin
-          const Ordinal = TRttiOrdinalType(RttiType);
-          const InRange = ((Number.AsInt64 >= Ordinal.MinValue) and (Number.AsInt64 <= Ordinal.MaxValue));
-          if not InRange then
-            raise EArgumentException.CreateFmt('%d is outside the range of %s', [Number.AsInt64, RttiType.Name]);
-          Result := TValue.FromOrdinal(RttiType.Handle, Number.AsInt64);
-        end;
-      end;
+      Result := ConvertJsonToInteger(JsonValue, RttiType);
 
     tkFloat:
-      if RttiType.Handle = TypeInfo(TDateTime) then
-      begin
-        if not (JsonValue is TJSONString) then
-          raise EArgumentException.Create('expected a date-time string');
-        try
-          Result := TValue.From<TDateTime>(ISO8601ToDate(JsonValue.Value, False));
-        except
-          raise EArgumentException.Create('expected an ISO 8601 date-time');
-        end;
-      end
-      else
-      begin
-        if not (JsonValue is TJSONNumber) then
-          raise EArgumentException.Create('expected a number');
-        Result := TJSONNumber(JsonValue).AsDouble;
-      end;
+      Result := ConvertJsonToFloat(JsonValue, RttiType);
 
     tkString, tkLString, tkWString, tkUString:
       begin
-        if not (JsonValue is TJSONString) or (JsonValue is TJSONNumber) then
+        if not IsJsonString(JsonValue) then
           raise EArgumentException.Create('expected a string');
         Result := JsonValue.Value;
       end;
@@ -280,31 +319,16 @@ begin
         Result := ConvertJsonToEnum(JsonValue, RttiType);
 
     tkClass:
-      if JsonValue is TJSONObject then
-      begin
-        NestedInstance := CreateInstanceFromType(RttiType);
-        if Assigned(NestedInstance) then
-        begin
-          try
-            DeserializeObject(NestedInstance, JsonValue as TJSONObject);
-          except
-            NestedInstance.Free;
-            raise;
-          end;
-          Result := NestedInstance;
-        end;
-      end
-      else if JsonValue is TJSONArray then
-        Result := DeserializeArray(RttiType, JsonValue as TJSONArray)
-      else
-        raise EArgumentException.Create('expected an object');
+      Result := ConvertJsonToClass(JsonValue, RttiType);
 
     tkDynArray:
       begin
         if not (JsonValue is TJSONArray) then
           raise EArgumentException.Create('expected an array');
-        Result := DeserializeArray(RttiType, JsonValue as TJSONArray);
+        Result := DeserializeArray(RttiType, TJSONArray(JsonValue));
       end;
+  else
+    Result := TValue.Empty;
   end;
 end;
 

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -302,7 +302,10 @@ function TLogsByLevelTemplate.Complete(const ArgumentName, Value: string;
   const Context: TArray<TPair<string, string>>): TMCPCompletion;
 begin
   if ArgumentName <> TEMPLATE_VARIABLE_LEVEL then
-    Exit(TMCPCompletion.Create(nil));
+    begin
+      Result := TMCPCompletion.Create(nil);
+      Exit;
+    end;
 
   var Levels := TStringList.Create;
   try

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -87,6 +87,12 @@ type
     function IsListedHeader(const List, Name: string): Boolean;
     procedure HandleCreatePostStream(Context: TIdContext; Headers: TIdHeaderList; var VPostStream: TStream);
     function MaxBodyBytes: Integer;
+    function MaxJsonDepth: Integer;
+    function IsBodyWithinLimits(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+      const Body: string): Boolean;
+    function ReadBody(RequestInfo: TIdHTTPRequestInfo): string;
+    procedure SendOutcome(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+      const Outcome: TMCPProcessResult; const AcceptsEventStream: Boolean);
   public
     constructor Create(Owner: TComponent); override;
     destructor Destroy; override;
@@ -653,40 +659,16 @@ end;
 procedure TMCPIdHTTPServer.HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo;
   ResponseInfo: TIdHTTPResponseInfo; const Principal: TMCPPrincipal);
 begin
-  var MaxDepth: Integer := TMCPSettings.DEFAULT_MAX_JSON_DEPTH;
-  if Assigned(FSettings) then
-    MaxDepth := FSettings.MaxJsonDepth;
-
-  const Limit = MaxBodyBytes;
-  const BodyTooLarge = Assigned(RequestInfo.PostStream)
-    and ((RequestInfo.PostStream is TMCPDiscardedBody) or (RequestInfo.PostStream.Size > Limit));
-  if BodyTooLarge then
-  begin
-    SendJsonRpcError(ResponseInfo, HTTP_PAYLOAD_TOO_LARGE, JSONRPC_INVALID_REQUEST,
-      Format('Request body exceeds %d bytes', [Limit]));
-    Exit;
-  end;
-
-  var RequestBody := '';
-  if Assigned(RequestInfo.PostStream) and (RequestInfo.PostStream.Size > 0) then
-  begin
-    RequestInfo.PostStream.Position := 0;
-    RequestBody := ReadStringFromStream(RequestInfo.PostStream, -1, IndyTextEncoding_UTF8);
-  end;
-
+  const RequestBody = ReadBody(RequestInfo);
   TLogger.Debug('Request: ' + TLogger.RedactJson(RequestBody));
-
-  if TMCPJsonLimits.NestingDepth(RequestBody) > MaxDepth then
-  begin
-    SendJsonRpcError(ResponseInfo, HTTP_STATUS_BAD_REQUEST, JSONRPC_PARSE_ERROR,
-      Format('JSON nesting exceeds %d levels', [MaxDepth]));
+  if not IsBodyWithinLimits(RequestInfo, ResponseInfo, RequestBody) then
     Exit;
-  end;
 
-  var AcceptsEventStream := TMCPAcceptHeader.Accepts(HeaderValue(RequestInfo, HEADER_ACCEPT), MEDIA_TYPE_EVENT_STREAM);
+  const AcceptsEventStream = TMCPAcceptHeader.Accepts(HeaderValue(RequestInfo, HEADER_ACCEPT), MEDIA_TYPE_EVENT_STREAM);
   var Hints := BuildTransportHints(RequestInfo);
   Hints.Principal := Principal.Subject;
   Hints.Scopes := Principal.Scopes;
+
   var Stream: TMCPHttpResponseStream := nil;
   var StreamRef: IMCPMessageSink := nil;
   if AcceptsEventStream then
@@ -698,27 +680,77 @@ begin
   end;
 
   var Outcome: TMCPProcessResult;
-  var Message := TJSONObject.ParseJSONValue(RequestBody);
+  const Message = TJSONObject.ParseJSONValue(RequestBody);
   try
     Outcome := FJsonRpcProcessor.ProcessRequestEx(Message, Hints);
   finally
     Message.Free;
   end;
 
-  if Assigned(Stream) and Stream.Opened then
+  const IsStreamed = (Assigned(Stream) and Stream.Opened);
+  if IsStreamed then
   begin
     TLogger.Debug('Response (streamed): ' + TLogger.RedactJson(Outcome.Body));
     Stream.Finish(Outcome.Body);
     Exit;
   end;
 
+  SendOutcome(RequestInfo, ResponseInfo, Outcome, AcceptsEventStream);
+end;
+
+function TMCPIdHTTPServer.MaxJsonDepth: Integer;
+begin
+  Result := TMCPSettings.DEFAULT_MAX_JSON_DEPTH;
+  if Assigned(FSettings) then
+    Result := FSettings.MaxJsonDepth;
+end;
+
+function TMCPIdHTTPServer.ReadBody(RequestInfo: TIdHTTPRequestInfo): string;
+begin
+  Result := '';
+  const HasBody = (Assigned(RequestInfo.PostStream) and (RequestInfo.PostStream.Size > 0));
+  if not HasBody then
+    Exit;
+
+  RequestInfo.PostStream.Position := 0;
+  Result := ReadStringFromStream(RequestInfo.PostStream, -1, IndyTextEncoding_UTF8);
+end;
+
+function TMCPIdHTTPServer.IsBodyWithinLimits(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+  const Body: string): Boolean;
+begin
+  const Limit = MaxBodyBytes;
+  const IsTooLarge = Assigned(RequestInfo.PostStream)
+    and ((RequestInfo.PostStream is TMCPDiscardedBody) or (RequestInfo.PostStream.Size > Limit));
+  if IsTooLarge then
+  begin
+    SendJsonRpcError(ResponseInfo, HTTP_PAYLOAD_TOO_LARGE, JSONRPC_INVALID_REQUEST,
+      Format('Request body exceeds %d bytes', [Limit]));
+    Exit(False);
+  end;
+
+  const Depth = MaxJsonDepth;
+  const IsTooDeep = (TMCPJsonLimits.NestingDepth(Body) > Depth);
+  if IsTooDeep then
+  begin
+    SendJsonRpcError(ResponseInfo, HTTP_STATUS_BAD_REQUEST, JSONRPC_PARSE_ERROR,
+      Format('JSON nesting exceeds %d levels', [Depth]));
+    Exit(False);
+  end;
+  Result := True;
+end;
+
+procedure TMCPIdHTTPServer.SendOutcome(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo;
+  const Outcome: TMCPProcessResult; const AcceptsEventStream: Boolean);
+begin
   if Outcome.Era = TMCPProtocolEra.Legacy then
     EchoLegacySessionId(RequestInfo, ResponseInfo);
   if Outcome.RequiredScope <> '' then
     ResponseInfo.CustomHeaders.Values[HEADER_WWW_AUTHENTICATE] :=
       TMCPBearerChallenge.Build(ResourceMetadataUrl, TMCPAuthChallenge.InsufficientScope(Outcome.RequiredScope));
 
-  if Outcome.Body = '' then
+  const IsEmpty = (Outcome.Body = '');
+  if IsEmpty then
   begin
     SendEmpty(ResponseInfo, Outcome.HttpStatus);
     Exit;
@@ -726,7 +758,8 @@ begin
 
   TLogger.Debug('Response: ' + TLogger.RedactJson(Outcome.Body));
 
-  if (Outcome.HttpStatus = HTTP_STATUS_OK) and AcceptsEventStream then
+  const AsEventStream = ((Outcome.HttpStatus = HTTP_STATUS_OK) and AcceptsEventStream);
+  if AsEventStream then
     SendSse(ResponseInfo, Outcome.Body)
   else
     SendJson(ResponseInfo, Outcome.HttpStatus, Outcome.Body);


### PR DESCRIPTION
## Summary

- The methods that ran past sixty lines with several phases are split into named steps: `ProcessRequestEx` and `BuildRequestContext` in the processor, `ValidateNode` in the schema validator, `TypeSchema` in the generator, `ConvertJsonToValue` in the serializer, `HandlePostRequest` in the HTTP server and `Listen` in the subscriptions manager.
- `MCPServer.Application` carries the wiring the program file repeated for HTTP and for stdio; `MCPServer.dpr` is down to the command line, the signal handlers and one call.
- `Exit` with a call is written as an assignment and a return.

Methods of thirty to forty lines with a single job were left alone; splitting them adds jumps without making them clearer.

## Verification

- DUnitX: 376/376 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 and Release build clean.
- HTTP goldens, conformance (155 and 59), Inspector smoke and stdio smoke unchanged.