### PR TITLE
House rules across the sources and the tests

### DIFF
--- a/src/Core/MCPServer.Authorization.pas
+++ b/src/Core/MCPServer.Authorization.pas
@@ -213,17 +213,22 @@ end;
 class function TMCPBearerChallenge.Build(const ResourceMetadataUrl: string; const Challenge: TMCPAuthChallenge): string;
 begin
   var Parameters: TArray<string> := nil;
-  if ResourceMetadataUrl <> '' then
+  const HasResourceMetadataUrl = (ResourceMetadataUrl <> '');
+  if HasResourceMetadataUrl then
     Parameters := Parameters + ['resource_metadata=' + Quote(ResourceMetadataUrl)];
-  if Challenge.Error <> '' then
+  const HasError = (Challenge.Error <> '');
+  if HasError then
     Parameters := Parameters + ['error=' + Quote(Challenge.Error)];
-  if Challenge.ErrorDescription <> '' then
+  const HasErrorDescription = (Challenge.ErrorDescription <> '');
+  if HasErrorDescription then
     Parameters := Parameters + ['error_description=' + Quote(Challenge.ErrorDescription)];
-  if Challenge.Scope <> '' then
+  const HasScope = (Challenge.Scope <> '');
+  if HasScope then
     Parameters := Parameters + ['scope=' + Quote(Challenge.Scope)];
 
   Result := SCHEME;
-  if Length(Parameters) > 0 then
+  const HasParameters = (Length(Parameters) > 0);
+  if HasParameters then
     Result := Result + ' ' + string.Join(', ', Parameters);
 end;
 
@@ -253,7 +258,8 @@ begin
     Servers.Add(Server);
   end;
   var Scopes := WithoutOfflineAccess(ScopesSupported);
-  if Length(Scopes) > 0 then
+  const HasScopes = (Length(Scopes) > 0);
+  if HasScopes then
   begin
     var ScopesArray := TJSONArray.Create;
     Result.AddPair('scopes_supported', ScopesArray);
@@ -265,7 +271,8 @@ begin
   var Methods := TJSONArray.Create;
   Methods.Add('header');
   Result.AddPair('bearer_methods_supported', Methods);
-  if ResourceName <> '' then
+  const HasResourceName = (ResourceName <> '');
+  if HasResourceName then
     Result.AddPair('resource_name', ResourceName);
 end;
 
@@ -279,10 +286,12 @@ begin
     if Token.Trim <> '' then
       FTokens := FTokens + [TEncoding.UTF8.GetBytes(Token.Trim)];
   end;
-  if Length(FTokens) = 0 then
+  const TokensIsEmpty = (Length(FTokens) = 0);
+  if TokensIsEmpty then
     raise EMCPAuthorizationConfiguration.Create('A static bearer authorizer needs at least one token');
   FScopes := Scopes;
-  if Length(FScopes) = 0 then
+  const ScopesIsEmpty = (Length(FScopes) = 0);
+  if ScopesIsEmpty then
     FScopes := [MCP_SCOPE_ANY];
 end;
 
@@ -317,7 +326,8 @@ end;
 constructor TMCPOAuthResourceServerAuthorizer.Create(const ExpectedAudience: string);
 begin
   inherited Create;
-  if ExpectedAudience.Trim = '' then
+  const ExpectedAudienceIsEmpty = (ExpectedAudience.Trim = '');
+  if ExpectedAudienceIsEmpty then
     raise EMCPAuthorizationConfiguration.Create('An OAuth resource server authorizer needs the expected audience');
   FExpectedAudience := ExpectedAudience.Trim;
 end;
@@ -410,7 +420,8 @@ end;
 constructor TMCPIntrospectionAuthorizer.Create(const ExpectedAudience, IntrospectionUrl, ClientId, ClientSecret: string);
 begin
   inherited Create(ExpectedAudience);
-  if IntrospectionUrl.Trim = '' then
+  const IntrospectionUrlIsEmpty = (IntrospectionUrl.Trim = '');
+  if IntrospectionUrlIsEmpty then
     raise EMCPAuthorizationConfiguration.Create('An introspection authorizer needs the introspection endpoint URL');
   FIntrospectionUrl := IntrospectionUrl.Trim;
   FClientId := ClientId;
@@ -430,7 +441,8 @@ begin
     const Form = TStringStream.Create(Format('token=%s', [TNetEncoding.URL.EncodeForm(Token)]), TEncoding.UTF8);
     try
       var Headers: TArray<TNetHeader> := [TNetHeader.Create('Accept', 'application/json')];
-      if FClientId <> '' then
+      const HasClientId = (FClientId <> '');
+      if HasClientId then
       begin
         const Credentials = TNetEncoding.Base64.Encode(Format('%s:%s', [FClientId, FClientSecret]));
         Headers := Headers + [TNetHeader.Create('Authorization', Format('Basic %s', [Credentials]))];

--- a/src/Core/MCPServer.Logger.pas
+++ b/src/Core/MCPServer.Logger.pas
@@ -320,7 +320,9 @@ begin
   end
   else if Value is TJSONArray then
     for var Item in TJSONArray(Value) do
+    begin
       RedactValue(Item);
+    end;
 end;
 
 class function TLogger.RedactJson(const Json: string): string;

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -127,7 +127,8 @@ constructor TMCPSettings.Create(const ASettingsFile: string; const ACreateFile: 
 begin
   inherited Create;
 
-  if ASettingsFile = '' then
+  const ASettingsFileIsEmpty = (ASettingsFile = '');
+  if ASettingsFileIsEmpty then
     FSettingsFile := TPath.Combine(ExtractFilePath(ParamStr(0)), 'settings.ini')
   else
     FSettingsFile := ASettingsFile;
@@ -346,7 +347,8 @@ begin
     if FSSLEnabled then
     begin
       TLogger.Info('SSL Enabled: True');
-      if FSSLCertFile <> '' then
+      const HasSSLCertFile = (FSSLCertFile <> '');
+      if HasSSLCertFile then
         TLogger.Info('SSL Certificate: ' + FSSLCertFile);
     end;
     TLogger.Info('CORS Enabled: ' + BoolToStr(FCorsEnabled, True));

--- a/src/Managers/MCPServer.CompletionManager.pas
+++ b/src/Managers/MCPServer.CompletionManager.pas
@@ -161,7 +161,9 @@ function TMCPCompletionManager.BuildCompletionJSON(const Completion: TMCPComplet
 begin
   var Values := TJSONArray.Create;
   for var Value in Completion.Values do
+  begin
     Values.Add(Value);
+  end;
 
   Result := TJSONObject.Create;
   Result.AddPair('values', Values);

--- a/src/Managers/MCPServer.CoreManager.pas
+++ b/src/Managers/MCPServer.CoreManager.pas
@@ -14,7 +14,8 @@ type
   TMCPCoreManager = class(TInterfacedObject, IMCPCapabilityManager, IMCPCapabilityManagerEx, IMCPRegistryAware)
   private
     FSettings: TMCPSettings;
-    [Weak] FManagerRegistry: IMCPManagerRegistry;
+    [Weak]
+    FManagerRegistry: IMCPManagerRegistry;
     function GetSessionID: string;
     function BuildServerInfo: TJSONObject;
     function BuildCapabilities(Era: TMCPProtocolEra): TJSONObject;
@@ -105,11 +106,14 @@ begin
   Result := TJSONObject.Create;
   Result.AddPair(MCP_KEY_NAME, FSettings.ServerName);
   Result.AddPair(MCP_KEY_VERSION, FSettings.ServerVersion);
-  if FSettings.ServerTitle <> '' then
+  const HasServerTitle = (FSettings.ServerTitle <> '');
+  if HasServerTitle then
     Result.AddPair(MCP_KEY_TITLE, FSettings.ServerTitle);
-  if FSettings.ServerDescription <> '' then
+  const HasServerDescription = (FSettings.ServerDescription <> '');
+  if HasServerDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, FSettings.ServerDescription);
-  if FSettings.ServerWebsiteUrl <> '' then
+  const HasServerWebsiteUrl = (FSettings.ServerWebsiteUrl <> '');
+  if HasServerWebsiteUrl then
     Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
 end;
 
@@ -122,10 +126,14 @@ function TMCPCoreManager.SupportedVersions: TJSONArray;
 begin
   Result := TJSONArray.Create;
   for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+  begin
     Result.Add(Version);
+  end;
   if FSettings.DiscoverListsLegacyVersions then
     for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+    begin
       Result.Add(Version);
+    end;
 end;
 
 procedure TMCPCoreManager.LogClientInfo(const ClientInfo: TJSONValue);
@@ -180,7 +188,8 @@ begin
     ResultJSON.AddPair(MCP_KEY_PROTOCOL_VERSION, Negotiated);
     ResultJSON.AddPair(MCP_KEY_CAPABILITIES, BuildCapabilities(TMCPProtocolEra.Legacy));
     ResultJSON.AddPair('serverInfo', BuildServerInfo);
-    if FSettings.Instructions <> '' then
+    const HasInstructions = (FSettings.Instructions <> '');
+    if HasInstructions then
       ResultJSON.AddPair(MCP_KEY_INSTRUCTIONS, FSettings.Instructions);
 
     if Assigned(Context) and Assigned(Context.LegacySession) then
@@ -208,7 +217,8 @@ begin
     ResultJSON.AddPair(MCP_KEY_META, Meta);
     Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
 
-    if FSettings.Instructions <> '' then
+    const HasInstructions = (FSettings.Instructions <> '');
+    if HasInstructions then
       ResultJSON.AddPair(MCP_KEY_INSTRUCTIONS, FSettings.Instructions);
     ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FSettings.DiscoverTtlMs));
     ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, MCP_CACHE_SCOPE_PUBLIC);

--- a/src/Managers/MCPServer.PromptsManager.pas
+++ b/src/Managers/MCPServer.PromptsManager.pas
@@ -170,7 +170,9 @@ end;
 procedure TMCPPromptsManager.RegisterBuiltInPrompts;
 begin
   for var PromptName in TMCPRegistry.GetPromptNames do
+  begin
     RegisterPrompt(TMCPRegistry.CreatePrompt(PromptName));
+  end;
 end;
 
 procedure TMCPPromptsManager.AddPrompt(const Prompt: IMCPPrompt);
@@ -201,13 +203,16 @@ var
 begin
   Result := TJSONObject.Create;
   Result.AddPair(MCP_KEY_NAME, Prompt.Name);
-  if Prompt.Title <> Prompt.Name then
+  const IsNotName = (Prompt.Title <> Prompt.Name);
+  if IsNotName then
     Result.AddPair(MCP_KEY_TITLE, Prompt.Title);
-  if Prompt.Description <> '' then
+  const HasDescription = (Prompt.Description <> '');
+  if HasDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, Prompt.Description);
 
   var Arguments := Prompt.Arguments;
-  if Length(Arguments) > 0 then
+  const HasArguments = (Length(Arguments) > 0);
+  if HasArguments then
   begin
     var ArgumentsArray := TJSONArray.Create;
     Result.AddPair(MCP_KEY_ARGUMENTS, ArgumentsArray);
@@ -250,7 +255,8 @@ begin
       FLock.Leave;
     end;
 
-    if Era = TMCPProtocolEra.Modern then
+    const IsModern = (Era = TMCPProtocolEra.Modern);
+    if IsModern then
     begin
       ResultJSON.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FListTtlMs));
       ResultJSON.AddPair(MCP_KEY_CACHE_SCOPE, FListCacheScope);

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -190,13 +190,17 @@ end;
 procedure TMCPResourcesManager.RegisterBuiltInResources;
 begin
   for var ResourceURI in TMCPRegistry.GetResourceURIs do
+  begin
     RegisterResource(TMCPRegistry.CreateResource(ResourceURI));
+  end;
 end;
 
 procedure TMCPResourcesManager.RegisterBuiltInResourceTemplates;
 begin
   for var UriTemplate in TMCPRegistry.GetResourceTemplateURIs do
+  begin
     FTemplates.Add(TMCPRegistry.CreateResourceTemplate(UriTemplate));
+  end;
 end;
 
 procedure TMCPResourcesManager.AddResource(const Resource: IMCPResource);
@@ -323,9 +327,11 @@ begin
     if Metadata.Title <> '' then
       Result.AddPair(MCP_KEY_TITLE, Metadata.Title);
   end;
-  if Resource.Description <> '' then
+  const HasDescription = (Resource.Description <> '');
+  if HasDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, Resource.Description);
-  if Resource.MimeType <> '' then
+  const HasMimeType = (Resource.MimeType <> '');
+  if HasMimeType then
     Result.AddPair(MCP_KEY_MIME_TYPE, Resource.MimeType);
   if Assigned(Metadata) then
   begin
@@ -341,11 +347,14 @@ begin
   Result := TJSONObject.Create;
   Result.AddPair('uriTemplate', Template.UriTemplate);
   Result.AddPair(MCP_KEY_NAME, Template.Name);
-  if Template.Title <> '' then
+  const HasTitle = (Template.Title <> '');
+  if HasTitle then
     Result.AddPair(MCP_KEY_TITLE, Template.Title);
-  if Template.Description <> '' then
+  const HasDescription = (Template.Description <> '');
+  if HasDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, Template.Description);
-  if Template.MimeType <> '' then
+  const HasMimeType = (Template.MimeType <> '');
+  if HasMimeType then
     Result.AddPair(MCP_KEY_MIME_TYPE, Template.MimeType);
 end;
 
@@ -356,7 +365,8 @@ begin
   Result := TJSONObject.Create;
   try
     Result.AddPair(MCP_KEY_URI, Resource.URI);
-    if Resource.MimeType <> '' then
+    const HasMimeType = (Resource.MimeType <> '');
+    if HasMimeType then
       Result.AddPair(MCP_KEY_MIME_TYPE, Resource.MimeType);
 
     if Supports(Resource, IMCPBinaryResource, Binary) then
@@ -441,7 +451,8 @@ begin
         raise EMCPError.InternalError('Error reading resource: ' + E.Message);
     end;
 
-    if Era = TMCPProtocolEra.Modern then
+    const IsModern = (Era = TMCPProtocolEra.Modern);
+    if IsModern then
     begin
       var TtlMs := 0;
       var CacheScope := MCP_CACHE_SCOPE_PRIVATE;

--- a/src/Managers/MCPServer.SubscriptionsManager.pas
+++ b/src/Managers/MCPServer.SubscriptionsManager.pas
@@ -139,7 +139,8 @@ begin
     Result.AddPair(FILTER_PROMPTS, TJSONBool.Create(True));
   if ResourcesListChanged then
     Result.AddPair(FILTER_RESOURCES, TJSONBool.Create(True));
-  if Length(ResourceSubscriptions) > 0 then
+  const HasResourceSubscriptions = (Length(ResourceSubscriptions) > 0);
+  if HasResourceSubscriptions then
   begin
     var Uris := TJSONArray.Create;
     Result.AddPair(FILTER_RESOURCE_SUBSCRIPTIONS, Uris);
@@ -416,7 +417,8 @@ end;
 procedure TMCPSubscriptionsManager.CloseAll(const Reason: string);
 begin
   var Open := Snapshot;
-  if Length(Open) > 0 then
+  const HasOpen = (Length(Open) > 0);
+  if HasOpen then
     TLogger.Info(Format('Closing %d subscription(s): %s', [Length(Open), Reason]));
   for var Subscription in Open do
   begin

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -244,7 +244,9 @@ end;
 procedure TMCPToolsManager.RegisterBuiltInTools;
 begin
   for var ToolName in TMCPRegistry.GetToolNames do
+  begin
     RegisterTool(TMCPRegistry.CreateTool(ToolName));
+  end;
 end;
 
 procedure TMCPToolsManager.AddTool(const Tool: IMCPTool);
@@ -369,7 +371,8 @@ var
 begin
   Result := TJSONObject.Create;
   Result.AddPair(MCP_KEY_NAME, Tool.Name);
-  if Tool.Title <> Tool.Name then
+  const IsNotName = (Tool.Title <> Tool.Name);
+  if IsNotName then
     Result.AddPair(MCP_KEY_TITLE, Tool.Title);
   Result.AddPair(MCP_KEY_DESCRIPTION, Tool.Description);
 
@@ -406,7 +409,8 @@ begin
     FLock.Leave;
   end;
 
-  if Era = TMCPProtocolEra.Modern then
+  const IsModern = (Era = TMCPProtocolEra.Modern);
+  if IsModern then
   begin
     Result.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(FListTtlMs));
     Result.AddPair(MCP_KEY_CACHE_SCOPE, FListCacheScope);

--- a/src/Prompts/MCPServer.Prompt.ContentSamples.pas
+++ b/src/Prompts/MCPServer.Prompt.ContentSamples.pas
@@ -163,7 +163,8 @@ begin
   var Context := TMCPRequestContext.Current;
   if Assigned(Context) and Context.TryGetInputResponse(KEY_USER_CONTEXT, Response) then
     UserContext := TMCPInputResponse.ElicitationField(Response, FIELD_CONTEXT);
-  if UserContext = '' then
+  const UserContextIsEmpty = (UserContext = '');
+  if UserContextIsEmpty then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create.AddElicitation(KEY_USER_CONTEXT,
       'What context should the prompt use?', TMCPInputRequests.FieldSchema(FIELD_CONTEXT)));
 

--- a/src/Protocol/MCPServer.ContentBlocks.pas
+++ b/src/Protocol/MCPServer.ContentBlocks.pas
@@ -70,9 +70,11 @@ begin
   Result.AddPair(MCP_KEY_TYPE, 'resource_link');
   Result.AddPair(MCP_KEY_URI, Uri);
   Result.AddPair(MCP_KEY_NAME, Name);
-  if Description <> '' then
+  const HasDescription = (Description <> '');
+  if HasDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, Description);
-  if MimeType <> '' then
+  const HasMimeType = (MimeType <> '');
+  if HasMimeType then
     Result.AddPair(MCP_KEY_MIME_TYPE, MimeType);
 end;
 

--- a/src/Protocol/MCPServer.Errors.pas
+++ b/src/Protocol/MCPServer.Errors.pas
@@ -127,7 +127,9 @@ class function EMCPError.UnsupportedProtocolVersion(const Requested: string; con
 begin
   var SupportedArray := TJSONArray.Create;
   for var Version in Supported do
+  begin
     SupportedArray.Add(Version);
+  end;
 
   var Data := TJSONObject.Create;
   Data.AddPair('supported', SupportedArray);
@@ -169,7 +171,8 @@ class function EMCPError.ResourceNotFound(const Uri: string; Era: TMCPProtocolEr
 begin
   var Data := TJSONObject.Create;
   Data.AddPair(MCP_KEY_URI, Uri);
-  if Era = TMCPProtocolEra.Modern then
+  const IsModern = (Era = TMCPProtocolEra.Modern);
+  if IsModern then
     Result := EMCPError.Create(JSONRPC_INVALID_PARAMS, MESSAGE_RESOURCE_NOT_FOUND, Data)
   else
     Result := EMCPError.Create(MCP_ERROR_RESOURCE_NOT_FOUND_LEGACY, MESSAGE_RESOURCE_NOT_FOUND, Data);

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -161,10 +161,14 @@ function TMCPJsonRpcProcessor.SupportedModernVersions: TArray<string>;
 begin
   Result := nil;
   for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+  begin
     Result := Result + [Version];
+  end;
   if FSettings.DiscoverListsLegacyVersions then
     for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+    begin
       Result := Result + [Version];
+    end;
 end;
 
 function TMCPJsonRpcProcessor.BuildServerInfo: TJSONObject;
@@ -172,11 +176,14 @@ begin
   Result := TJSONObject.Create;
   Result.AddPair(MCP_KEY_NAME, FSettings.ServerName);
   Result.AddPair(MCP_KEY_VERSION, FSettings.ServerVersion);
-  if FSettings.ServerTitle <> '' then
+  const HasServerTitle = (FSettings.ServerTitle <> '');
+  if HasServerTitle then
     Result.AddPair(MCP_KEY_TITLE, FSettings.ServerTitle);
-  if FSettings.ServerDescription <> '' then
+  const HasServerDescription = (FSettings.ServerDescription <> '');
+  if HasServerDescription then
     Result.AddPair(MCP_KEY_DESCRIPTION, FSettings.ServerDescription);
-  if FSettings.ServerWebsiteUrl <> '' then
+  const HasServerWebsiteUrl = (FSettings.ServerWebsiteUrl <> '');
+  if HasServerWebsiteUrl then
     Result.AddPair('websiteUrl', FSettings.ServerWebsiteUrl);
 end;
 
@@ -240,8 +247,8 @@ end;
 
 function TMCPJsonRpcProcessor.EraFromHeaders(const Hints: TMCPTransportHints): TMCPProtocolEra;
 begin
-  if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader
-    and TMCPProtocolVersion.IsModern(Hints.ProtocolVersionHeader) then
+  if Hints.HasHeaderLayer and Hints.HasProtocolVersionHeader and
+    TMCPProtocolVersion.IsModern(Hints.ProtocolVersionHeader) then
     Result := TMCPProtocolEra.Modern
   else
     Result := TMCPProtocolEra.Legacy;
@@ -300,7 +307,8 @@ var
 begin
   if not Hints.HasMethodHeader then
     raise EMCPError.HeaderMismatch('Mcp-Method header is missing');
-  if Hints.MethodHeader <> Method then
+  const IsNotMethod = (Hints.MethodHeader <> Method);
+  if IsNotMethod then
     raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
       ['Mcp-Method', Hints.MethodHeader, Method]));
 
@@ -309,7 +317,8 @@ begin
     SourceField := 'name'
   else if Method = MCP_METHOD_RESOURCES_READ then
     SourceField := 'uri';
-  if SourceField = '' then
+  const SourceFieldIsEmpty = (SourceField = '');
+  if SourceFieldIsEmpty then
     Exit;
 
   if not Hints.HasNameHeader then
@@ -324,7 +333,8 @@ begin
     if IsJsonString(Source) then
       BodyValue := TJSONString(Source).Value;
   end;
-  if Decoded <> BodyValue then
+  const IsNotBodyValue = (Decoded <> BodyValue);
+  if IsNotBodyValue then
     raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
       ['Mcp-Name', Decoded, BodyValue]));
 end;
@@ -364,7 +374,8 @@ begin
   begin
     if not Hints.HasProtocolVersionHeader then
       raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
-    if Hints.ProtocolVersionHeader <> Version then
+    const IsNotVersion = (Hints.ProtocolVersionHeader <> Version);
+    if IsNotVersion then
       raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
         ['MCP-Protocol-Version', Hints.ProtocolVersionHeader, Version]));
   end;
@@ -440,7 +451,8 @@ begin
   var Version := '';
   if Assigned(Hints.LegacySession) then
     Version := Hints.LegacySession.ProtocolVersion;
-  if Version = '' then
+  const VersionIsEmpty = (Version = '');
+  if VersionIsEmpty then
     Version := MCP_LATEST_LEGACY_PROTOCOL_VERSION;
 
   Result := NewContext(TMCPProtocolEra.Legacy, Version, Method, RequestId, Meta, Hints);
@@ -456,7 +468,8 @@ begin
 
   TLogger.Info('Notification received: ' + Method);
 
-  if Method = MCP_METHOD_NOTIFICATIONS_CANCELLED then
+  const IsMcpMethodNotificationsCancelled = (Method = MCP_METHOD_NOTIFICATIONS_CANCELLED);
+  if IsMcpMethodNotificationsCancelled then
   begin
     HandleCancelled(Params, Hints);
     Exit;
@@ -520,7 +533,8 @@ begin
   for var Method in Required.Requests.Methods do
   begin
     var Capability := TMCPInputRequests.RequiredCapability(Method);
-    if Capability = '' then
+    const CapabilityIsEmpty = (Capability = '');
+    if CapabilityIsEmpty then
       raise EMCPError.InternalError(Format('%s is not a request a client can answer', [Method]));
     Context.RequireClientCapability(Capability);
   end;
@@ -528,7 +542,8 @@ begin
   var ResultObject := TJSONObject.Create;
   try
     ResultObject.AddPair(MCP_KEY_RESULT_TYPE, RESULT_TYPE_INPUT_REQUIRED);
-    if Required.Requests.Count > 0 then
+    const HasRequests = (Required.Requests.Count > 0);
+    if HasRequests then
       ResultObject.AddPair('inputRequests', Required.Requests.ToJson);
     if Assigned(Required.State) then
       ResultObject.AddPair(PARAM_REQUEST_STATE, FStateSealer.Seal(Required.State, Context.Method,
@@ -598,8 +613,8 @@ begin
     Meta.AddPair(MCP_META_SERVER_INFO, BuildServerInfo);
 
   var ResultType := ResultObject.GetValue(MCP_KEY_RESULT_TYPE);
-  if IsCacheableMethod(Method) and (ResultType is TJSONString)
-    and (TJSONString(ResultType).Value = RESULT_TYPE_COMPLETE) then
+  if IsCacheableMethod(Method) and (ResultType is TJSONString) and
+    (TJSONString(ResultType).Value = RESULT_TYPE_COMPLETE) then
   begin
     if not Assigned(ResultObject.GetValue(MCP_KEY_TTL_MS)) then
       ResultObject.AddPair(MCP_KEY_TTL_MS, TJSONNumber.Create(0));
@@ -674,7 +689,8 @@ function TMCPJsonRpcProcessor.ErrorResult(Era: TMCPProtocolEra; const RequestId:
 begin
   TLogger.Error('Error processing request: ' + Error.Message);
   var RequiredScope := '';
-  if Error.HttpStatus = HTTP_STATUS_FORBIDDEN then
+  const IsHttpStatusForbidden = (Error.HttpStatus = HTTP_STATUS_FORBIDDEN);
+  if IsHttpStatusForbidden then
     RequiredScope := Error.RequiredScope;
 
   var Response := TJSONObject.Create;
@@ -723,9 +739,11 @@ end;
 function TMCPJsonRpcProcessor.ReadRequestId(const Request: TJSONObject): TMCPRequestId;
 begin
   Result := TMCPRequestId.FromJson(Request.GetValue(MCP_KEY_ID));
-  if Result.Kind = TMCPRequestIdKind.Null then
+  const IsNull = (Result.Kind = TMCPRequestIdKind.Null);
+  if IsNull then
     raise EMCPError.InvalidRequest('id must not be null');
-  if Result.Kind = TMCPRequestIdKind.Invalid then
+  const IsInvalid = (Result.Kind = TMCPRequestIdKind.Invalid);
+  if IsInvalid then
   begin
     Result := TMCPRequestId.FromJson(nil);
     raise EMCPError.InvalidRequest('id must be a string or an integer');
@@ -751,7 +769,8 @@ begin
   const IsResponse = (Assigned(Request.GetValue(MCP_KEY_RESULT)) or Assigned(Request.GetValue(MCP_KEY_ERROR)));
   if not IsResponse then
     raise EMCPError.InvalidRequest('method must be a string');
-  if Era = TMCPProtocolEra.Modern then
+  const IsModern = (Era = TMCPProtocolEra.Modern);
+  if IsModern then
     raise EMCPError.InvalidRequest('JSON-RPC responses are not accepted');
 
   IsClientResponse := True;
@@ -876,7 +895,8 @@ begin
         end;
 
       const Params = ReadParams(Request, Era);
-      if RequestId.Kind = TMCPRequestIdKind.None then
+      const IsNone = (RequestId.Kind = TMCPRequestIdKind.None);
+      if IsNone then
         begin
           Result := ProcessNotification(Method, Params, Hints);
           Exit;

--- a/src/Protocol/MCPServer.Mrtr.pas
+++ b/src/Protocol/MCPServer.Mrtr.pas
@@ -120,7 +120,8 @@ begin
   Message.AddPair(MCP_KEY_CONTENT, Content);
   Content.AddPair(MCP_KEY_TYPE, 'text');
   Content.AddPair(MCP_KEY_TEXT, UserText);
-  if SystemPrompt <> '' then
+  const HasSystemPrompt = (SystemPrompt <> '');
+  if HasSystemPrompt then
     Params.AddPair('systemPrompt', SystemPrompt);
   Params.AddPair('maxTokens', TJSONNumber.Create(MaxTokens));
   Result := AddRequest(Key, MCP_METHOD_SAMPLING_CREATE_MESSAGE, Params);
@@ -140,7 +141,9 @@ function TMCPInputRequests.Methods: TArray<string>;
 begin
   Result := nil;
   for var Pair in FRequests do
+  begin
     Result := Result + [TJSONObject(Pair.JsonValue).GetValue<string>(MCP_KEY_METHOD)];
+  end;
 end;
 
 class function TMCPInputRequests.RequiredCapability(const Method: string): string;

--- a/src/Protocol/MCPServer.RequestContext.pas
+++ b/src/Protocol/MCPServer.RequestContext.pas
@@ -391,7 +391,8 @@ begin
     Params.AddPair('progress', TJSONNumber.Create(Progress));
     if Total >= 0 then
       Params.AddPair('total', TJSONNumber.Create(Total));
-    if Message <> '' then
+    const HasMessage = (Message <> '');
+    if HasMessage then
       Params.AddPair('message', Message);
     FSink.Send(Notification.ToJSON);
   finally
@@ -407,8 +408,8 @@ end;
 procedure TMCPRequestContext.LogJson(const Level: string; const Data: TJSONValue; const Logger: string);
 begin
   var Threshold := GetLogLevel;
-  var Wanted := Assigned(FSink) and (Threshold <> '') and not IsCancelled
-    and (TMCPLogLevel.Rank(Level) >= TMCPLogLevel.Rank(Threshold));
+  var Wanted := Assigned(FSink) and (Threshold <> '') and not IsCancelled and
+    (TMCPLogLevel.Rank(Level) >= TMCPLogLevel.Rank(Threshold));
   if not Wanted then
   begin
     Data.Free;
@@ -422,7 +423,8 @@ begin
     var Params := TJSONObject.Create;
     Notification.AddPair(MCP_KEY_PARAMS, Params);
     Params.AddPair('level', Level);
-    if Logger <> '' then
+    const HasLogger = (Logger <> '');
+    if HasLogger then
       Params.AddPair('logger', Logger);
     Params.AddPair('data', Data);
     FSink.Send(Notification.ToJSON);

--- a/src/Protocol/MCPServer.RequestState.pas
+++ b/src/Protocol/MCPServer.RequestState.pas
@@ -112,7 +112,8 @@ constructor TMCPRequestStateSealer.Create(const Key: string; TtlSeconds: Integer
 begin
   inherited Create;
   FTtlSeconds := TtlSeconds;
-  if Key.Trim <> '' then
+  const HasKey = (Key.Trim <> '');
+  if HasKey then
     FKey := TEncoding.UTF8.GetBytes(Key)
   else
   begin
@@ -141,7 +142,8 @@ end;
 class function TMCPRequestStateSealer.TryFromBase64Url(const Text: string; out Bytes: TBytes): Boolean;
 begin
   Bytes := nil;
-  if Text = '' then
+  const TextIsEmpty = (Text = '');
+  if TextIsEmpty then
     Exit(False);
   for var C in Text do
     if not (CharInSet(C, ['A'..'Z', 'a'..'z', '0'..'9', '-', '_'])) then
@@ -149,7 +151,9 @@ begin
 
   var Standard := Text.Replace('-', '+').Replace('_', '/');
   while Length(Standard) mod 4 <> 0 do
+  begin
     Standard := Standard + '=';
+  end;
   try
     Bytes := TNetEncoding.Base64.DecodeStringToBytes(Standard);
     Result := Length(Bytes) > 0;
@@ -165,7 +169,9 @@ begin
     var Names := TList<string>.Create;
     try
       for var Pair in TJSONObject(Value) do
+      begin
         Names.Add(Pair.JsonString.Value);
+      end;
       Names.Sort(TComparer<string>.Construct(
         function(const Left, Right: string): Integer
         begin
@@ -262,9 +268,9 @@ var
   PayloadBytes, SignatureBytes: TBytes;
 begin
   var Separator := Token.LastIndexOf(TOKEN_SEPARATOR);
-  if (Separator <= 0) or not TryFromBase64Url(Token.Substring(0, Separator), PayloadBytes)
-    or not TryFromBase64Url(Token.Substring(Separator + 1), SignatureBytes)
-    or not TMCPConstantTime.SameBytes(SignatureBytes, Signature(PayloadBytes)) then
+  if (Separator <= 0) or not TryFromBase64Url(Token.Substring(0, Separator), PayloadBytes) or
+    not TryFromBase64Url(Token.Substring(Separator + 1), SignatureBytes) or
+    not TMCPConstantTime.SameBytes(SignatureBytes, Signature(PayloadBytes)) then
     raise EMCPError.InvalidParams(MESSAGE_INTEGRITY_FAILED);
 
   const Parsed = TJSONObject.ParseJSONValue(TEncoding.UTF8.GetString(PayloadBytes));

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -102,7 +102,9 @@ begin
   var EnumType := TRttiEnumerationType(RttiType);
   Result := TJSONArray.Create;
   for var Ordinal := EnumType.MinValue to EnumType.MaxValue do
+  begin
     Result.Add(GetEnumName(RttiType.Handle, Ordinal));
+  end;
 end;
 
 class function TMCPSchemaGenerator.ListItemType(RttiType: TRttiType): TRttiType;
@@ -269,7 +271,9 @@ begin
       PropSchema.RemovePair(SCHEMA_KEY_ENUM).Free;
       var EnumArray := TJSONArray.Create;
       for var Value in SchemaEnumAttribute(Attr).Values do
+      begin
         EnumArray.Add(Value);
+      end;
       PropSchema.AddPair(SCHEMA_KEY_ENUM, EnumArray);
     end
     else if Attr is SchemaMinLengthAttribute then
@@ -317,7 +321,8 @@ begin
         RequiredArray.Add(JsonName);
     end;
 
-    if RequiredArray.Count > 0 then
+    const HasRequiredArray = (RequiredArray.Count > 0);
+    if HasRequiredArray then
       Result.AddPair(SCHEMA_KEY_REQUIRED, RequiredArray)
     else
       RequiredArray.Free;

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -372,7 +372,9 @@ begin
   SetLength(Names, EnumType.MaxValue - EnumType.MinValue + 1);
 
   for Ordinal := EnumType.MinValue to EnumType.MaxValue do
+  begin
     Names[Ordinal - EnumType.MinValue] := GetEnumName(EnumType.Handle, Ordinal);
+  end;
 
   Result := String.Join(', ', Names);
 end;
@@ -504,8 +506,8 @@ begin
   ListType := FContext.GetType(Obj.ClassType);
   CountProp := ListType.GetProperty('Count');
   ItemsProp := ListType.GetIndexedProperty('Items');
-  if not Assigned(CountProp) or not Assigned(ItemsProp) or not ItemsProp.IsReadable
-    or not Assigned(ItemsProp.ReadMethod) then
+  if not Assigned(CountProp) or not Assigned(ItemsProp) or not ItemsProp.IsReadable or
+    not Assigned(ItemsProp.ReadMethod) then
     Exit;
 
   IndexParams := ItemsProp.ReadMethod.GetParameters;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -741,7 +741,9 @@ begin
   inherited Create;
   SetLength(FValues, Length(AValues));
   for I := 0 to High(AValues) do
+  begin
     FValues[I] := AValues[I];
+  end;
 end;
 
 constructor SchemaEnumAttribute.Create(const AValue1: string);

--- a/src/Resources/MCPServer.Resource.Base.pas
+++ b/src/Resources/MCPServer.Resource.Base.pas
@@ -298,7 +298,8 @@ begin
           VarName := Expr;
           Result.Pattern := Result.Pattern + Format('(?<%s>[^/]+)', [VarName]);
         end;
-        if VarName = '' then
+        const VarNameIsEmpty = (VarName = '');
+        if VarNameIsEmpty then
           raise EArgumentException.CreateFmt('Empty variable name in URI template "%s"', [UriTemplate]);
         for var C in VarName do
           if not CharInSet(C, ['A'..'Z', 'a'..'z', '0'..'9', '_']) then
@@ -315,7 +316,9 @@ begin
       begin
         var LiteralStart := Position;
         while (Position <= Length(UriTemplate)) and (UriTemplate[Position] <> '{') do
+        begin
           Inc(Position);
+        end;
         LiteralRun := Copy(UriTemplate, LiteralStart, Position - LiteralStart);
         Result.Pattern := Result.Pattern + TRegEx.Escape(LiteralRun);
       end;
@@ -375,7 +378,9 @@ begin
   Result := Match.Success;
   if Result then
     for var VarName in FVariableNames do
+    begin
       Vars.AddOrSetValue(VarName, PercentDecode(Match.Groups[VarName].Value));
+    end;
 end;
 
 end.

--- a/src/Resources/MCPServer.Resource.Logs.pas
+++ b/src/Resources/MCPServer.Resource.Logs.pas
@@ -128,7 +128,9 @@ var
   Entry: TLogEntry;
 begin
   for Entry in FLogs do
+  begin
     Entry.Free;
+  end;
   FLogs.Free;
   inherited;
 end;

--- a/src/Resources/MCPServer.Resource.Server.pas
+++ b/src/Resources/MCPServer.Resource.Server.pas
@@ -108,7 +108,8 @@ begin
   while Current > 0 do
   begin
     var Previous := AtomicCmpExchange(FActiveConnections, Current - 1, Current);
-    if Previous = Current then
+    const IsCurrent = (Previous = Current);
+    if IsCurrent then
       Exit;
     Current := Previous;
   end;

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -68,8 +68,8 @@ end;
 
 class function TMCPHeaderValue.IsSentinel(const Value: string): Boolean;
 begin
-  Result := (Length(Value) >= Length(SENTINEL_PREFIX) + Length(SENTINEL_SUFFIX))
-    and Value.StartsWith(SENTINEL_PREFIX, False) and Value.EndsWith(SENTINEL_SUFFIX, False);
+  Result := (Length(Value) >= Length(SENTINEL_PREFIX) + Length(SENTINEL_SUFFIX)) and
+    Value.StartsWith(SENTINEL_PREFIX, False) and Value.EndsWith(SENTINEL_SUFFIX, False);
 end;
 
 class function TMCPHeaderValue.TryDecodeBase64(const Text: string; out Bytes: TBytes): Boolean;
@@ -201,7 +201,8 @@ begin
   if not IsParsed then
     Exit(False);
 
-  if Wanted.Port = '' then
+  const PortIsEmpty = (Wanted.Port = '');
+  if PortIsEmpty then
     Wanted.Port := Wanted.DefaultPort;
   if Allowed.Port = '' then
     Allowed.Port := Allowed.DefaultPort;
@@ -214,7 +215,8 @@ end;
 class function TMCPOriginPolicy.IsAllowed(const Origin: string; const AllowList: TArray<string>): Boolean;
 begin
   var Value := Origin.Trim;
-  if Value = '' then
+  const ValueIsEmpty = (Value = '');
+  if ValueIsEmpty then
     Exit(True);
   if SameText(Value, 'null') then
     Exit(False);

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -231,8 +231,8 @@ procedure TMCPIdHTTPServer.CloseSubscriptions;
 var
   Hub: IMCPSubscriptionHub;
 begin
-  if not Assigned(FManagerRegistry)
-    or not Supports(FManagerRegistry.GetManagerForMethod(MCP_METHOD_SUBSCRIPTIONS_LISTEN), IMCPSubscriptionHub, Hub) then
+  if not Assigned(FManagerRegistry) or
+    not Supports(FManagerRegistry.GetManagerForMethod(MCP_METHOD_SUBSCRIPTIONS_LISTEN), IMCPSubscriptionHub, Hub) then
     Exit;
 
   var Deadline := TThread.GetTickCount64 + SUBSCRIPTION_CLOSE_GRACE_MS;
@@ -261,7 +261,8 @@ begin
   for var I := 0 to FHTTPServer.Bindings.Count - 1 do
   begin
     var Binding := FHTTPServer.Bindings[I];
-    if Binding.IPVersion = Id_IPv6 then
+    const IsId_IPv6 = (Binding.IPVersion = Id_IPv6);
+    if IsId_IPv6 then
       Result := Result + [Format('[%s]:%d', [Binding.IP, Binding.Port])]
     else
       Result := Result + [Format('%s:%d', [Binding.IP, Binding.Port])];
@@ -288,7 +289,8 @@ begin
     Host := FSettings.Host.Trim;
   end;
 
-  if Address <> '' then
+  const HasAddress = (Address <> '');
+  if HasAddress then
   begin
     if (Address = ANY_IPV4) or (Address = ANY_IPV6) then
       TLogger.Warning('BindAddress ' + Address + ': the server is reachable from every network interface');
@@ -350,7 +352,8 @@ begin
   TLogger.Info('SSL configured successfully');
   TLogger.Info('Certificate: ' + FSettings.SSLCertFile);
   TLogger.Info('Private Key: ' + FSettings.SSLKeyFile);
-  if FSettings.SSLRootCertFile <> '' then
+  const HasSSLRootCertFile = (FSettings.SSLRootCertFile <> '');
+  if HasSSLRootCertFile then
     TLogger.Info('Root Certificate: ' + FSettings.SSLRootCertFile);
 end;
 
@@ -429,14 +432,15 @@ begin
       Exit;
     end;
 
-    if Assigned(FAuthorizer) and (RequestInfo.CommandType = hcGET)
-      and IsProtectedResourceMetadataPath(RequestInfo.Document) then
+    if Assigned(FAuthorizer) and (RequestInfo.CommandType = hcGET) and
+      IsProtectedResourceMetadataPath(RequestInfo.Document) then
     begin
       HandleProtectedResourceMetadata(ResponseInfo);
       Exit;
     end;
 
-    if RequestInfo.Document <> Endpoint then
+    const IsNotEndpoint = (RequestInfo.Document <> Endpoint);
+    if IsNotEndpoint then
     begin
       SendEmpty(ResponseInfo, HTTP_STATUS_NOT_FOUND);
       Exit;
@@ -468,7 +472,8 @@ begin
     Exit;
 
   var List := FSettings.AllowedOrigins;
-  if List.Trim = '' then
+  const ListIsEmpty = (List.Trim = '');
+  if ListIsEmpty then
     Exit;
 
   for var Entry in List.Split([',']) do
@@ -542,9 +547,13 @@ begin
     var Versions := TJSONArray.Create;
     Info.AddPair('protocolVersions', Versions);
     for var Version in MCP_MODERN_PROTOCOL_VERSIONS do
+    begin
       Versions.Add(Version);
+    end;
     for var Version in MCP_LEGACY_PROTOCOL_VERSIONS do
+    begin
       Versions.Add(Version);
+    end;
     SendJson(ResponseInfo, HTTP_STATUS_OK, Info.ToJSON);
   finally
     Info.Free;
@@ -556,8 +565,8 @@ begin
   var Endpoint := DEFAULT_ENDPOINT;
   if Assigned(FSettings) then
     Endpoint := FSettings.Endpoint;
-  Result := (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH)
-    or (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH + Endpoint);
+  Result := (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH) or
+    (Document = TMCPProtectedResourceMetadata.WELL_KNOWN_PATH + Endpoint);
 end;
 
 function TMCPIdHTTPServer.ResourceUri: string;
@@ -565,7 +574,8 @@ begin
   Result := '';
   if Assigned(FSettings) then
     Result := FSettings.ResourceUri.Trim;
-  if Result <> '' then
+  const HasResult = (Result <> '');
+  if HasResult then
     Exit;
 
   Result := Format('%s://%s:%d%s', [FSettings.Protocol.ToLower, FSettings.Host.ToLower, FPort, FSettings.Endpoint]);
@@ -720,8 +730,8 @@ function TMCPIdHTTPServer.IsBodyWithinLimits(RequestInfo: TIdHTTPRequestInfo; Re
   const Body: string): Boolean;
 begin
   const Limit = MaxBodyBytes;
-  const IsTooLarge = Assigned(RequestInfo.PostStream)
-    and ((RequestInfo.PostStream is TMCPDiscardedBody) or (RequestInfo.PostStream.Size > Limit));
+  const IsTooLarge = Assigned(RequestInfo.PostStream) and
+    ((RequestInfo.PostStream is TMCPDiscardedBody) or (RequestInfo.PostStream.Size > Limit));
   if IsTooLarge then
   begin
     SendJsonRpcError(ResponseInfo, HTTP_PAYLOAD_TOO_LARGE, JSONRPC_INVALID_REQUEST,
@@ -745,7 +755,8 @@ procedure TMCPIdHTTPServer.SendOutcome(RequestInfo: TIdHTTPRequestInfo; Response
 begin
   if Outcome.Era = TMCPProtocolEra.Legacy then
     EchoLegacySessionId(RequestInfo, ResponseInfo);
-  if Outcome.RequiredScope <> '' then
+  const HasRequiredScope = (Outcome.RequiredScope <> '');
+  if HasRequiredScope then
     ResponseInfo.CustomHeaders.Values[HEADER_WWW_AUTHENTICATE] :=
       TMCPBearerChallenge.Build(ResourceMetadataUrl, TMCPAuthChallenge.InsufficientScope(Outcome.RequiredScope));
 

--- a/src/Server/MCPServer.StdioTransport.pas
+++ b/src/Server/MCPServer.StdioTransport.pas
@@ -210,7 +210,8 @@ begin
     Exit;
   if Assigned(Context) then
     Context.Cancel;
-  if Reason <> '' then
+  const HasReason = (Reason <> '');
+  if HasReason then
     TLogger.Info(Format('Request %s cancelled by the client: %s', [RequestId.AsText, Reason]))
   else
     TLogger.Info(Format('Request %s cancelled by the client', [RequestId.AsText]));
@@ -235,7 +236,9 @@ begin
       FLock.Leave;
     end;
     for var Context in Contexts do
+    begin
       Context.Cancel;
+    end;
   finally
     Contexts.Free;
   end;

--- a/src/Tools/MCPServer.Tool.InputRequiredSamples.pas
+++ b/src/Tools/MCPServer.Tool.InputRequiredSamples.pas
@@ -168,7 +168,8 @@ begin
   var Name := '';
   if Context.TryGetInputResponse(KEY_USER_NAME, Response) then
     Name := TMCPInputResponse.ElicitationField(Response, FIELD_NAME);
-  if Name = '' then
+  const NameIsEmpty = (Name = '');
+  if NameIsEmpty then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
       .AddElicitation(KEY_USER_NAME, ASK_NAME, TMCPInputRequests.FieldSchema(FIELD_NAME)));
 
@@ -191,7 +192,8 @@ begin
   var Answer := '';
   if Context.TryGetInputResponse(KEY_CAPITAL_QUESTION, Response) then
     Answer := TMCPInputResponse.SamplingText(Response);
-  if Answer = '' then
+  const AnswerIsEmpty = (Answer = '');
+  if AnswerIsEmpty then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
       .AddSampling(KEY_CAPITAL_QUESTION, CAPITAL_QUESTION, SAMPLING_MAX_TOKENS));
 
@@ -211,8 +213,8 @@ function TListRootsInputTool.ExecuteWithContext(const Params: TNoParams; const C
 var
   Response: TJSONObject;
 begin
-  if not Context.TryGetInputResponse(KEY_CLIENT_ROOTS, Response)
-    or not Assigned(TMCPInputResponse.Roots(Response)) then
+  if not Context.TryGetInputResponse(KEY_CLIENT_ROOTS, Response) or
+    not Assigned(TMCPInputResponse.Roots(Response)) then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create.AddListRoots(KEY_CLIENT_ROOTS));
 
   Result := TMCPToolResult.Text(TInputSample.DescribeRoots(TMCPInputResponse.Roots(Response)));
@@ -231,8 +233,8 @@ function TRequestStateInputTool.ExecuteWithContext(const Params: TNoParams; cons
 var
   Response: TJSONObject;
 begin
-  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
+  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response) and
+    (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   var HasState := Assigned(Context.RequestState) and Assigned(Context.RequestState.GetValue(STATE_NONCE));
   if not Confirmed or not HasState then
   begin
@@ -259,10 +261,10 @@ function TMultipleInputsTool.ExecuteWithContext(const Params: TNoParams; const C
 var
   NameResponse, GreetingResponse, RootsResponse: TJSONObject;
 begin
-  var Complete := Context.TryGetInputResponse(KEY_USER_NAME, NameResponse)
-    and Context.TryGetInputResponse(KEY_GREETING, GreetingResponse)
-    and Context.TryGetInputResponse(KEY_CLIENT_ROOTS, RootsResponse)
-    and Assigned(Context.RequestState);
+  var Complete := Context.TryGetInputResponse(KEY_USER_NAME, NameResponse) and
+    Context.TryGetInputResponse(KEY_GREETING, GreetingResponse) and
+    Context.TryGetInputResponse(KEY_CLIENT_ROOTS, RootsResponse) and
+    Assigned(Context.RequestState);
   if not Complete then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
       .AddElicitation(KEY_USER_NAME, ASK_NAME, TMCPInputRequests.FieldSchema(FIELD_NAME))
@@ -301,7 +303,8 @@ begin
     var Name := '';
     if Context.TryGetInputResponse(KEY_STEP1, Response) then
       Name := TMCPInputResponse.ElicitationField(Response, FIELD_NAME);
-    if Name = '' then
+    const NameIsEmpty = (Name = '');
+    if NameIsEmpty then
       raise EMCPInputRequired.Create(TMCPInputRequests.Create
         .AddElicitation(KEY_STEP1, ASK_STEP_ONE, TMCPInputRequests.FieldSchema(FIELD_NAME)), TInputSample.NewState(1));
 
@@ -314,7 +317,8 @@ begin
   var Color := '';
   if Context.TryGetInputResponse(KEY_STEP2, Response) then
     Color := TMCPInputResponse.ElicitationField(Response, FIELD_COLOR);
-  if Color = '' then
+  const ColorIsEmpty = (Color = '');
+  if ColorIsEmpty then
   begin
     var State := TInputSample.NewState(2);
     State.AddPair(STATE_NAME, Context.RequestState.GetValue<string>(STATE_NAME, ''));
@@ -339,8 +343,8 @@ function TTamperedStateInputTool.ExecuteWithContext(const Params: TNoParams; con
 var
   Response: TJSONObject;
 begin
-  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
+  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response) and
+    (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   if not Confirmed or not Assigned(Context.RequestState) then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
       .AddElicitation(KEY_CONFIRM, ASK_CONFIRM, TMCPInputRequests.FieldSchema(FIELD_OK, SCHEMA_TYPE_BOOLEAN)), TInputSample.NewState(1));
@@ -385,7 +389,8 @@ begin
         Requests.AddListRoots(KEY_CLIENT_ROOTS);
     end;
 
-    if Requests.Count > 0 then
+    const HasRequests = (Requests.Count > 0);
+    if HasRequests then
     begin
       var Pending := Requests;
       Requests := nil;
@@ -395,7 +400,8 @@ begin
     Requests.Free;
   end;
 
-  if Length(Answers) = 0 then
+  const AnswersIsEmpty = (Length(Answers) = 0);
+  if AnswersIsEmpty then
     Result := TMCPToolResult.Text('The client declared no capability this tool can ask input through')
   else
     Result := TMCPToolResult.Text(string.Join('; ', Answers));
@@ -430,8 +436,8 @@ var
   Response: TJSONObject;
 begin
   Context.Log('info', 'Asking the client to confirm', TOOL_STREAMING_ELICITATION);
-  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response)
-    and (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
+  var Confirmed := Context.TryGetInputResponse(KEY_CONFIRM, Response) and
+    (TMCPInputResponse.ElicitationField(Response, FIELD_OK) = VALUE_TRUE);
   if not Confirmed then
     raise EMCPInputRequired.Create(TMCPInputRequests.Create
       .AddElicitation(KEY_CONFIRM, ASK_CONFIRM, TMCPInputRequests.FieldSchema(FIELD_OK, SCHEMA_TYPE_BOOLEAN)));

--- a/src/Tools/MCPServer.Tool.Result.pas
+++ b/src/Tools/MCPServer.Tool.Result.pas
@@ -185,8 +185,8 @@ begin
   try
     Result.AddPair(MCP_KEY_CONTENT, BuildContent(Era));
 
-    if Assigned(FStructuredContent)
-      and ((Era = TMCPProtocolEra.Modern) or (FStructuredContent is TJSONObject)) then
+    if Assigned(FStructuredContent) and
+      ((Era = TMCPProtocolEra.Modern) or (FStructuredContent is TJSONObject)) then
       Result.AddPair('structuredContent', FStructuredContent.Clone as TJSONValue);
 
     if FIsError then

--- a/tests/MCPServer.Tests.Authorization.pas
+++ b/tests/MCPServer.Tests.Authorization.pas
@@ -35,16 +35,35 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure StaticBearer_AcceptsListedTokens_RejectsOthers;
-    [Test] procedure StaticBearer_NeedsAToken;
-    [Test] procedure ConstantTime_ComparesWholeToken;
-    [Test] procedure Principal_HasScope_HonoursWildcard;
-    [Test] procedure OAuth_RejectsWrongAudience_Expiry_AndScope;
-    [Test] procedure OAuth_AcceptsAudienceArray_AndScopeArray;
-    [Test] procedure OAuth_NeedsAnAudience;
-    [Test] procedure Challenge_Build_QuotesParameters;
-    [Test] procedure Metadata_Build_DropsOfflineAccess;
-    [Test] procedure Introspection_PostsTokenWithClientCredentials;
+    [Test]
+    procedure StaticBearer_AcceptsListedTokens_RejectsOthers;
+
+    [Test]
+    procedure StaticBearer_NeedsAToken;
+
+    [Test]
+    procedure ConstantTime_ComparesWholeToken;
+
+    [Test]
+    procedure Principal_HasScope_HonoursWildcard;
+
+    [Test]
+    procedure OAuth_RejectsWrongAudience_Expiry_AndScope;
+
+    [Test]
+    procedure OAuth_AcceptsAudienceArray_AndScopeArray;
+
+    [Test]
+    procedure OAuth_NeedsAnAudience;
+
+    [Test]
+    procedure Challenge_Build_QuotesParameters;
+
+    [Test]
+    procedure Metadata_Build_DropsOfflineAccess;
+
+    [Test]
+    procedure Introspection_PostsTokenWithClientCredentials;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Cancellation.pas
+++ b/tests/MCPServer.Tests.Cancellation.pas
@@ -44,18 +44,41 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Cancel_SetsIsCancelled_And_CheckRaises;
-    [Test] procedure Progress_WithoutToken_SendsNothing;
-    [Test] procedure Progress_NotificationShape;
-    [Test] procedure Progress_IntegerToken_IsKept;
-    [Test] procedure Progress_Monotonic_And_Throttled;
-    [Test] procedure Progress_AfterCancel_SendsNothing;
-    [Test] procedure Progress_WithoutSink_IsNoOp;
-    [Test] procedure Log_WithoutLogLevel_SendsNothing;
-    [Test] procedure Log_AtOrAboveLevel_HasNotificationShape;
-    [Test] procedure Log_AfterCancel_SendsNothing;
-    [Test] procedure Processor_CancelledRequest_HasNoResponse;
-    [Test] procedure Processor_CancelledNotification_ReachesTracker;
+    [Test]
+    procedure Cancel_SetsIsCancelled_And_CheckRaises;
+
+    [Test]
+    procedure Progress_WithoutToken_SendsNothing;
+
+    [Test]
+    procedure Progress_NotificationShape;
+
+    [Test]
+    procedure Progress_IntegerToken_IsKept;
+
+    [Test]
+    procedure Progress_Monotonic_And_Throttled;
+
+    [Test]
+    procedure Progress_AfterCancel_SendsNothing;
+
+    [Test]
+    procedure Progress_WithoutSink_IsNoOp;
+
+    [Test]
+    procedure Log_WithoutLogLevel_SendsNothing;
+
+    [Test]
+    procedure Log_AtOrAboveLevel_HasNotificationShape;
+
+    [Test]
+    procedure Log_AfterCancel_SendsNothing;
+
+    [Test]
+    procedure Processor_CancelledRequest_HasNoResponse;
+
+    [Test]
+    procedure Processor_CancelledNotification_ReachesTracker;
   end;
 
 implementation
@@ -121,7 +144,8 @@ end;
 function TCancellationTests.NewContext(const MetaJson: string): IMCPRequestContext;
 begin
   var Meta: TJSONObject := nil;
-  if MetaJson <> '' then
+  const HasMetaJson = (MetaJson <> '');
+  if HasMetaJson then
     Meta := TJSONObject.ParseJSONValue(MetaJson) as TJSONObject;
   try
     Result := TMCPRequestContext.Create(TMCPProtocolEra.Modern, MCP_LATEST_PROTOCOL_VERSION, 'tools/call',

--- a/tests/MCPServer.Tests.Capabilities.pas
+++ b/tests/MCPServer.Tests.Capabilities.pas
@@ -9,9 +9,14 @@ type
   [TestFixture]
   TCapabilityBuilderTests = class
   public
-    [Test] procedure Registry_YieldsAllManagersInRegistrationOrder;
-    [Test] procedure Registry_NeverEmitsLogging;
-    [Test] procedure RegistryWithoutEnumeration_YieldsDefaults;
+    [Test]
+    procedure Registry_YieldsAllManagersInRegistrationOrder;
+
+    [Test]
+    procedure Registry_NeverEmitsLogging;
+
+    [Test]
+    procedure RegistryWithoutEnumeration_YieldsDefaults;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.CompletionManager.pas
+++ b/tests/MCPServer.Tests.CompletionManager.pas
@@ -19,15 +19,32 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure RefPrompt_KnownArgument_ReturnsFilteredValues;
-    [Test] procedure RefPrompt_UnknownPrompt_IsInvalidParams;
-    [Test] procedure RefPrompt_MissingRefName_IsInvalidParams;
-    [Test] procedure RefResource_Template_Completes;
-    [Test] procedure RefResource_UnknownUri_IsNotFound;
-    [Test] procedure RefResource_UnknownUri_Legacy_IsLegacyNotFound;
-    [Test] procedure MissingArgument_IsInvalidParams;
-    [Test] procedure UnknownRefType_IsInvalidParams;
-    [Test] procedure CapabilitiesInclude_Completions;
+    [Test]
+    procedure RefPrompt_KnownArgument_ReturnsFilteredValues;
+
+    [Test]
+    procedure RefPrompt_UnknownPrompt_IsInvalidParams;
+
+    [Test]
+    procedure RefPrompt_MissingRefName_IsInvalidParams;
+
+    [Test]
+    procedure RefResource_Template_Completes;
+
+    [Test]
+    procedure RefResource_UnknownUri_IsNotFound;
+
+    [Test]
+    procedure RefResource_UnknownUri_Legacy_IsLegacyNotFound;
+
+    [Test]
+    procedure MissingArgument_IsInvalidParams;
+
+    [Test]
+    procedure UnknownRefType_IsInvalidParams;
+
+    [Test]
+    procedure CapabilitiesInclude_Completions;
   end;
 
 implementation
@@ -59,7 +76,9 @@ begin
     try
       var Values := Json.FindValue('completion.values') as TJSONArray;
       for var Value in Values do
+      begin
         Assert.IsTrue(Value.Value.ToUpper.StartsWith('IN'), 'every suggestion starts with the typed prefix');
+      end;
       Assert.IsFalse(Json.GetValue<Boolean>('completion.hasMore'));
     finally
       Json.Free;

--- a/tests/MCPServer.Tests.Constants.pas
+++ b/tests/MCPServer.Tests.Constants.pas
@@ -9,13 +9,26 @@ type
   [TestFixture]
   TProtocolConstantsTests = class
   public
-    [Test] procedure JsonRpcErrorCodes_HaveSpecValues;
-    [Test] procedure ProcessorAliases_MatchTypes;
-    [Test] procedure McpErrorCodes_HaveSpecValues;
-    [Test] procedure ProtocolVersions_AreConsistent;
-    [Test] procedure MetaKeys_UseReservedPrefix;
-    [Test] procedure CacheableMethods_MatchSpec;
-    [Test] procedure IsJsonString_AcceptsStringsOnly;
+    [Test]
+    procedure JsonRpcErrorCodes_HaveSpecValues;
+
+    [Test]
+    procedure ProcessorAliases_MatchTypes;
+
+    [Test]
+    procedure McpErrorCodes_HaveSpecValues;
+
+    [Test]
+    procedure ProtocolVersions_AreConsistent;
+
+    [Test]
+    procedure MetaKeys_UseReservedPrefix;
+
+    [Test]
+    procedure CacheableMethods_MatchSpec;
+
+    [Test]
+    procedure IsJsonString_AcceptsStringsOnly;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Golden.Legacy.pas
+++ b/tests/MCPServer.Tests.Golden.Legacy.pas
@@ -19,47 +19,119 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Initialize_2025_06_18;
-    [Test] procedure Initialize_2025_11_25;
-    [Test] procedure Initialize_2025_03_26;
-    [Test] procedure Initialize_UnknownVersion;
-    [Test] procedure Initialize_WithoutParams;
-    [Test] procedure Notifications_Initialized;
-    [Test] procedure Ping;
+    [Test]
+    procedure Initialize_2025_06_18;
 
-    [Test] procedure Tools_List;
-    [Test] procedure Tools_Call_Echo;
-    [Test] procedure Tools_Call_Echo_Unicode;
-    [Test] procedure Tools_Call_Calculate;
-    [Test] procedure Tools_Call_Calculate_DivideByZero;
-    [Test] procedure Tools_Call_GetTime;
-    [Test] procedure Tools_Call_ListFiles;
-    [Test] procedure Tools_Call_ListFiles_OutsideAllowedDirectory;
-    [Test] procedure Tools_Call_MissingArguments;
-    [Test] procedure Tools_Call_UnknownTool;
-    [Test] procedure Tools_Call_InvalidArgumentType;
-    [Test] procedure Tools_Call_WithoutParams;
-    [Test] procedure Tools_Call_EmptyName;
+    [Test]
+    procedure Initialize_2025_11_25;
 
-    [Test] procedure Resources_List;
-    [Test] procedure Resources_Read_ProjectInfo;
-    [Test] procedure Resources_Read_ProjectReadme;
-    [Test] procedure Resources_Read_LogsRecent;
-    [Test] procedure Resources_Read_ServerStatus;
-    [Test] procedure Resources_Read_UnknownUri;
-    [Test] procedure Resources_Read_WithoutParams;
-    [Test] procedure Resources_Templates_List;
+    [Test]
+    procedure Initialize_2025_03_26;
 
-    [Test] procedure UnknownMethod;
-    [Test] procedure ServerDiscover_WithoutMeta;
-    [Test] procedure ParseError;
-    [Test] procedure EmptyBody;
-    [Test] procedure RequestNotAnObject;
-    [Test] procedure Id_Null;
-    [Test] procedure Id_String;
-    [Test] procedure MissingJsonRpcField;
-    [Test] procedure MissingMethod;
-    [Test] procedure ParamsNotAnObject;
+    [Test]
+    procedure Initialize_UnknownVersion;
+
+    [Test]
+    procedure Initialize_WithoutParams;
+
+    [Test]
+    procedure Notifications_Initialized;
+
+    [Test]
+    procedure Ping;
+
+    [Test]
+    procedure Tools_List;
+
+    [Test]
+    procedure Tools_Call_Echo;
+
+    [Test]
+    procedure Tools_Call_Echo_Unicode;
+
+    [Test]
+    procedure Tools_Call_Calculate;
+
+    [Test]
+    procedure Tools_Call_Calculate_DivideByZero;
+
+    [Test]
+    procedure Tools_Call_GetTime;
+
+    [Test]
+    procedure Tools_Call_ListFiles;
+
+    [Test]
+    procedure Tools_Call_ListFiles_OutsideAllowedDirectory;
+
+    [Test]
+    procedure Tools_Call_MissingArguments;
+
+    [Test]
+    procedure Tools_Call_UnknownTool;
+
+    [Test]
+    procedure Tools_Call_InvalidArgumentType;
+
+    [Test]
+    procedure Tools_Call_WithoutParams;
+
+    [Test]
+    procedure Tools_Call_EmptyName;
+
+    [Test]
+    procedure Resources_List;
+
+    [Test]
+    procedure Resources_Read_ProjectInfo;
+
+    [Test]
+    procedure Resources_Read_ProjectReadme;
+
+    [Test]
+    procedure Resources_Read_LogsRecent;
+
+    [Test]
+    procedure Resources_Read_ServerStatus;
+
+    [Test]
+    procedure Resources_Read_UnknownUri;
+
+    [Test]
+    procedure Resources_Read_WithoutParams;
+
+    [Test]
+    procedure Resources_Templates_List;
+
+    [Test]
+    procedure UnknownMethod;
+
+    [Test]
+    procedure ServerDiscover_WithoutMeta;
+
+    [Test]
+    procedure ParseError;
+
+    [Test]
+    procedure EmptyBody;
+
+    [Test]
+    procedure RequestNotAnObject;
+
+    [Test]
+    procedure Id_Null;
+
+    [Test]
+    procedure Id_String;
+
+    [Test]
+    procedure MissingJsonRpcField;
+
+    [Test]
+    procedure MissingMethod;
+
+    [Test]
+    procedure ParamsNotAnObject;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Golden.Modern.pas
+++ b/tests/MCPServer.Tests.Golden.Modern.pas
@@ -19,23 +19,56 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Server_Discover;
-    [Test] procedure Server_Discover_AfterInitialize;
-    [Test] procedure Server_Discover_WithoutMeta;
-    [Test] procedure Tools_List;
-    [Test] procedure Tools_Call_Echo;
-    [Test] procedure Tools_Call_UnknownTool;
-    [Test] procedure Resources_List;
-    [Test] procedure Resources_Read_ProjectInfo;
-    [Test] procedure Resources_Templates_List;
-    [Test] procedure Ping_IsNotFound;
-    [Test] procedure UnknownMethod;
-    [Test] procedure UnknownProtocolVersion;
-    [Test] procedure MissingClientCapabilities;
-    [Test] procedure InvalidLogLevel;
-    [Test] procedure Initialize_WithModernMeta_IsNotFound;
-    [Test] procedure Id_Null;
-    [Test] procedure MissingJsonRpcField;
+    [Test]
+    procedure Server_Discover;
+
+    [Test]
+    procedure Server_Discover_AfterInitialize;
+
+    [Test]
+    procedure Server_Discover_WithoutMeta;
+
+    [Test]
+    procedure Tools_List;
+
+    [Test]
+    procedure Tools_Call_Echo;
+
+    [Test]
+    procedure Tools_Call_UnknownTool;
+
+    [Test]
+    procedure Resources_List;
+
+    [Test]
+    procedure Resources_Read_ProjectInfo;
+
+    [Test]
+    procedure Resources_Templates_List;
+
+    [Test]
+    procedure Ping_IsNotFound;
+
+    [Test]
+    procedure UnknownMethod;
+
+    [Test]
+    procedure UnknownProtocolVersion;
+
+    [Test]
+    procedure MissingClientCapabilities;
+
+    [Test]
+    procedure InvalidLogLevel;
+
+    [Test]
+    procedure Initialize_WithModernMeta_IsNotFound;
+
+    [Test]
+    procedure Id_Null;
+
+    [Test]
+    procedure MissingJsonRpcField;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Golden.pas
+++ b/tests/MCPServer.Tests.Golden.pas
@@ -89,7 +89,8 @@ const
 class function TGoldenFiles.GoldenRoot: string;
 begin
   Result := GetEnvironmentVariable(GOLDEN_DIR_ENVIRONMENT_VARIABLE);
-  if Result <> '' then
+  const HasResult = (Result <> '');
+  if HasResult then
     Exit(TPath.GetFullPath(Result));
 
   var Dir := ExtractFilePath(ParamStr(0));
@@ -133,7 +134,9 @@ begin
       Result := Result + '[*';
       Inc(I);
       while (I <= Length(Segment)) and CharInSet(Segment[I], ['0'..'9']) do
+      begin
         Inc(I);
+      end;
     end
     else
     begin
@@ -191,14 +194,18 @@ begin
   begin
     var Obj := TJSONObject.Create;
     for var Pair in TJSONObject(Value) do
+    begin
       Obj.AddPair(Pair.JsonString.Value, Shape(Pair.JsonValue));
+    end;
     Result := Obj;
   end
   else if Value is TJSONArray then
   begin
     var Arr := TJSONArray.Create;
     for var Item in TJSONArray(Value) do
+    begin
       Arr.AddElement(Shape(Item));
+    end;
     Result := Arr;
   end
   else if Value is TJSONNull then
@@ -219,7 +226,8 @@ begin
   for var Pair in Obj do
   begin
     var ChildPath := Pair.JsonString.Value;
-    if Path <> '' then
+    const HasPath = (Path <> '');
+    if HasPath then
       ChildPath := Path + '.' + ChildPath;
 
     if MatchesAny(ChildPath, MaskPaths) then
@@ -290,7 +298,9 @@ begin
   var Arr := TJSONArray(Value);
   SetLength(Result, Arr.Count);
   for var I := 0 to Arr.Count - 1 do
+  begin
     Result[I] := Arr.Items[I].Value;
+  end;
 end;
 
 function TGoldenCase.GetRequestBody: string;
@@ -362,7 +372,8 @@ begin
   RemoveExpected;
 
   var Parsed: TJSONValue := nil;
-  if ResponseBody.Trim <> '' then
+  const HasResponseBody = (ResponseBody.Trim <> '');
+  if HasResponseBody then
     Parsed := TJSONObject.ParseJSONValue(ResponseBody);
 
   if Assigned(Parsed) then
@@ -390,7 +401,8 @@ begin
   try
     var Response: string;
     var SavedDirectory := GetCurrentDir;
-    if GoldenCase.WorkingDirectory <> '' then
+    const HasWorkingDirectory = (GoldenCase.WorkingDirectory <> '');
+    if HasWorkingDirectory then
       SetCurrentDir(GoldenCase.WorkingDirectory);
     try
       Response := Process(GoldenCase.RequestBody);
@@ -406,7 +418,8 @@ begin
 
     var Expected := GoldenCase.ExpectedText;
     var Actual := GoldenCase.NormalizeResponse(Response);
-    if Expected <> Actual then
+    const IsNotActual = (Expected <> Actual);
+    if IsNotActual then
       raise EGoldenError.CreateFmt('Golden mismatch for %s/%s'#13#10'--- expected ---'#13#10'%s'#13#10'--- actual ---'#13#10'%s',
         [Suite, CaseName, Expected, Actual]);
   finally

--- a/tests/MCPServer.Tests.Http.pas
+++ b/tests/MCPServer.Tests.Http.pas
@@ -48,50 +48,137 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Notification_Is202WithEmptyBody;
-    [Test] procedure Get_IsMethodNotAllowedWithAllow;
-    [Test] procedure Delete_IsMethodNotAllowed;
-    [Test] procedure Options_Is204;
-    [Test] procedure WrongPath_Is404;
-    [Test] procedure Origin_NotAllowed_Is403WithJsonRpcBody_EvenWithCorsDisabled;
-    [Test] procedure Origin_LoopbackOnAnyPort_IsAllowed;
-    [Test] procedure Origin_Null_IsDenied;
-    [Test] procedure Origin_AllowListWithPortWildcard;
-    [Test] procedure Cors_HeadersOnlyWhenEnabled;
-    [Test] procedure Cors_PreflightReflectsRequestedHeaders;
-    [Test] procedure Legacy_UnknownMethod_Is200;
-    [Test] procedure Modern_UnknownMethod_Is404;
-    [Test] procedure Modern_MissingVersionHeader_Is400HeaderMismatch;
-    [Test] procedure Modern_UnsupportedVersion_Is400;
-    [Test] procedure Modern_MissingClientCapabilities_Is400;
-    [Test] procedure ModernHeader_WithoutMeta_Is400InvalidParams;
-    [Test] procedure Legacy_UnknownVersionHeader_Is400;
-    [Test] procedure Modern_McpMethodHeader_IsRequiredAndMustMatch;
-    [Test] procedure Modern_McpNameHeader_Base64IsDecoded;
-    [Test] procedure Modern_Discover_Is200;
-    [Test] procedure BodyTooLarge_Is413;
-    [Test] procedure NestingTooDeep_Is400;
-    [Test] procedure SessionId_IsEchoedForLegacyOnly;
-    [Test] procedure Sse_HasNoIdLine;
-    [Test] procedure Bind_DefaultIsLoopback;
-    [Test] procedure Bind_ExplicitAddress;
-    [Test] procedure EndpointInfoPath_AnswersJson;
-    [Test] procedure Progress_IsStreamedBeforeTheResponse;
-    [Test] procedure Progress_WithoutEventStreamAccept_IsPlainJson;
-    [Test] procedure Log_OnlyWithLogLevel_InMeta;
-    [Test] procedure InputRequired_StreamsAsFinalEvent;
-    [Test] procedure StreamedError_IsFinalEvent;
-    [Test] procedure Listen_StreamsAckAndChanges_UntilStopped;
-    [Test] procedure Listen_WithoutEventStreamAccept_IsInvalidRequest;
-    [Test] procedure Auth_MissingToken_Is401WithChallenge;
-    [Test] procedure Auth_WrongToken_Is401_InvalidToken;
-    [Test] procedure Auth_MalformedHeader_Is400;
-    [Test] procedure Auth_ValidToken_IsServed;
-    [Test] procedure Auth_PreflightAndMetadata_NeedNoToken;
-    [Test] procedure Auth_ScopedTool_Is403_WithInsufficientScope;
-    [Test] procedure Auth_ScopedTool_OnOpenServer_Is403;
-    [Test] procedure Host_NotAllowed_Is403;
-    [Test] procedure Rejection_CarriesCorsHeaders;
+    [Test]
+    procedure Notification_Is202WithEmptyBody;
+
+    [Test]
+    procedure Get_IsMethodNotAllowedWithAllow;
+
+    [Test]
+    procedure Delete_IsMethodNotAllowed;
+
+    [Test]
+    procedure Options_Is204;
+
+    [Test]
+    procedure WrongPath_Is404;
+
+    [Test]
+    procedure Origin_NotAllowed_Is403WithJsonRpcBody_EvenWithCorsDisabled;
+
+    [Test]
+    procedure Origin_LoopbackOnAnyPort_IsAllowed;
+
+    [Test]
+    procedure Origin_Null_IsDenied;
+
+    [Test]
+    procedure Origin_AllowListWithPortWildcard;
+
+    [Test]
+    procedure Cors_HeadersOnlyWhenEnabled;
+
+    [Test]
+    procedure Cors_PreflightReflectsRequestedHeaders;
+
+    [Test]
+    procedure Legacy_UnknownMethod_Is200;
+
+    [Test]
+    procedure Modern_UnknownMethod_Is404;
+
+    [Test]
+    procedure Modern_MissingVersionHeader_Is400HeaderMismatch;
+
+    [Test]
+    procedure Modern_UnsupportedVersion_Is400;
+
+    [Test]
+    procedure Modern_MissingClientCapabilities_Is400;
+
+    [Test]
+    procedure ModernHeader_WithoutMeta_Is400InvalidParams;
+
+    [Test]
+    procedure Legacy_UnknownVersionHeader_Is400;
+
+    [Test]
+    procedure Modern_McpMethodHeader_IsRequiredAndMustMatch;
+
+    [Test]
+    procedure Modern_McpNameHeader_Base64IsDecoded;
+
+    [Test]
+    procedure Modern_Discover_Is200;
+
+    [Test]
+    procedure BodyTooLarge_Is413;
+
+    [Test]
+    procedure NestingTooDeep_Is400;
+
+    [Test]
+    procedure SessionId_IsEchoedForLegacyOnly;
+
+    [Test]
+    procedure Sse_HasNoIdLine;
+
+    [Test]
+    procedure Bind_DefaultIsLoopback;
+
+    [Test]
+    procedure Bind_ExplicitAddress;
+
+    [Test]
+    procedure EndpointInfoPath_AnswersJson;
+
+    [Test]
+    procedure Progress_IsStreamedBeforeTheResponse;
+
+    [Test]
+    procedure Progress_WithoutEventStreamAccept_IsPlainJson;
+
+    [Test]
+    procedure Log_OnlyWithLogLevel_InMeta;
+
+    [Test]
+    procedure InputRequired_StreamsAsFinalEvent;
+
+    [Test]
+    procedure StreamedError_IsFinalEvent;
+
+    [Test]
+    procedure Listen_StreamsAckAndChanges_UntilStopped;
+
+    [Test]
+    procedure Listen_WithoutEventStreamAccept_IsInvalidRequest;
+
+    [Test]
+    procedure Auth_MissingToken_Is401WithChallenge;
+
+    [Test]
+    procedure Auth_WrongToken_Is401_InvalidToken;
+
+    [Test]
+    procedure Auth_MalformedHeader_Is400;
+
+    [Test]
+    procedure Auth_ValidToken_IsServed;
+
+    [Test]
+    procedure Auth_PreflightAndMetadata_NeedNoToken;
+
+    [Test]
+    procedure Auth_ScopedTool_Is403_WithInsufficientScope;
+
+    [Test]
+    procedure Auth_ScopedTool_OnOpenServer_Is403;
+
+    [Test]
+    procedure Host_NotAllowed_Is403;
+
+    [Test]
+    procedure Rejection_CarriesCorsHeaders;
   end;
 
 implementation
@@ -470,8 +557,8 @@ begin
   var Addresses := FServer.BoundAddresses;
   Assert.IsTrue(Length(Addresses) >= 1);
   for var Address in Addresses do
-    Assert.IsTrue(Address.StartsWith('127.0.0.1:') or Address.StartsWith('[::1]:')
-      or Address.StartsWith('[0:0:0:0:0:0:0:1]:'), Address);
+    Assert.IsTrue(Address.StartsWith('127.0.0.1:') or Address.StartsWith('[::1]:') or
+      Address.StartsWith('[0:0:0:0:0:0:0:1]:'), Address);
 end;
 
 procedure THttpTransportTests.Bind_ExplicitAddress;
@@ -595,7 +682,9 @@ begin
 
   var Deadline := TThread.GetTickCount64 + 2000;
   while (FHarness.SubscriptionsManager.ActiveCount = 0) and (TThread.GetTickCount64 < Deadline) do
+  begin
     Sleep(10);
+  end;
   Assert.AreEqual(1, FHarness.SubscriptionsManager.ActiveCount, 'the subscription is open');
 
   Post(Format(TRIGGER, ['test_trigger_tool_change']), [MODERN_VERSION_HEADER, 'Mcp-Method: tools/call', 'Mcp-Name: test_trigger_tool_change']);

--- a/tests/MCPServer.Tests.HttpHeaders.pas
+++ b/tests/MCPServer.Tests.HttpHeaders.pas
@@ -9,22 +9,53 @@ type
   [TestFixture]
   THttpHeadersTests = class
   public
-    [Test] procedure Decode_PlainAsciiValue_IsReturnedAsIs;
-    [Test] procedure Decode_SentinelValues_FromSpecTable;
-    [Test] procedure Decode_LiteralSentinelPattern_RoundTrips;
-    [Test] procedure Decode_BadPadding_Fails;
-    [Test] procedure Decode_InvalidBase64Characters_Fails;
-    [Test] procedure Decode_NonAsciiPlainValue_Fails;
-    [Test] procedure Decode_UppercaseMarkers_AreNotASentinel;
-    [Test] procedure Accept_ListsMediaTypesCaseInsensitively;
-    [Test] procedure Accept_WildcardDoesNotCount;
-    [Test] procedure Origin_LoopbackOnAnyPort_IsAllowed;
-    [Test] procedure Origin_AbsentAllowed_NullDenied;
-    [Test] procedure Origin_AllowListMatchesSchemeHostAndPort;
-    [Test] procedure Origin_PortWildcardAndAllowAll;
-    [Test] procedure Origin_DefaultPortEqualsExplicitPort;
-    [Test] procedure Host_AllowList_MatchesNameAndPort;
-    [Test] procedure NestingDepth_CountsObjectsAndArraysOutsideStrings;
+    [Test]
+    procedure Decode_PlainAsciiValue_IsReturnedAsIs;
+
+    [Test]
+    procedure Decode_SentinelValues_FromSpecTable;
+
+    [Test]
+    procedure Decode_LiteralSentinelPattern_RoundTrips;
+
+    [Test]
+    procedure Decode_BadPadding_Fails;
+
+    [Test]
+    procedure Decode_InvalidBase64Characters_Fails;
+
+    [Test]
+    procedure Decode_NonAsciiPlainValue_Fails;
+
+    [Test]
+    procedure Decode_UppercaseMarkers_AreNotASentinel;
+
+    [Test]
+    procedure Accept_ListsMediaTypesCaseInsensitively;
+
+    [Test]
+    procedure Accept_WildcardDoesNotCount;
+
+    [Test]
+    procedure Origin_LoopbackOnAnyPort_IsAllowed;
+
+    [Test]
+    procedure Origin_AbsentAllowed_NullDenied;
+
+    [Test]
+    procedure Origin_AllowListMatchesSchemeHostAndPort;
+
+    [Test]
+    procedure Origin_PortWildcardAndAllowAll;
+
+    [Test]
+    procedure Origin_DefaultPortEqualsExplicitPort;
+
+    [Test]
+    procedure Host_AllowList_MatchesNameAndPort;
+
+    [Test]
+    procedure NestingDepth_CountsObjectsAndArraysOutsideStrings;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Logger.pas
+++ b/tests/MCPServer.Tests.Logger.pas
@@ -17,10 +17,17 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure StdoutReserved_ForcesUseStdErr;
-    [Test] procedure StdoutReserved_RefusesUseStdErrFalse_AndWarnsOnce;
-    [Test] procedure StdoutReleased_AllowsUseStdErrFalseAgain;
-    [Test] procedure StdioTransport_Create_ReservesStdout;
+    [Test]
+    procedure StdoutReserved_ForcesUseStdErr;
+
+    [Test]
+    procedure StdoutReserved_RefusesUseStdErrFalse_AndWarnsOnce;
+
+    [Test]
+    procedure StdoutReleased_AllowsUseStdErrFalseAgain;
+
+    [Test]
+    procedure StdioTransport_Create_ReservesStdout;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Mrtr.pas
+++ b/tests/MCPServer.Tests.Mrtr.pas
@@ -18,24 +18,48 @@ type
   private
     function Base64Url(const Bytes: TBytes): string;
   public
-    [Test] procedure Seal_Open_RoundTripsState;
-    [Test] procedure Open_TamperedToken_Fails;
-    [Test] procedure Open_OtherMethodOrDigestOrPrincipal_Fails;
-    [Test] procedure Open_Expired_Fails;
-    [Test] procedure Open_OtherKey_Fails;
-    [Test] procedure DigestOf_IgnoresMetaInputResponsesAndRequestState;
-    [Test] procedure EmptyKey_IsEphemeral;
-    [Test] procedure EmptyKey_DiffersPerInstance;
-    [Test] procedure Open_PayloadIsNotAnObject_IsInvalidParams;
+    [Test]
+    procedure Seal_Open_RoundTripsState;
+
+    [Test]
+    procedure Open_TamperedToken_Fails;
+
+    [Test]
+    procedure Open_OtherMethodOrDigestOrPrincipal_Fails;
+
+    [Test]
+    procedure Open_Expired_Fails;
+
+    [Test]
+    procedure Open_OtherKey_Fails;
+
+    [Test]
+    procedure DigestOf_IgnoresMetaInputResponsesAndRequestState;
+
+    [Test]
+    procedure EmptyKey_IsEphemeral;
+
+    [Test]
+    procedure EmptyKey_DiffersPerInstance;
+
+    [Test]
+    procedure Open_PayloadIsNotAnObject_IsInvalidParams;
   end;
 
   [TestFixture]
   TInputRequestsTests = class
   public
-    [Test] procedure ToJson_HasMethodAndParamsPerKey;
-    [Test] procedure RequiredCapability_PerMethod;
-    [Test] procedure FieldSchema_IsObjectWithRequiredField;
-    [Test] procedure InputResponse_Readers;
+    [Test]
+    procedure ToJson_HasMethodAndParamsPerKey;
+
+    [Test]
+    procedure RequiredCapability_PerMethod;
+
+    [Test]
+    procedure FieldSchema_IsObjectWithRequiredField;
+
+    [Test]
+    procedure InputResponse_Readers;
   end;
 
   [TestFixture]
@@ -53,25 +77,62 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Elicitation_RoundOne_IsInputRequired_WithResultType;
-    [Test] procedure Elicitation_RoundTwo_Completes;
-    [Test] procedure Elicitation_WrongKey_ReRequests;
-    [Test] procedure Elicitation_ExtraKeys_AreIgnored;
-    [Test] procedure InputResponses_NotObject_IsInvalidParams;
-    [Test] procedure InputResponses_ValueNotObject_IsInvalidParams;
-    [Test] procedure Sampling_RoundTrip;
-    [Test] procedure ListRoots_RoundTrip;
-    [Test] procedure RequestState_RoundTrip_MentionsStateOk;
-    [Test] procedure RequestState_Tampered_IsInvalidParams;
-    [Test] procedure RequestState_OtherTool_IsInvalidParams;
-    [Test] procedure MultipleInputs_RoundTrip;
-    [Test] procedure MultiRound_StateChangesPerRound;
-    [Test] procedure Capabilities_OnlyDeclaredKinds;
-    [Test] procedure Capabilities_UndeclaredKind_Is32021;
-    [Test] procedure MissingCapabilityTool_Is32021_WithRequiredCapabilities;
-    [Test] procedure Legacy_IsInternalError;
-    [Test] procedure Prompt_RoundTrip;
-    [Test] procedure ToolsList_IsNeverInputRequired;
+    [Test]
+    procedure Elicitation_RoundOne_IsInputRequired_WithResultType;
+
+    [Test]
+    procedure Elicitation_RoundTwo_Completes;
+
+    [Test]
+    procedure Elicitation_WrongKey_ReRequests;
+
+    [Test]
+    procedure Elicitation_ExtraKeys_AreIgnored;
+
+    [Test]
+    procedure InputResponses_NotObject_IsInvalidParams;
+
+    [Test]
+    procedure InputResponses_ValueNotObject_IsInvalidParams;
+
+    [Test]
+    procedure Sampling_RoundTrip;
+
+    [Test]
+    procedure ListRoots_RoundTrip;
+
+    [Test]
+    procedure RequestState_RoundTrip_MentionsStateOk;
+
+    [Test]
+    procedure RequestState_Tampered_IsInvalidParams;
+
+    [Test]
+    procedure RequestState_OtherTool_IsInvalidParams;
+
+    [Test]
+    procedure MultipleInputs_RoundTrip;
+
+    [Test]
+    procedure MultiRound_StateChangesPerRound;
+
+    [Test]
+    procedure Capabilities_OnlyDeclaredKinds;
+
+    [Test]
+    procedure Capabilities_UndeclaredKind_Is32021;
+
+    [Test]
+    procedure MissingCapabilityTool_Is32021_WithRequiredCapabilities;
+
+    [Test]
+    procedure Legacy_IsInternalError;
+
+    [Test]
+    procedure Prompt_RoundTrip;
+
+    [Test]
+    procedure ToolsList_IsNeverInputRequired;
   end;
 
 implementation
@@ -358,7 +419,8 @@ begin
   var Meta := Format('"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":%s}',
     [Capabilities]);
   var Params := ParamsJson;
-  if Params = '' then
+  const ParamsIsEmpty = (Params = '');
+  if ParamsIsEmpty then
     Params := Meta
   else
     Params := Params + ',' + Meta;
@@ -372,7 +434,8 @@ end;
 function TInputRequiredFlowTests.CallTool(const Name, ExtraParams: string; const Capabilities: string): TJSONObject;
 begin
   var Params := Format('"name":"%s","arguments":{}', [Name]);
-  if ExtraParams <> '' then
+  const HasExtraParams = (ExtraParams <> '');
+  if HasExtraParams then
     Params := Params + ',' + ExtraParams;
   Result := Call('tools/call', Params, Capabilities);
 end;

--- a/tests/MCPServer.Tests.Processor.pas
+++ b/tests/MCPServer.Tests.Processor.pas
@@ -39,23 +39,56 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Modern_UnknownMethod_Is404;
-    [Test] procedure Legacy_UnknownMethod_Is200;
-    [Test] procedure ParseError_ModernHeader_Is400_LegacyIs200;
-    [Test] procedure Modern_MetaValidationError_Is400;
-    [Test] procedure Modern_ApplicationInvalidParams_Is200;
-    [Test] procedure Modern_ToolsList_HasEnvelopeAndCacheHints;
-    [Test] procedure Modern_ToolsCall_HasResultTypeButNoCacheHints;
-    [Test] procedure Modern_Discover_ListsModernVersionsAndCapabilities;
-    [Test] procedure Modern_Discover_ListsLegacyVersions_WhenConfigured;
-    [Test] procedure Modern_ServerInfo_UsesSettings;
-    [Test] procedure Legacy_Initialize_NegotiatesAndDeclaresCapabilities;
-    [Test] procedure Legacy_Result_IsUntouched;
-    [Test] procedure Notification_Returns202WithoutBody;
-    [Test] procedure ClientResponse_Legacy_IsIgnored_Modern_IsRejected;
-    [Test] procedure ErrorData_IsEmitted;
-    [Test] procedure Current_IsSetDuringDispatch_AndClearedAfter;
-    [Test] procedure Concurrent_Initialize_AllSucceed;
+    [Test]
+    procedure Modern_UnknownMethod_Is404;
+
+    [Test]
+    procedure Legacy_UnknownMethod_Is200;
+
+    [Test]
+    procedure ParseError_ModernHeader_Is400_LegacyIs200;
+
+    [Test]
+    procedure Modern_MetaValidationError_Is400;
+
+    [Test]
+    procedure Modern_ApplicationInvalidParams_Is200;
+
+    [Test]
+    procedure Modern_ToolsList_HasEnvelopeAndCacheHints;
+
+    [Test]
+    procedure Modern_ToolsCall_HasResultTypeButNoCacheHints;
+
+    [Test]
+    procedure Modern_Discover_ListsModernVersionsAndCapabilities;
+
+    [Test]
+    procedure Modern_Discover_ListsLegacyVersions_WhenConfigured;
+
+    [Test]
+    procedure Modern_ServerInfo_UsesSettings;
+
+    [Test]
+    procedure Legacy_Initialize_NegotiatesAndDeclaresCapabilities;
+
+    [Test]
+    procedure Legacy_Result_IsUntouched;
+
+    [Test]
+    procedure Notification_Returns202WithoutBody;
+
+    [Test]
+    procedure ClientResponse_Legacy_IsIgnored_Modern_IsRejected;
+
+    [Test]
+    procedure ErrorData_IsEmitted;
+
+    [Test]
+    procedure Current_IsSetDuringDispatch_AndClearedAfter;
+
+    [Test]
+    procedure Concurrent_Initialize_AllSucceed;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Prompt.pas
+++ b/tests/MCPServer.Tests.Prompt.pas
@@ -33,20 +33,36 @@ type
   [TestFixture]
   TPromptMessagesTests = class
   public
-    [Test] procedure AddText_ProducesOneMessage;
-    [Test] procedure ContentIsASingleObject_NotAnArray;
-    [Test] procedure Image_Audio_ResourceLink_Embedded_Blocks;
-    [Test] procedure WithAnnotations_AttachesToLastMessage;
-    [Test] procedure WithAnnotations_BeforeAnyMessage_AttachesToTheNextMessage;
-    [Test] procedure ToJson_ReturnsAClone;
+    [Test]
+    procedure AddText_ProducesOneMessage;
+
+    [Test]
+    procedure ContentIsASingleObject_NotAnArray;
+
+    [Test]
+    procedure Image_Audio_ResourceLink_Embedded_Blocks;
+
+    [Test]
+    procedure WithAnnotations_AttachesToLastMessage;
+
+    [Test]
+    procedure WithAnnotations_BeforeAnyMessage_AttachesToTheNextMessage;
+
+    [Test]
+    procedure ToJson_ReturnsAClone;
   end;
 
   [TestFixture]
   TPromptBaseTests = class
   public
-    [Test] procedure Arguments_DerivedFromRttiWithDescriptionAndRequired;
-    [Test] procedure Get_BuildsMessages_AndReturnsDescription;
-    [Test] procedure Get_MissingRequiredArgument_Raises;
+    [Test]
+    procedure Arguments_DerivedFromRttiWithDescriptionAndRequired;
+
+    [Test]
+    procedure Get_BuildsMessages_AndReturnsDescription;
+
+    [Test]
+    procedure Get_MissingRequiredArgument_Raises;
   end;
 
 implementation
@@ -63,7 +79,8 @@ end;
 function TGreetingPrompt.ExecuteWithParams(const Params: TGreetingParams; Messages: TMCPPromptMessages): string;
 begin
   var Tone := Params.Tone;
-  if Tone = '' then
+  const ToneIsEmpty = (Tone = '');
+  if ToneIsEmpty then
     Tone := 'friendly';
   Messages.AddText('user', Format('Write a %s greeting for %s.', [Tone, Params.Name]));
   Result := 'Greeting request';

--- a/tests/MCPServer.Tests.PromptsManager.pas
+++ b/tests/MCPServer.Tests.PromptsManager.pas
@@ -35,14 +35,29 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure List_IsInRegistrationOrder_WithArguments;
-    [Test] procedure List_CacheHints_ModernOnly;
-    [Test] procedure List_Cursor_IsInvalidParams;
-    [Test] procedure Get_MissingName_IsInvalidParams;
-    [Test] procedure Get_UnknownPrompt_IsInvalidParams_WithName;
-    [Test] procedure Get_MissingRequiredArgument_IsInvalidParams;
-    [Test] procedure Get_ReturnsDescriptionAndMessages;
-    [Test] procedure Get_ResultHasNoCacheHints;
+    [Test]
+    procedure List_IsInRegistrationOrder_WithArguments;
+
+    [Test]
+    procedure List_CacheHints_ModernOnly;
+
+    [Test]
+    procedure List_Cursor_IsInvalidParams;
+
+    [Test]
+    procedure Get_MissingName_IsInvalidParams;
+
+    [Test]
+    procedure Get_UnknownPrompt_IsInvalidParams_WithName;
+
+    [Test]
+    procedure Get_MissingRequiredArgument_IsInvalidParams;
+
+    [Test]
+    procedure Get_ReturnsDescriptionAndMessages;
+
+    [Test]
+    procedure Get_ResultHasNoCacheHints;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Registration.pas
+++ b/tests/MCPServer.Tests.Registration.pas
@@ -9,14 +9,29 @@ type
   [TestFixture]
   TRegistryTests = class
   public
-    [Test] procedure BuiltInTools_AreRegisteredFromInitialization;
-    [Test] procedure BuiltInResources_AreRegisteredFromInitialization;
-    [Test] procedure BuiltInPrompts_AreRegisteredFromInitialization;
-    [Test] procedure BuiltInResourceTemplates_AreRegisteredFromInitialization;
-    [Test] procedure ServerStatus_IsRegisteredByDefault;
-    [Test] procedure CreateTool_UnknownName_Raises;
-    [Test] procedure CreateResource_UnknownUri_Raises;
-    [Test] procedure CreateTool_ReturnsFreshInstances;
+    [Test]
+    procedure BuiltInTools_AreRegisteredFromInitialization;
+
+    [Test]
+    procedure BuiltInResources_AreRegisteredFromInitialization;
+
+    [Test]
+    procedure BuiltInPrompts_AreRegisteredFromInitialization;
+
+    [Test]
+    procedure BuiltInResourceTemplates_AreRegisteredFromInitialization;
+
+    [Test]
+    procedure ServerStatus_IsRegisteredByDefault;
+
+    [Test]
+    procedure CreateTool_UnknownName_Raises;
+
+    [Test]
+    procedure CreateResource_UnknownUri_Raises;
+
+    [Test]
+    procedure CreateTool_ReturnsFreshInstances;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.RequestContext.pas
+++ b/tests/MCPServer.Tests.RequestContext.pas
@@ -30,32 +30,83 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Initialize_WithModernMeta_IsNotFound;
-    [Test] procedure Initialize_EchoesServedRevision;
-    [Test] procedure Initialize_UnknownRevision_AnswersLatestLegacy;
-    [Test] procedure ModernMeta_IsModern;
-    [Test] procedure ModernMeta_Http_HeaderMissing_IsHeaderMismatch;
-    [Test] procedure ModernMeta_Http_HeaderDiffers_IsHeaderMismatch;
-    [Test] procedure ModernMeta_Http_HeaderMatches_IsModern;
-    [Test] procedure ModernMeta_Http_NameHeader_IsDecodedAndCompared;
-    [Test] procedure ModernMeta_UnknownVersion_ListsSupported;
-    [Test] procedure ModernMeta_MissingClientCapabilities_IsInvalidParams;
-    [Test] procedure ModernMeta_ClientInfoNotObject_IsInvalidParams;
-    [Test] procedure ModernMeta_InvalidLogLevel_IsInvalidParams;
-    [Test] procedure ModernMeta_Ping_IsMethodNotFound;
-    [Test] procedure ModernMeta_Ping_LenientSetting_Allows;
-    [Test] procedure ModernMeta_LegacyOnlyMethods_AreNotFound;
-    [Test] procedure ModernOnlyMethod_WithoutMeta_IsInvalidParams;
-    [Test] procedure Http_ModernHeader_WithoutMeta_IsInvalidParams;
-    [Test] procedure Http_UnknownHeaderVersion_IsInvalidRequest;
-    [Test] procedure Http_LegacyHeader_IsLegacyWithHeaderVersion;
-    [Test] procedure Http_NoHeader_NoMeta_IsLegacy;
-    [Test] procedure Stdio_SessionVersion_IsUsedForLegacyRequests;
-    [Test] procedure Stdio_NoSessionVersion_IsLatestLegacy;
-    [Test] procedure LegacyMeta_WithProgressTokenOnly_IsLegacy;
-    [Test] procedure Meta_NotAnObject_IsInvalidParams;
-    [Test] procedure ClientCapabilities_AreReadable;
-    [Test] procedure RequireClientCapability_RaisesMissingCapability;
+    [Test]
+    procedure Initialize_WithModernMeta_IsNotFound;
+
+    [Test]
+    procedure Initialize_EchoesServedRevision;
+
+    [Test]
+    procedure Initialize_UnknownRevision_AnswersLatestLegacy;
+
+    [Test]
+    procedure ModernMeta_IsModern;
+
+    [Test]
+    procedure ModernMeta_Http_HeaderMissing_IsHeaderMismatch;
+
+    [Test]
+    procedure ModernMeta_Http_HeaderDiffers_IsHeaderMismatch;
+
+    [Test]
+    procedure ModernMeta_Http_HeaderMatches_IsModern;
+
+    [Test]
+    procedure ModernMeta_Http_NameHeader_IsDecodedAndCompared;
+
+    [Test]
+    procedure ModernMeta_UnknownVersion_ListsSupported;
+
+    [Test]
+    procedure ModernMeta_MissingClientCapabilities_IsInvalidParams;
+
+    [Test]
+    procedure ModernMeta_ClientInfoNotObject_IsInvalidParams;
+
+    [Test]
+    procedure ModernMeta_InvalidLogLevel_IsInvalidParams;
+
+    [Test]
+    procedure ModernMeta_Ping_IsMethodNotFound;
+
+    [Test]
+    procedure ModernMeta_Ping_LenientSetting_Allows;
+
+    [Test]
+    procedure ModernMeta_LegacyOnlyMethods_AreNotFound;
+
+    [Test]
+    procedure ModernOnlyMethod_WithoutMeta_IsInvalidParams;
+
+    [Test]
+    procedure Http_ModernHeader_WithoutMeta_IsInvalidParams;
+
+    [Test]
+    procedure Http_UnknownHeaderVersion_IsInvalidRequest;
+
+    [Test]
+    procedure Http_LegacyHeader_IsLegacyWithHeaderVersion;
+
+    [Test]
+    procedure Http_NoHeader_NoMeta_IsLegacy;
+
+    [Test]
+    procedure Stdio_SessionVersion_IsUsedForLegacyRequests;
+
+    [Test]
+    procedure Stdio_NoSessionVersion_IsLatestLegacy;
+
+    [Test]
+    procedure LegacyMeta_WithProgressTokenOnly_IsLegacy;
+
+    [Test]
+    procedure Meta_NotAnObject_IsInvalidParams;
+
+    [Test]
+    procedure ClientCapabilities_AreReadable;
+
+    [Test]
+    procedure RequireClientCapability_RaisesMissingCapability;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.ResourcesManager.pas
+++ b/tests/MCPServer.Tests.ResourcesManager.pas
@@ -57,22 +57,53 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Unknown_Modern_Is32602_WithUri;
-    [Test] procedure Unknown_Legacy_Is32002_WithUri;
-    [Test] procedure MissingUri_IsInvalidParams;
-    [Test] procedure ReadFailure_IsInternalError;
-    [Test] procedure Text_ReadsText;
-    [Test] procedure Binary_ReadsBlob;
-    [Test] procedure Read_CacheHints_ModernOnly_FromResource;
-    [Test] procedure List_HasMetadata_AndOmitsEmptyFields;
-    [Test] procedure List_CacheHints_ModernOnly;
-    [Test] procedure Templates_ListsRegisteredTemplates_WithHints;
-    [Test] procedure Templates_Cursor_IsInvalidParams;
-    [Test] procedure Read_ViaTemplate_ResolvesWithActualUri;
-    [Test] procedure Read_TemplateMismatch_IsNotFound;
-    [Test] procedure Read_ViaTemplate_PercentDecodes_KeepsPlusLiteral;
-    [Test] procedure Read_ViaTemplate_ConcurrentReads_Succeed;
-    [Test] procedure RemoveResourceTemplate_StopsMatching;
+    [Test]
+    procedure Unknown_Modern_Is32602_WithUri;
+
+    [Test]
+    procedure Unknown_Legacy_Is32002_WithUri;
+
+    [Test]
+    procedure MissingUri_IsInvalidParams;
+
+    [Test]
+    procedure ReadFailure_IsInternalError;
+
+    [Test]
+    procedure Text_ReadsText;
+
+    [Test]
+    procedure Binary_ReadsBlob;
+
+    [Test]
+    procedure Read_CacheHints_ModernOnly_FromResource;
+
+    [Test]
+    procedure List_HasMetadata_AndOmitsEmptyFields;
+
+    [Test]
+    procedure List_CacheHints_ModernOnly;
+
+    [Test]
+    procedure Templates_ListsRegisteredTemplates_WithHints;
+
+    [Test]
+    procedure Templates_Cursor_IsInvalidParams;
+
+    [Test]
+    procedure Read_ViaTemplate_ResolvesWithActualUri;
+
+    [Test]
+    procedure Read_TemplateMismatch_IsNotFound;
+
+    [Test]
+    procedure Read_ViaTemplate_PercentDecodes_KeepsPlusLiteral;
+
+    [Test]
+    procedure Read_ViaTemplate_ConcurrentReads_Succeed;
+
+    [Test]
+    procedure RemoveResourceTemplate_StopsMatching;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Schema.pas
+++ b/tests/MCPServer.Tests.Schema.pas
@@ -85,19 +85,44 @@ type
   [TestFixture]
   TSchemaGeneratorTests = class
   public
-    [Test] procedure Integers_AreInteger_FloatsAreNumber;
-    [Test] procedure DateTime_IsStringWithFormat;
-    [Test] procedure Boolean_And_Enum;
-    [Test] procedure Set_IsArrayOfEnumNames;
-    [Test] procedure DynArray_And_List_HaveItems;
-    [Test] procedure NestedObject_HasProperties;
-    [Test] procedure Attributes_AreApplied;
-    [Test] procedure Optional_IsNotRequired;
-    [Test] procedure NoParameters_ForbidsAdditionalProperties;
-    [Test] procedure StringConstraints_AreApplied;
-    [Test] procedure SchemaName_OverridesPropertyName;
-    [Test] procedure ClassAttributes_AdditionalPropertiesAndDialect;
-    [Test] procedure Dialect_OnlyAppliesAtRoot;
+    [Test]
+    procedure Integers_AreInteger_FloatsAreNumber;
+
+    [Test]
+    procedure DateTime_IsStringWithFormat;
+
+    [Test]
+    procedure Boolean_And_Enum;
+
+    [Test]
+    procedure Set_IsArrayOfEnumNames;
+
+    [Test]
+    procedure DynArray_And_List_HaveItems;
+
+    [Test]
+    procedure NestedObject_HasProperties;
+
+    [Test]
+    procedure Attributes_AreApplied;
+
+    [Test]
+    procedure Optional_IsNotRequired;
+
+    [Test]
+    procedure NoParameters_ForbidsAdditionalProperties;
+
+    [Test]
+    procedure StringConstraints_AreApplied;
+
+    [Test]
+    procedure SchemaName_OverridesPropertyName;
+
+    [Test]
+    procedure ClassAttributes_AdditionalPropertiesAndDialect;
+
+    [Test]
+    procedure Dialect_OnlyAppliesAtRoot;
   end;
 
 implementation
@@ -203,7 +228,9 @@ begin
   try
     var Required := Schema.GetValue('required') as TJSONArray;
     for var Item in Required do
+    begin
       Assert.AreNotEqual('code', Item.Value);
+    end;
     Assert.AreEqual('count', Required.Items[0].Value);
   finally
     Schema.Free;

--- a/tests/MCPServer.Tests.SchemaValidator.pas
+++ b/tests/MCPServer.Tests.SchemaValidator.pas
@@ -9,21 +9,50 @@ type
   [TestFixture]
   TSchemaValidatorTests = class
   public
-    [Test] procedure Type_Mismatch_Fails;
-    [Test] procedure Type_Array_AcceptsEitherAlternative;
-    [Test] procedure Integer_RejectsFraction;
-    [Test] procedure Required_MissingProperty_Fails;
-    [Test] procedure Properties_RecurseIntoNestedObject;
-    [Test] procedure AdditionalProperties_False_RejectsExtraKey;
-    [Test] procedure Items_RecurseIntoArrayElements;
-    [Test] procedure MinimumMaximum_OutOfRange_Fails;
-    [Test] procedure MinLengthMaxLengthPattern_Fail;
-    [Test] procedure Enum_RejectsValueNotListed;
-    [Test] procedure Const_RejectsDifferentValue;
-    [Test] procedure Ref_ResolvesSameDocumentDefs;
-    [Test] procedure Ref_UnsupportedShape_IsAnError;
-    [Test] procedure Valid_Instance_HasNoErrors;
-    [Test] procedure ExcessiveNesting_IsAnError;
+    [Test]
+    procedure Type_Mismatch_Fails;
+
+    [Test]
+    procedure Type_Array_AcceptsEitherAlternative;
+
+    [Test]
+    procedure Integer_RejectsFraction;
+
+    [Test]
+    procedure Required_MissingProperty_Fails;
+
+    [Test]
+    procedure Properties_RecurseIntoNestedObject;
+
+    [Test]
+    procedure AdditionalProperties_False_RejectsExtraKey;
+
+    [Test]
+    procedure Items_RecurseIntoArrayElements;
+
+    [Test]
+    procedure MinimumMaximum_OutOfRange_Fails;
+
+    [Test]
+    procedure MinLengthMaxLengthPattern_Fail;
+
+    [Test]
+    procedure Enum_RejectsValueNotListed;
+
+    [Test]
+    procedure Const_RejectsDifferentValue;
+
+    [Test]
+    procedure Ref_ResolvesSameDocumentDefs;
+
+    [Test]
+    procedure Ref_UnsupportedShape_IsAnError;
+
+    [Test]
+    procedure Valid_Instance_HasNoErrors;
+
+    [Test]
+    procedure ExcessiveNesting_IsAnError;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Serializer.pas
+++ b/tests/MCPServer.Tests.Serializer.pas
@@ -33,13 +33,20 @@ type
     destructor Destroy; override;
     property Name: string read FName write FName;
     property Count: Integer read FCount write FCount;
-    [Optional] property Ratio: Double read FRatio write FRatio;
-    [Optional] property Enabled: Boolean read FEnabled write FEnabled;
-    [Optional] property Colour: TColour read FColour write FColour;
-    [Optional] property When: TDateTime read FWhen write FWhen;
-    [Optional] property Tags: TArray<string> read FTags write FTags;
-    [Optional] property Nested: TNested read FNested write FNested;
-    [Optional] property Note: string read FNote write FNote;
+    [Optional]
+    property Ratio: Double read FRatio write FRatio;
+    [Optional]
+    property Enabled: Boolean read FEnabled write FEnabled;
+    [Optional]
+    property Colour: TColour read FColour write FColour;
+    [Optional]
+    property When: TDateTime read FWhen write FWhen;
+    [Optional]
+    property Tags: TArray<string> read FTags write FTags;
+    [Optional]
+    property Nested: TNested read FNested write FNested;
+    [Optional]
+    property Note: string read FNote write FNote;
   end;
 
   TRenamedParams = class
@@ -71,18 +78,41 @@ type
     function Deserialize(const Json: string): TSampleParams;
     procedure ExpectArgumentError(const Json, Fragment: string);
   public
-    [Test] procedure Deserialize_AllTypes;
-    [Test] procedure MissingRequired_Raises;
-    [Test] procedure Null_CountsAsAbsent;
-    [Test] procedure WrongType_String_Raises;
-    [Test] procedure WrongType_Integer_Raises;
-    [Test] procedure Fraction_ForInteger_Raises;
-    [Test] procedure WrongType_Boolean_Raises;
-    [Test] procedure UnknownParameter_Raises;
-    [Test] procedure Enum_ByName_AndInvalidRaises;
-    [Test] procedure Serialize_Enum_Set_Array_DateTime;
-    [Test] procedure Serialize_NilObject_IsNull;
-    [Test] procedure SchemaName_UsedForDeserializeAndSerialize;
+    [Test]
+    procedure Deserialize_AllTypes;
+
+    [Test]
+    procedure MissingRequired_Raises;
+
+    [Test]
+    procedure Null_CountsAsAbsent;
+
+    [Test]
+    procedure WrongType_String_Raises;
+
+    [Test]
+    procedure WrongType_Integer_Raises;
+
+    [Test]
+    procedure Fraction_ForInteger_Raises;
+
+    [Test]
+    procedure WrongType_Boolean_Raises;
+
+    [Test]
+    procedure UnknownParameter_Raises;
+
+    [Test]
+    procedure Enum_ByName_AndInvalidRaises;
+
+    [Test]
+    procedure Serialize_Enum_Set_Array_DateTime;
+
+    [Test]
+    procedure Serialize_NilObject_IsNull;
+
+    [Test]
+    procedure SchemaName_UsedForDeserializeAndSerialize;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.ServerStatus.pas
+++ b/tests/MCPServer.Tests.ServerStatus.pas
@@ -19,10 +19,17 @@ type
     [Setup]
     procedure Setup;
 
-    [Test] procedure Counters_StartAtZero;
-    [Test] procedure Counters_AreExactUnderConcurrentUpdates;
-    [Test] procedure ConnectionClosed_NeverGoesBelowZero;
-    [Test] procedure Read_ProducesJsonWithStatusFields;
+    [Test]
+    procedure Counters_StartAtZero;
+
+    [Test]
+    procedure Counters_AreExactUnderConcurrentUpdates;
+
+    [Test]
+    procedure ConnectionClosed_NeverGoesBelowZero;
+
+    [Test]
+    procedure Read_ProducesJsonWithStatusFields;
   end;
 
 implementation

--- a/tests/MCPServer.Tests.Stdio.pas
+++ b/tests/MCPServer.Tests.Stdio.pas
@@ -29,18 +29,41 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Handshake_And_ToolsList;
-    [Test] procedure Utf8_RoundTrip_LfFraming_NoBom;
-    [Test] procedure CrLf_Input_IsAccepted;
-    [Test] procedure InvalidJson_IsParseError_WithNullId;
-    [Test] procedure Notification_ProducesNoOutput;
-    [Test] procedure DuplicateId_WhileInFlight_IsInvalidRequest;
-    [Test] procedure Cancelled_GetsNoResponse_PingIsStillAnswered;
-    [Test] procedure Progress_IsSentBeforeTheResponse;
-    [Test] procedure ModernRequest_OverStdio;
-    [Test] procedure Eof_WithRunningRequest_ReturnsAfterDrain;
-    [Test] procedure Listen_AckThenCancel_HasNoResponse;
-    [Test] procedure Listen_Eof_ClosesGracefully;
+    [Test]
+    procedure Handshake_And_ToolsList;
+
+    [Test]
+    procedure Utf8_RoundTrip_LfFraming_NoBom;
+
+    [Test]
+    procedure CrLf_Input_IsAccepted;
+
+    [Test]
+    procedure InvalidJson_IsParseError_WithNullId;
+
+    [Test]
+    procedure Notification_ProducesNoOutput;
+
+    [Test]
+    procedure DuplicateId_WhileInFlight_IsInvalidRequest;
+
+    [Test]
+    procedure Cancelled_GetsNoResponse_PingIsStillAnswered;
+
+    [Test]
+    procedure Progress_IsSentBeforeTheResponse;
+
+    [Test]
+    procedure ModernRequest_OverStdio;
+
+    [Test]
+    procedure Eof_WithRunningRequest_ReturnsAfterDrain;
+
+    [Test]
+    procedure Listen_AckThenCancel_HasNoResponse;
+
+    [Test]
+    procedure Listen_Eof_ClosesGracefully;
   end;
 
 implementation
@@ -69,7 +92,9 @@ function TStdioTransportTests.Run(const Lines: array of string; DrainMs: Integer
 begin
   var Input := '';
   for var Line in Lines do
+  begin
     Input := Input + Line + Separator;
+  end;
 
   var InputStream := TBytesStream.Create(TEncoding.UTF8.GetBytes(Input));
   var OutputStream := TBytesStream.Create;
@@ -151,7 +176,9 @@ begin
   Assert.AreEqual($7B, Integer(FOutputBytes[0]), 'no byte-order mark');
   Assert.AreEqual(10, Integer(FOutputBytes[High(FOutputBytes)]), 'ends with LF');
   for var B in FOutputBytes do
+  begin
     Assert.AreNotEqual(13, Integer(B), 'no CR on stdout');
+  end;
 end;
 
 procedure TStdioTransportTests.CrLf_Input_IsAccepted;

--- a/tests/MCPServer.Tests.StdioChannel.pas
+++ b/tests/MCPServer.Tests.StdioChannel.pas
@@ -15,18 +15,41 @@ type
   private
     function ReadAll(const Bytes: TBytes; const MaxLineBytes: Integer): TArray<TMCPLine>;
   public
-    [Test] procedure Reader_SplitsOnLf_DropsCr_LastLineWithoutNewline;
-    [Test] procedure Reader_SkipsByteOrderMark;
-    [Test] procedure Reader_DecodesUtf8;
-    [Test] procedure Reader_ReportsOverlongLine_AndContinues;
-    [Test] procedure Reader_ReportsInvalidUtf8_AndContinues;
-    [Test] procedure Reader_ReportsReplacedUtf8_AsInvalid;
-    [Test] procedure Reader_OverlongLineWithoutNewline_EndsStream;
-    [Test] procedure Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
-    [Test] procedure Reader_EmptyStream_HasNoLines;
-    [Test] procedure Writer_OneLinePerMessage_Utf8_NoBom;
-    [Test] procedure Writer_ReplacesEmbeddedNewlines;
-    [Test] procedure Writer_ConcurrentSends_DoNotInterleave;
+    [Test]
+    procedure Reader_SplitsOnLf_DropsCr_LastLineWithoutNewline;
+
+    [Test]
+    procedure Reader_SkipsByteOrderMark;
+
+    [Test]
+    procedure Reader_DecodesUtf8;
+
+    [Test]
+    procedure Reader_ReportsOverlongLine_AndContinues;
+
+    [Test]
+    procedure Reader_ReportsInvalidUtf8_AndContinues;
+
+    [Test]
+    procedure Reader_ReportsReplacedUtf8_AsInvalid;
+
+    [Test]
+    procedure Reader_OverlongLineWithoutNewline_EndsStream;
+
+    [Test]
+    procedure Reader_OverlongLineBeyondChunk_IsSkippedUpToNewline;
+
+    [Test]
+    procedure Reader_EmptyStream_HasNoLines;
+
+    [Test]
+    procedure Writer_OneLinePerMessage_Utf8_NoBom;
+
+    [Test]
+    procedure Writer_ReplacesEmbeddedNewlines;
+
+    [Test]
+    procedure Writer_ConcurrentSends_DoNotInterleave;
   end;
 
 implementation
@@ -197,7 +220,9 @@ begin
         begin
           try
             for var I := 1 to MESSAGES_PER_THREAD do
+            begin
               SinkIntf.Send('{"thread":' + ThreadNo.ToString + ',"payload":"' + StringOfChar('x', 300) + '"}');
+            end;
           finally
             Done.Signal;
           end;

--- a/tests/MCPServer.Tests.Subscriptions.pas
+++ b/tests/MCPServer.Tests.Subscriptions.pas
@@ -63,14 +63,29 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure Filter_FromJson_HonoursBooleansAndUris;
-    [Test] procedure Listen_AckFirst_ThenTaggedNotifications_ThenCompletion;
-    [Test] procedure Listen_UnrequestedNotifications_AreNotSent;
-    [Test] procedure Listen_Cancel_EndsTheWait;
-    [Test] procedure Listen_KeepAlive_OnInterval;
-    [Test] procedure Listen_WithoutSink_IsInvalidRequest;
-    [Test] procedure Listen_NotificationsNotObject_IsInvalidParams;
-    [Test] procedure Managers_NotifyTheHub_AndAnnounceCapabilities;
+    [Test]
+    procedure Filter_FromJson_HonoursBooleansAndUris;
+
+    [Test]
+    procedure Listen_AckFirst_ThenTaggedNotifications_ThenCompletion;
+
+    [Test]
+    procedure Listen_UnrequestedNotifications_AreNotSent;
+
+    [Test]
+    procedure Listen_Cancel_EndsTheWait;
+
+    [Test]
+    procedure Listen_KeepAlive_OnInterval;
+
+    [Test]
+    procedure Listen_WithoutSink_IsInvalidRequest;
+
+    [Test]
+    procedure Listen_NotificationsNotObject_IsInvalidParams;
+
+    [Test]
+    procedure Managers_NotifyTheHub_AndAnnounceCapabilities;
   end;
 
 implementation
@@ -249,7 +264,9 @@ procedure TSubscriptionsTests.WaitUntilOpen;
 begin
   var Deadline := TThread.GetTickCount64 + WAIT_MS;
   while (FManager.ActiveCount = 0) and (FError = '') and (TThread.GetTickCount64 < Deadline) do
+  begin
     Sleep(5);
+  end;
   Assert.AreEqual('', FError);
   Assert.AreEqual(1, FManager.ActiveCount, 'the subscription is registered');
 end;
@@ -357,7 +374,9 @@ begin
   FContext.Cancel;
   var Deadline := TThread.GetTickCount64 + WAIT_MS;
   while (FManager.ActiveCount > 0) and (TThread.GetTickCount64 < Deadline) do
+  begin
     Sleep(5);
+  end;
   Assert.AreEqual(0, FManager.ActiveCount, 'cancellation ends the subscription');
   FThread.WaitFor;
   Assert.AreEqual(1, FSink.Count, 'nothing after the acknowledgement');
@@ -370,7 +389,9 @@ begin
   WaitUntilOpen;
   var Deadline := TThread.GetTickCount64 + WAIT_MS;
   while (FSink.KeepAlives < 2) and (TThread.GetTickCount64 < Deadline) do
+  begin
     Sleep(5);
+  end;
   Assert.IsTrue(FSink.KeepAlives >= 2, 'keep-alives are sent while the subscription is quiet');
   Assert.AreEqual(1, FSink.Count, 'keep-alives are not messages');
 end;

--- a/tests/MCPServer.Tests.ToolResult.pas
+++ b/tests/MCPServer.Tests.ToolResult.pas
@@ -9,15 +9,32 @@ type
   [TestFixture]
   TToolResultTests = class
   public
-    [Test] procedure Text_ProducesOneTextBlock;
-    [Test] procedure Image_Audio_Embedded_Blocks;
-    [Test] procedure StructuredOnly_GetsTextFallback;
-    [Test] procedure StructuredArray_LegacyDropsIt_ModernKeepsIt;
-    [Test] procedure Error_SetsIsError;
-    [Test] procedure Meta_IsEmitted;
-    [Test] procedure Annotations_AttachToLastBlock;
-    [Test] procedure Annotations_BeforeAnyBlock_AttachToTheNextBlock;
-    [Test] procedure Base64Blob_HasNoLineBreaks;
+    [Test]
+    procedure Text_ProducesOneTextBlock;
+
+    [Test]
+    procedure Image_Audio_Embedded_Blocks;
+
+    [Test]
+    procedure StructuredOnly_GetsTextFallback;
+
+    [Test]
+    procedure StructuredArray_LegacyDropsIt_ModernKeepsIt;
+
+    [Test]
+    procedure Error_SetsIsError;
+
+    [Test]
+    procedure Meta_IsEmitted;
+
+    [Test]
+    procedure Annotations_AttachToLastBlock;
+
+    [Test]
+    procedure Annotations_BeforeAnyBlock_AttachToTheNextBlock;
+
+    [Test]
+    procedure Base64Blob_HasNoLineBreaks;
   end;
 
 implementation
@@ -162,7 +179,9 @@ begin
   var Bytes: TBytes;
   SetLength(Bytes, 300);
   for var I := 0 to High(Bytes) do
+  begin
     Bytes[I] := Byte(I);
+  end;
   var Encoded := TMCPContentBlock.EncodeBlob(Bytes);
   Assert.AreEqual(400, Length(Encoded));
   Assert.IsFalse(Encoded.Contains(#13) or Encoded.Contains(#10));

--- a/tests/MCPServer.Tests.ToolsManager.pas
+++ b/tests/MCPServer.Tests.ToolsManager.pas
@@ -52,21 +52,50 @@ type
     [TearDown]
     procedure TearDown;
 
-    [Test] procedure UnknownTool_IsInvalidParams_WithName;
-    [Test] procedure MissingName_IsInvalidParams;
-    [Test] procedure ArgumentsNotObject_IsInvalidParams;
-    [Test] procedure MissingRequiredArgument_IsErrorResult;
-    [Test] procedure WrongArgumentType_IsErrorResult;
-    [Test] procedure UnknownArgument_IsErrorResult;
-    [Test] procedure ToolError_IsErrorResult;
-    [Test] procedure ContentBlocks_FromToolResult;
-    [Test] procedure StructuredResult_HasTextFallback;
-    [Test] procedure List_IsInRegistrationOrder_WithAnnotations;
-    [Test] procedure List_CacheHints_ModernOnly;
-    [Test] procedure List_Cursor_IsInvalidParams;
-    [Test] procedure HandWrittenTool_ValidArguments_Runs;
-    [Test] procedure HandWrittenTool_MissingRequired_IsErrorResult;
-    [Test] procedure HandWrittenTool_WrongType_IsErrorResult;
+    [Test]
+    procedure UnknownTool_IsInvalidParams_WithName;
+
+    [Test]
+    procedure MissingName_IsInvalidParams;
+
+    [Test]
+    procedure ArgumentsNotObject_IsInvalidParams;
+
+    [Test]
+    procedure MissingRequiredArgument_IsErrorResult;
+
+    [Test]
+    procedure WrongArgumentType_IsErrorResult;
+
+    [Test]
+    procedure UnknownArgument_IsErrorResult;
+
+    [Test]
+    procedure ToolError_IsErrorResult;
+
+    [Test]
+    procedure ContentBlocks_FromToolResult;
+
+    [Test]
+    procedure StructuredResult_HasTextFallback;
+
+    [Test]
+    procedure List_IsInRegistrationOrder_WithAnnotations;
+
+    [Test]
+    procedure List_CacheHints_ModernOnly;
+
+    [Test]
+    procedure List_Cursor_IsInvalidParams;
+
+    [Test]
+    procedure HandWrittenTool_ValidArguments_Runs;
+
+    [Test]
+    procedure HandWrittenTool_MissingRequired_IsErrorResult;
+
+    [Test]
+    procedure HandWrittenTool_WrongType_IsErrorResult;
   end;
 
 implementation


### PR DESCRIPTION
## Summary

- Every `for` and `while` body is wrapped in `begin`/`end` (38 sites).
- A boolean operator trails its line instead of leading the next (20 sites).
- Every attribute sits on its own line, with a blank line between test declarations (384 attributes, 344 blank lines).
- Comparisons in `if` are named first where the name carries meaning: emptiness, presence, counts and comparisons against a constant or an enum value (87 sites).

About 250 comparisons are still written inline. They are shapes like `if Left = Right then` or `if A > B then`, where a generated name would say less than the comparison itself; naming those needs a reading of each site rather than a rule.

## Verification

- DUnitX: 376/376 on Win64 and Win32, no leaks, zero hints and warnings; Linux64 and Release build clean.
- HTTP goldens, conformance (155 and 59), Inspector smoke and stdio smoke unchanged.