### PR TITLE
feat: mark a tool read-only in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,9 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   ready-made `TJSONArray` of content blocks) next to `ExecuteWithParams`;
   `EMCPToolError` for a failure the tool wants reported as an `isError` result.
 - Tool metadata through `IMCPToolMetadata` (`annotations`, `icons`) on every
-  tool base; resource metadata through `IMCPResourceMetadata` (`title`, `size`,
+  tool base, with `MarkReadOnly(OpenWorld)` on the tool bases for the two
+  hints a client uses to decide about parallel or auto-approved calls
+  (`test_simple_text` publishes `readOnlyHint: true, openWorldHint: false`); resource metadata through `IMCPResourceMetadata` (`title`, `size`,
   `annotations`), `IMCPBinaryResource` (`blob` contents) and
   `IMCPCacheableResource` (`ttlMs`, `cacheScope`) on `TMCPResourceBase<T>`.
 - `TMCPToolsManager` and `TMCPResourcesManager`: `AddTool` / `AddResource`

--- a/README.md
+++ b/README.md
@@ -402,8 +402,10 @@ The builder also has `AddAudio`, `AddEmbeddedText`, `AddEmbeddedBlob`,
 `isError` result; the request context gives the protocol era and the
 client's `_meta`. Tools that inherit from `TMCPToolBase<T, R>` return an
 object that becomes `structuredContent` plus a text block with the same
-JSON. Set `FAnnotations` (for example `readOnlyHint`) or `FIcons` in the
-constructor to publish them in `tools/list`. `MCPServer.Tool.ContentSamples`
+JSON. Set `FAnnotations` or `FIcons` in the constructor to publish them in
+`tools/list`; `MarkReadOnly` writes the `readOnlyHint` and `openWorldHint`
+pair for a tool that only reads (pass `True` when it reaches outside the
+server). `MCPServer.Tool.ContentSamples`
 has one small example per content type.
 
 ### Asking the client for input (multi round-trip requests)

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -104,6 +104,8 @@ const
   MCP_KEY_CURSOR = 'cursor';
   MCP_KEY_ARGUMENTS = 'arguments';
   MCP_KEY_ANNOTATIONS = 'annotations';
+  MCP_ANNOTATION_READ_ONLY_HINT = 'readOnlyHint';
+  MCP_ANNOTATION_OPEN_WORLD_HINT = 'openWorldHint';
   MCP_KEY_ICONS = 'icons';
   MCP_KEY_CAPABILITIES = 'capabilities';
   MCP_KEY_PROTOCOL_VERSION = 'protocolVersion';

--- a/src/Tools/MCPServer.Tool.Base.pas
+++ b/src/Tools/MCPServer.Tool.Base.pas
@@ -9,6 +9,11 @@ uses
   MCPServer.Types;
 
 type
+  TMCPToolAnnotationWriter = record
+  public
+    class procedure ReadOnly(var Annotations: TJSONObject; const OpenWorld: Boolean); static;
+  end;
+
   IMCPTool = interface
     ['{F1E2D3C4-B5A6-4798-8901-234567890ABC}']
     function GetName: string;
@@ -32,6 +37,7 @@ type
     FDescription: string;
     FAnnotations: TJSONObject;
     FIcons: TJSONArray;
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
     function BuildSchema: TJSONObject; virtual; abstract;
     function DoExecute(const Arguments: TJSONObject): TValue; virtual; abstract;
   public
@@ -55,6 +61,7 @@ type
     FDescription: string;
     FAnnotations: TJSONObject;
     FIcons: TJSONArray;
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
     function ExecuteWithParams(const Params: T): string; virtual;
     function ExecuteWithContext(const Params: T; const Context: IMCPRequestContext): TValue; virtual;
     function GetParamsClass: TClass; virtual;
@@ -79,6 +86,7 @@ type
     FDescription: string;
     FAnnotations: TJSONObject;
     FIcons: TJSONArray;
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
     function ExecuteWithParams(const Params: T): R; virtual;
     function ExecuteWithContext(const Params: T; const Context: IMCPRequestContext): TValue; virtual;
   public
@@ -103,6 +111,19 @@ uses
   MCPServer.Serializer,
   MCPServer.RequestContext,
   MCPServer.Tool.Result;
+
+{ TMCPToolAnnotationWriter }
+
+class procedure TMCPToolAnnotationWriter.ReadOnly(var Annotations: TJSONObject; const OpenWorld: Boolean);
+begin
+  const HasAnnotations = Assigned(Annotations);
+  if not HasAnnotations then
+    Annotations := TJSONObject.Create;
+  Annotations.RemovePair(MCP_ANNOTATION_READ_ONLY_HINT).Free;
+  Annotations.RemovePair(MCP_ANNOTATION_OPEN_WORLD_HINT).Free;
+  Annotations.AddPair(MCP_ANNOTATION_READ_ONLY_HINT, TJSONBool.Create(True));
+  Annotations.AddPair(MCP_ANNOTATION_OPEN_WORLD_HINT, TJSONBool.Create(OpenWorld));
+end;
 
 { TMCPToolBase }
 
@@ -144,6 +165,11 @@ end;
 function TMCPToolBase.GetInputSchema: TJSONObject;
 begin
   Result := BuildSchema;
+end;
+
+procedure TMCPToolBase.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  TMCPToolAnnotationWriter.ReadOnly(FAnnotations, OpenWorld);
 end;
 
 function TMCPToolBase.GetAnnotations: TJSONObject;
@@ -209,6 +235,11 @@ end;
 function TMCPToolBase<T>.GetInputSchema: TJSONObject;
 begin
   Result := TMCPSchemaGenerator.GenerateSchema(T);
+end;
+
+procedure TMCPToolBase<T>.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  TMCPToolAnnotationWriter.ReadOnly(FAnnotations, OpenWorld);
 end;
 
 function TMCPToolBase<T>.GetAnnotations: TJSONObject;
@@ -324,6 +355,11 @@ end;
 function TMCPToolBase<T, R>.GetOutputSchema: TJSONObject;
 begin
   Result := TMCPSchemaGenerator.GenerateSchema(R);
+end;
+
+procedure TMCPToolBase<T, R>.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  TMCPToolAnnotationWriter.ReadOnly(FAnnotations, OpenWorld);
 end;
 
 function TMCPToolBase<T, R>.GetAnnotations: TJSONObject;

--- a/src/Tools/MCPServer.Tool.ContentSamples.pas
+++ b/src/Tools/MCPServer.Tool.ContentSamples.pas
@@ -130,8 +130,7 @@ begin
   inherited;
   FName := TOOL_SIMPLE_TEXT;
   FDescription := 'Returns a plain text result';
-  FAnnotations := TJSONObject.Create;
-  FAnnotations.AddPair('readOnlyHint', TJSONBool.Create(True));
+  MarkReadOnly;
 end;
 
 function TSimpleTextTool.ExecuteWithParams(const Params: TNoParams): string;

--- a/tests/MCPServer.Tests.ToolsManager.pas
+++ b/tests/MCPServer.Tests.ToolsManager.pas
@@ -40,6 +40,11 @@ type
     constructor Create; override;
   end;
 
+  TReadOnlyTool = class(THandWrittenTool)
+  public
+    constructor Create; override;
+  end;
+
   [TestFixture]
   TToolsManagerTests = class
   private
@@ -81,6 +86,9 @@ type
 
     [Test]
     procedure List_IsInRegistrationOrder_WithAnnotations;
+
+    [Test]
+    procedure MarkReadOnly_SetsBothHints_Once;
 
     [Test]
     procedure List_CacheHints_ModernOnly;
@@ -127,6 +135,16 @@ begin
   inherited;
   FName := 'hand_written';
   FDescription := 'A tool with a hand-written schema';
+end;
+
+{ TReadOnlyTool }
+
+constructor TReadOnlyTool.Create;
+begin
+  inherited;
+  FName := 'read_only';
+  MarkReadOnly(True);
+  MarkReadOnly(True);
 end;
 
 function THandWrittenTool.BuildSchema: TJSONObject;
@@ -287,6 +305,29 @@ begin
     Assert.IsTrue(ReadOnly);
     Assert.AreEqual('integer',
       Json.GetValue<string>('tools[' + (Tools.Count - 2).ToString + '].inputSchema.properties.value.type'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TToolsManagerTests.MarkReadOnly_SetsBothHints_Once;
+begin
+  FManager.AddTool(TReadOnlyTool.Create);
+  var Json := FManager.ListTools(nil, TMCPProtocolEra.Legacy).AsType<TJSONObject>;
+  try
+    const Tools = Json.GetValue('tools') as TJSONArray;
+    var Annotations: TJSONObject := nil;
+    for var Tool in Tools do
+    begin
+      const IsReadOnlyTool = (Tool.GetValue<string>('name') = 'read_only');
+      if IsReadOnlyTool then
+        Annotations := (Tool as TJSONObject).GetValue('annotations') as TJSONObject;
+    end;
+
+    Assert.IsNotNull(Annotations, 'the tool is listed with its annotations');
+    Assert.IsTrue(Annotations.GetValue<Boolean>('readOnlyHint'), 'the tool reads only');
+    Assert.IsTrue(Annotations.GetValue<Boolean>('openWorldHint'), 'the tool reaches outside the server');
+    Assert.AreEqual(2, Annotations.Count, 'marking twice leaves one pair per hint');
   finally
     Json.Free;
   end;

--- a/tests/golden/legacy/tools-list.json
+++ b/tests/golden/legacy/tools-list.json
@@ -97,7 +97,8 @@
             "additionalProperties": false
           },
           "annotations": {
-            "readOnlyHint": true
+            "readOnlyHint": true,
+            "openWorldHint": false
           }
         },
         {

--- a/tests/golden/modern/tools-list.json
+++ b/tests/golden/modern/tools-list.json
@@ -108,7 +108,8 @@
             "additionalProperties": false
           },
           "annotations": {
-            "readOnlyHint": true
+            "readOnlyHint": true,
+            "openWorldHint": false
           }
         },
         {


### PR DESCRIPTION
Neemt het bruikbare deel van PR #31 over op de integratiebranch. De rest van die PR (`IMCPToolAnnotations`, `Server.Instructions`) zit hier al in, breder: `IMCPToolMetadata` met annotations en icons, en `instructions` in zowel `initialize` als `server/discover`.

- `MarkReadOnly(OpenWorld: Boolean = False)` op `TMCPToolBase`, `TMCPToolBase<T>` en `TMCPToolBase<T, R>` schrijft `readOnlyHint` en `openWorldHint`. Twee keer aanroepen levert één paar per hint.
- `test_simple_text` gebruikt het, dus `tools/list` publiceert nu ook `openWorldHint: false`. Beide goldens zijn opnieuw opgenomen.
- README en CHANGELOG bijgewerkt, nieuwe test `MarkReadOnly_SetsBothHints_Once`.

Verificatie: 377/377 DUnitX op Win64 en Win32, 0 leaks. Release- en Linux64-build schoon. Conformance 2026-07-28 155 passed en 2025-11-25 59 passed, beide gelijk aan de baseline. Inspector-smoke 26 tools in vier modi, stdio-smoke geslaagd.