### PR TITLE
fix(list_files): anchor the allowed-directory check on a path separator

### DIFF
--- a/src/Core/MCPServer.PathBoundary.pas
+++ b/src/Core/MCPServer.PathBoundary.pas
@@ -1,0 +1,27 @@
+﻿unit MCPServer.PathBoundary;
+
+interface
+
+type
+  TPathBoundary = class
+  public
+    class function IsWithin(const Path: string; const BasePath: string): Boolean; static;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils;
+
+class function TPathBoundary.IsWithin(const Path: string; const BasePath: string): Boolean;
+begin
+  const NormalizedPath = ExcludeTrailingPathDelimiter(TPath.GetFullPath(Path));
+  const NormalizedBase = ExcludeTrailingPathDelimiter(TPath.GetFullPath(BasePath));
+
+  const IsBaseItself = SameText(NormalizedPath, NormalizedBase);
+  const IsInsideBase = NormalizedPath.StartsWith(IncludeTrailingPathDelimiter(NormalizedBase), True);
+  Result := (IsBaseItself or IsInsideBase);
+end;
+
+end.

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -15,6 +15,7 @@ uses
   MCPServer.Serializer in 'Protocol\MCPServer.Serializer.pas',
   MCPServer.Schema.Generator in 'Protocol\MCPServer.Schema.Generator.pas',
   MCPServer.Logger in 'Core\MCPServer.Logger.pas',
+  MCPServer.PathBoundary in 'Core\MCPServer.PathBoundary.pas',
   MCPServer.Settings in 'Core\MCPServer.Settings.pas',
   MCPServer.Registration in 'Core\MCPServer.Registration.pas',
   MCPServer.ManagerRegistry in 'Core\MCPServer.ManagerRegistry.pas',

--- a/src/MCPServer.dproj
+++ b/src/MCPServer.dproj
@@ -132,6 +132,7 @@
         <DCCReference Include="Protocol\MCPServer.Serializer.pas"/>
         <DCCReference Include="Protocol\MCPServer.Schema.Generator.pas"/>
         <DCCReference Include="Core\MCPServer.Logger.pas"/>
+        <DCCReference Include="Core\MCPServer.PathBoundary.pas"/>
         <DCCReference Include="Core\MCPServer.Settings.pas"/>
         <DCCReference Include="Core\MCPServer.Registration.pas"/>
         <DCCReference Include="Core\MCPServer.ManagerRegistry.pas"/>

--- a/src/Tools/MCPServer.Tool.ListFiles.pas
+++ b/src/Tools/MCPServer.Tool.ListFiles.pas
@@ -35,7 +35,8 @@ type
 implementation
 
 uses
-  MCPServer.Registration;
+  MCPServer.Registration,
+  MCPServer.PathBoundary;
 
 { TListFilesTool }
 
@@ -62,7 +63,8 @@ begin
     NormalizedPath := TPath.GetFullPath(Params.Path);
     AllowedBasePath := TPath.GetFullPath(GetCurrentDir);
 
-    if not NormalizedPath.StartsWith(AllowedBasePath, True) then
+    const IsAllowed = TPathBoundary.IsWithin(NormalizedPath, AllowedBasePath);
+    if not IsAllowed then
     begin
       Result := 'Error: Access denied - path outside allowed directory';
       Exit;


### PR DESCRIPTION
The allowed-directory check in the built-in `list_files` tool compared two absolute paths with a plain `StartsWith`. A sibling directory whose name begins with the working directory's name (`mcp-server-secrets` next to `mcp-server`) therefore passed the check and got listed (CWE-22, incomplete string comparison).

`TPathBoundary.IsWithin` (new unit `MCPServer.PathBoundary.pas`) accepts the base directory itself and anything below it, comparing against the base with a trailing path delimiter. Trailing delimiters on either input are normalised first.

Symlinks inside the base directory are not resolved; that is unchanged.

Reported by Syed Anas Mohiuddin.

The same branch is merged into `feature/mcp-2026-07-28` in a separate PR, which also adds a DUnitX test for `TPathBoundary`.