### PR TITLE
Use the server as a library: a host facade, manager isolation, method tools and schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,9 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Streaming HTTP responses (`MCPServer.HttpStream`): when a request accepts
   `text/event-stream` and its handler sends a notification, the response is a
   chunked SSE stream (`X-Accel-Buffering: no`) with the notifications before
-  the final JSON-RPC response; a client that disconnects cancels the request.
+  the final JSON-RPC response; a client that disconnects cancels the request,
+  which is the only cancellation over HTTP: a `notifications/cancelled`
+  arrives on a connection of its own and is answered `202` and dropped.
   `notifications/progress` therefore reaches HTTP clients in both eras.
 - `IMCPRequestContext.Log` and `LogJson`: `notifications/message` on the
   request's own stream, only when the request carries
@@ -219,12 +221,59 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`MCPServer.Tool.InputRequiredSamples`) and the prompt
   `test_input_required_result_prompt`: the multi round-trip fixtures of the
   conformance suite.
+- `MCPServer.Host` (`TMCPServerHost`): the manager composition behind one
+  class, for an application that embeds the server. `StartHttp` returns as soon
+  as the server listens, `Stop` and `StartHttp` are idempotent, and `AddTool`,
+  `RemoveTool`, `HasTool`, `AddResource` and `AddPrompt` fill the managers
+  directly. A host publishes only what it was given; `SeedFromGlobalRegistry`,
+  set before the managers are built, takes `TMCPRegistry` instead, so two hosts
+  in one process publish exactly what each of them was handed.
+  `[Server] ExposeDiagnosticsResources` is honoured either way. `Create` reads
+  no settings file, `Create(SettingsFile)` reads the file it is named and
+  writes none, and `Create(Settings)` takes a `TMCPSettings` the caller keeps
+  owning; only the standalone server reads `settings.ini` from the executable's
+  directory. `RunStdio` is the blocking console entry point and
+  `RunStdioWith(Input, Output)` runs the same dispatch over two streams.
+  `TMCPServerApplication` is built on the host, so the composition exists once.
+- `TMCPToolsManager.Create(SeedFromRegistry)`, and the same overload on
+  `TMCPResourcesManager` and `TMCPPromptsManager`: a manager that starts empty
+  instead of reading `TMCPRegistry`. The parameterless constructor still seeds.
+- `TMCPIdHTTPServer.BoundPort`: the port the listener took, which is the one to
+  dial after `Port = 0`. A loopback or all-interfaces server on port 0 now
+  claims one ephemeral port and gives it to both the IPv4 and the IPv6 binding,
+  so the bound port is the same one whichever family a client resolves first.
+- `MCPServer.Tool.Method` (`TMCPMethodTool`): a tool whose shape comes from a
+  method. The input schema is generated from the parameter list, the arguments
+  are marshalled onto it, the method is invoked and its result is converted
+  back to JSON: `{"ok": true}` for a procedure, `{"result": ...}` for a
+  function. `MarshalArgument`, `ResultToJson`, `ReleaseResult` and
+  `ReleaseArguments` are virtual. By default the tool frees every object it
+  marshalled from the arguments and every object the method returned; a method
+  that keeps what it is handed, or hands back something it still owns,
+  overrides the matching release to do nothing.
+- `TMCPSchemaGenerator.GenerateSchemaFromMethod`, `GenerateSchemaFromType` and
+  `GenerateSchemaFromMethodResult`: the input schema of a parameter list, the
+  schema of a single type, and the `{"result": ...}` wrapper of a return type.
+  An untyped parameter, and a `var` or `out` parameter, are refused with an
+  `EArgumentException` naming the parameter, because a tool answers with its
+  result and not through its arguments. `$schema` from `[SchemaDialect]` stays
+  on the root schema and is never copied into a parameter or result member.
+- `TMCPSerializer.JsonToValue` and `ValueToJson`: the runtime marshal on a
+  `TRttiType` rather than a class. `JsonToValue` appends every object it
+  created to the list the caller passes, so the caller can free them.
+- `TMCPHeaderValue.Encode`: the counterpart of `TryDecode`, passing a
+  header-safe value through and wrapping anything else in the `=?base64?...?=`
+  sentinel. `MCP_HEADER_SESSION_ID`, `MCP_HEADER_PROTOCOL_VERSION`,
+  `MCP_HEADER_METHOD` and `MCP_HEADER_NAME` in `MCPServer.Types` are the one
+  place the four MCP header names are spelled; the HTTP server and the JSON-RPC
+  processor read them from there.
 
 ### Changed
 
 - `MCPServer.Application` holds the wiring the executable used to repeat for
-  each transport: `TMCPServerApplication.RunHttp` and `RunStdio` build the
-  managers once and the program file is the command-line entry point only.
+  each transport: `TMCPServerApplication` builds a `TMCPServerHost` seeded from
+  the global registry, `RunHttp` and `RunStdio` drive it, and the program file
+  is the command-line entry point only.
 - The content block helpers, the protocol version helpers and the redaction
   helpers are class functions on `TMCPContentBlock`, `TMCPProtocolVersion` and
   `TLogger`; `MCPServer.Schema.Generator` keeps its RTTI context in a class
@@ -396,3 +445,6 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `EArgumentException` instead of being silently dropped.
 - A tool result that fails to serialise no longer leaks the partial JSON
   object; the DEBUG `outputSchema` check no longer leaks the schema.
+- `build.bat` and `build-tests.bat` quote the TaurusTLS path they pass to the
+  compiler, so a path with a space no longer splits the `-I` and `-R`
+  arguments, and a build without TaurusTLS no longer passes a bare `-R`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,7 +50,11 @@ Such a stream is `200` even when the request ends in a JSON-RPC error,
 because the status line has already been sent. Requests that send no
 notification, and requests without `text/event-stream` in `Accept`, are
 answered as before (single JSON object, or one SSE event, with a
-`Content-Length`). Closing the stream cancels the request.
+`Content-Length`). Closing the stream cancels the request, and that is the
+only cancellation over HTTP: a `notifications/cancelled` for a request still
+in flight arrives on a connection of its own, is answered `202` and is
+dropped, because the tracker a request consults is its own response stream.
+Over stdio the same notification does stop the request.
 
 **TLS 1.0 and 1.1 are disabled** on the OpenSSL 1.0.2 handler (the build
 without `USE_TAURUS_TLS`).

--- a/README.md
+++ b/README.md
@@ -158,7 +158,12 @@ request accepts `text/event-stream` and a tool sends one, the response turns
 into an SSE stream (chunked, `X-Accel-Buffering: no`) that carries the
 notifications first and the JSON-RPC response as its last event. A request
 that sends none is answered as before. A client that closes the stream
-cancels the request.
+cancels the request: the server's next write to it fails and the tool sees
+`IsCancelled`. That is the HTTP cancellation. A `notifications/cancelled`
+naming the same request is answered `202` and dropped, because the tracker a
+request consults is its own response stream and a notification always arrives
+on a connection of its own; only over stdio, where every message shares one
+channel, does the notification stop a running request.
 
 ### Change notifications (`subscriptions/listen`)
 
@@ -240,20 +245,23 @@ Copy the `src` folder from MCPServer into your project and add the units to your
    - `lib\mcpserver\src\Resources`
    - `lib\mcpserver\src\Prompts`
 
-2. **Required Units**: Include these core units in your project:
+2. **Required Units**: `MCPServer.Host` is the only unit a host needs; it pulls
+   in the managers, the HTTP server and the stdio transport:
    ```pascal
-   MCPServer.Types,
-   MCPServer.Settings,
-   MCPServer.Registration,
-   MCPServer.ManagerRegistry,
-   MCPServer.IdHTTPServer,      // For HTTP transport
-   MCPServer.StdioTransport,    // For STDIO transport
-   MCPServer.JsonRpcProcessor   // Shared JSON-RPC processing
+   MCPServer.Host,              // TMCPServerHost, the library facade
+   MCPServer.Types,             // Interfaces, protocol constants, schema attributes
+   MCPServer.Registration       // TMCPRegistry, for self-registering tools
    ```
+   Composing the managers by hand instead needs `MCPServer.Settings`,
+   `MCPServer.ManagerRegistry`, `MCPServer.CoreManager`, the managers you want,
+   and `MCPServer.IdHTTPServer` or `MCPServer.StdioTransport`.
 
 ### Library Integration
 
-Once you have the project setup complete, the simplest way to add MCP capabilities to your application:
+`TMCPServerHost` (`MCPServer.Host`) is the whole composition behind one class:
+it builds the managers, owns the HTTP server and drives either transport.
+`StartHttp` returns as soon as the server listens, so the host fits into an
+application that has a message loop of its own:
 
 ```pascal
 program YourMCPServer;
@@ -262,36 +270,77 @@ program YourMCPServer;
 
 uses
   System.SysUtils,
-  MCPServer.Types in 'lib\mcpserver\src\Protocol\MCPServer.Types.pas',
-  MCPServer.IdHTTPServer in 'lib\mcpserver\src\Server\MCPServer.IdHTTPServer.pas',
-  MCPServer.Settings in 'lib\mcpserver\src\Core\MCPServer.Settings.pas',
-  MCPServer.ManagerRegistry in 'lib\mcpserver\src\Core\MCPServer.ManagerRegistry.pas',
-  MCPServer.CoreManager in 'lib\mcpserver\src\Managers\MCPServer.CoreManager.pas',
-  MCPServer.ToolsManager in 'lib\mcpserver\src\Managers\MCPServer.ToolsManager.pas',
-  MCPServer.ResourcesManager in 'lib\mcpserver\src\Managers\MCPServer.ResourcesManager.pas';
+  MCPServer.Host in 'lib\mcpserver\src\Server\MCPServer.Host.pas',
+  YourProject.Tool.Custom in 'YourProject.Tool.Custom.pas';
 
-var
-  Server: TMCPIdHTTPServer;
-  Settings: TMCPSettings;
-  ManagerRegistry: IMCPManagerRegistry;
-  
 begin
-  Settings := TMCPSettings.Create;
+  const Host = TMCPServerHost.Create;
+  try
+    Host.Settings.Port := 3000;
+    Host.AddTool(TCustomTool.Create);
+    Host.StartHttp;
+
+    Writeln('MCP Server running on port ', Host.BoundPort);
+    Readln;
+
+    Host.Stop;
+  finally
+    Host.Free;
+  end;
+end.
+```
+
+**What a host starts with.** Nothing. A fresh host publishes only the tools,
+resources, resource templates and prompts it was handed through `AddTool`,
+`AddResource` and `AddPrompt`, so two hosts in one process publish exactly what
+each of them was given. `SeedFromGlobalRegistry := True` takes everything from
+`TMCPRegistry` instead, which is what the standalone server does; set it before
+the first call that builds the managers, or it raises
+`EMCPConfigurationError`. `[Server] ExposeDiagnosticsResources` is honoured
+either way: with it off, `server://status`, `logs://recent` and `logs://{level}`
+never reach the lists.
+
+**Settings.** `Create` reads no file at all and starts from the built-in
+defaults, which `Host.Settings` then lets you change in code.
+`Create(SettingsFile)` reads the `.ini` you name and writes none.
+`Create(Settings)` takes a `TMCPSettings` you built yourself and keep owning.
+Only the standalone server reads `settings.ini` from the executable's own
+directory.
+
+**Ports.** `Settings.Port := 0` asks the operating system for a free port and
+`BoundPort` reports the one it gave. A loopback server takes that same port on
+both its IPv4 and its IPv6 binding, so `localhost` reaches it whichever family
+the client resolves first. `StartHttp` and `Stop` are both idempotent.
+
+**Transports.** `RunStdio` blocks and is a console entry point only: the stdio
+transport claims stdout and redirects the logger to stderr for the whole
+process, so a GUI application must never call it. `RunStdioWith(Input, Output)`
+runs the same dispatch over two streams, which is how a test drives one line in
+and reads one line out.
+
+Composing the managers by hand still works, and is what to do when you need a
+manager the host does not build:
+
+```pascal
+var
+  ManagerRegistry: IMCPManagerRegistry;
+begin
+  const Settings = TMCPSettings.Create;
   try
     ManagerRegistry := TMCPManagerRegistry.Create;
     ManagerRegistry.RegisterManager(TMCPCoreManager.Create(Settings));
-    ManagerRegistry.RegisterManager(TMCPToolsManager.Create);
-    ManagerRegistry.RegisterManager(TMCPResourcesManager.Create);
-    
-    Server := TMCPIdHTTPServer.Create(nil);
+    ManagerRegistry.RegisterManager(TMCPToolsManager.Create(False));
+    ManagerRegistry.RegisterManager(TMCPResourcesManager.Create(False));
+
+    const Server = TMCPIdHTTPServer.Create(nil);
     try
       Server.Settings := Settings;
       Server.ManagerRegistry := ManagerRegistry;
       Server.Start;
-      
-      Writeln('MCP Server running on port ', Settings.Port);
-      Readln; // Keep running
-      
+
+      Writeln('MCP Server running on port ', Server.BoundPort);
+      Readln;
+
       Server.Stop;
     finally
       Server.Free;
@@ -304,10 +353,10 @@ end.
 
 #### Library checklist
 
-- **Register before you start.** `TMCPToolsManager.Create` and `TMCPResourcesManager.Create` read `TMCPRegistry` once. Register your tools and resources (normally from unit `initialization` sections) before the managers are created, which means before `TMCPIdHTTPServer.Start` or `TMCPStdioTransport.Run`. Later registrations are not picked up.
+- **Register before you start, or hand them over afterwards.** The parameterless `TMCPToolsManager.Create`, `TMCPResourcesManager.Create` and `TMCPPromptsManager.Create` read `TMCPRegistry` once, so a registration made after the managers exist is not picked up: register your tools, resources and prompts (normally from unit `initialization` sections) first. `Create(False)`, and a `TMCPServerHost` left at its default `SeedFromGlobalRegistry`, read the registry not at all and publish only what you hand them, which you can do at any time.
 - **STDIO: keep stdout clean.** Everything on stdout must be an MCP message. `TMCPStdioTransport.Create` forces `TLogger.UseStdErr := True` and sets `TLogger.StdoutReserved`, so console logging goes to stderr and an attempt to switch it back is refused with a one-time warning. Never `Writeln` from tools, managers or resources; log through `TLogger`.
-- **`server://status` is registered by default** by the unit initialization of `MCPServer.Resource.Server`. `TServerStatusResource.SetNamePrefix('myapp_')` renames it to `server://myapp_status`; call it before the managers are created.
-- **Error codes and protocol constants** live in `MCPServer.Types` (`JSONRPC_*`, `MCP_ERROR_*`, `MCP_PROTOCOL_VERSION_*`, `MCP_META_*`). The `JSONRPC_*` names in `MCPServer.JsonRpcProcessor` remain as aliases.
+- **`server://status` is registered by default** by the unit initialization of `MCPServer.Resource.Server`, and reaches every manager that seeds from the registry. `TServerStatusResource.SetNamePrefix('myapp_')` renames it to `server://myapp_status`; call it before the managers are created. `[Server] ExposeDiagnosticsResources = false` keeps it, `logs://recent` and `logs://{level}` out of the lists altogether.
+- **Error codes and protocol constants** live in `MCPServer.Types` (`JSONRPC_*`, `MCP_ERROR_*`, `MCP_PROTOCOL_VERSION_*`, `MCP_META_*`, and the header names `MCP_HEADER_SESSION_ID`, `MCP_HEADER_PROTOCOL_VERSION`, `MCP_HEADER_METHOD` and `MCP_HEADER_NAME`). The `JSONRPC_*` names in `MCPServer.JsonRpcProcessor` remain as aliases. `TMCPHeaderValue.Encode` (`MCPServer.HttpHeaders`) writes a value into a header the way `TryDecode` reads one back: a header-safe value passes through, anything else is wrapped in the `=?base64?...?=` sentinel.
 - **Prompts and completion are optional managers**, registered the same way as tools and resources: `ManagerRegistry.RegisterManager(TMCPPromptsManager.Create)` and, if you want argument completion, `ManagerRegistry.RegisterManager(TMCPCompletionManager.Create(PromptsManager, ResourcesManager))` (it needs the concrete manager instances, not the `IMCPCapabilityManager` interface, to look prompts and resource templates up by name). The `prompts` and `completions` capabilities are only advertised when these managers are registered.
 
 ### Creating Custom Tools
@@ -407,6 +456,84 @@ JSON. Set `FAnnotations` or `FIcons` in the constructor to publish them in
 pair for a tool that only reads (pass `True` when it reaches outside the
 server). `MCPServer.Tool.ContentSamples`
 has one small example per content type.
+
+### A tool from a method
+
+`TMCPMethodTool` (`MCPServer.Tool.Method`) turns a method you already have into
+a tool. The input schema comes from the parameter list, the arguments are
+marshalled onto it, the method is invoked, and its result is converted back to
+JSON:
+
+```pascal
+type
+  TOrderService = class
+  public
+    function PlaceOrder([SchemaDescription('Customer code')] const Customer: string;
+                        [Optional] const Quantity: Integer): string;
+  end;
+
+var
+  Context: TRttiContext;
+begin
+  const Service = TOrderService.Create;
+  const Method = Context.GetType(TOrderService).GetMethod('PlaceOrder');
+
+  Host.AddTool(TMCPMethodTool.Create(TValue.From<TOrderService>(Service), Method,
+                                     'place_order', 'Places an order'));
+end;
+```
+
+A parameter is published under its lower-cased name, or under `[SchemaName]`
+when it carries one, and is required unless it carries `[Optional]`; every
+schema attribute that works on a class property works on a parameter. The
+method needs RTTI, which a public method of a class compiled with the default
+`{$RTTI}` settings has, and `MarkReadOnly` writes the `readOnlyHint` pair the
+same way it does for `TMCPToolBase`.
+
+The result of a procedure is `{"ok": true}` and the result of a function is
+`{"result": <value>}`, which is what `GetOutputSchema` describes. A descendant
+that overrides `ResultToJson` replaces that object wholesale, so its envelope is
+the whole structured result and is not nested under `result`; such a descendant
+overrides `GetOutputSchema` with it, or the two disagree.
+
+**Who frees what.** Every object the tool marshalled from the arguments, and
+every object the method returned, is freed after the call, along with the
+elements of a returned dynamic array of objects. That is the wrong rule for a
+method that keeps what it is handed, which is the ordinary `Add(Item)` shape in
+Delphi, and for a method that hands back something it still owns. Both are
+virtual, so a descendant says so:
+
+```pascal
+type
+  TAdoptingTool = class(TMCPMethodTool)
+  protected
+    procedure ReleaseArguments(const Owned: TList<TObject>); override;
+    procedure ReleaseResult(const Value: TValue; const ResultType: TRttiType); override;
+  end;
+
+procedure TAdoptingTool.ReleaseArguments(const Owned: TList<TObject>);
+begin
+end;
+
+procedure TAdoptingTool.ReleaseResult(const Value: TValue; const ResultType: TRttiType);
+begin
+end;
+```
+
+An untyped parameter, and a `var` or `out` parameter, have no place in a schema:
+a tool answers with its result, not through its arguments. Both are refused when
+the tool is created, with an `EArgumentException` naming the parameter.
+
+The three generator entry points are usable on their own:
+`TMCPSchemaGenerator.GenerateSchemaFromMethod` builds the input schema of a
+parameter list, `GenerateSchemaFromType` the schema of a single type, and
+`GenerateSchemaFromMethodResult` the `{"result": ...}` wrapper of a return type
+(`nil` for a procedure, and for a return type that has no JSON shape). `$schema`
+from `[SchemaDialect]` belongs to a root schema only and is never copied into a
+parameter or result member. The marshal underneath them is public too:
+`TMCPSerializer.JsonToValue` builds a `TValue` of a given `TRttiType` from a
+`TJSONValue` and appends every object it created to the list you pass, and
+`TMCPSerializer.ValueToJson` writes one back out.
 
 ### Asking the client for input (multi round-trip requests)
 

--- a/build-tests.bat
+++ b/build-tests.bat
@@ -41,9 +41,13 @@ if "!TAURUS_PATH!"=="" if exist "!CATALOG_DIR!\TaurusTLS-12\Source" set "TAURUS_
 
 :TaurusResolved
 if not "!TAURUS_PATH!"=="" (
-    set EXTRA_UNITS=;!TAURUS_PATH!
+    set "EXTRA_UNITS=;!TAURUS_PATH!"
+    set "EXTRA_INCLUDES=;!TAURUS_PATH!"
+    set "EXTRA_RES=-R!TAURUS_PATH!"
 ) else (
-    set EXTRA_UNITS=
+    set "EXTRA_UNITS="
+    set "EXTRA_INCLUDES="
+    set "EXTRA_RES="
     echo Warning: TaurusTLS not found. The HTTP server unit needs it.
 )
 
@@ -54,10 +58,10 @@ echo Building MCPServer.Tests - %CONFIG% %PLATFORM%
 echo.
 
 if "%PLATFORM%"=="Win32" (
-    !DCC32! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win32\debug";%UNIT_PATHS% -Isrc;!TAURUS_PATH!;"!DUNITX_PATH!" -R!TAURUS_PATH! -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServerTests.dpr
+    !DCC32! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win32\debug";%UNIT_PATHS% -Isrc!EXTRA_INCLUDES!;"!DUNITX_PATH!" !EXTRA_RES! -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServerTests.dpr
     goto :CheckBuildResult
 ) else if "%PLATFORM%"=="Win64" (
-    !DCC64! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win64\debug";%UNIT_PATHS% -Isrc;!TAURUS_PATH!;"!DUNITX_PATH!" -R!TAURUS_PATH! -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServerTests.dpr
+    !DCC64! -B -H -W -NS%NAMESPACES% -U"!DELPHI_PATH!\lib\Win64\debug";%UNIT_PATHS% -Isrc!EXTRA_INCLUDES!;"!DUNITX_PATH!" !EXTRA_RES! -E%OUTPUT_DIR% -N0%OUTPUT_DIR% -D%CONFIG% tests\MCPServerTests.dpr
     goto :CheckBuildResult
 ) else (
     echo ERROR: Invalid platform. Use Win32 or Win64

--- a/build.bat
+++ b/build.bat
@@ -63,17 +63,21 @@ if "!TAURUS_PATH!"=="" if exist "!CATALOG_DIR!\TaurusTLS-12\Source" set "TAURUS_
 :TaurusResolved
 if not "!TAURUS_PATH!"=="" (
     echo Using TaurusTLS: !TAURUS_PATH!
-    set EXTRA_UNITS=;!TAURUS_PATH!
+    set "EXTRA_UNITS=;!TAURUS_PATH!"
+    set "EXTRA_INCLUDES=;!TAURUS_PATH!"
+    set "EXTRA_RES=-R!TAURUS_PATH!"
 ) else (
-    set EXTRA_UNITS=
+    set "EXTRA_UNITS="
+    set "EXTRA_INCLUDES="
+    set "EXTRA_RES="
     echo Warning: TaurusTLS not found. SSL/TLS support may be limited.
 )
 
 if "%PLATFORM%"=="Win32" (
-    !DCC32! -B -H -W -NSWinapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;System;Xml;Data;Datasnap;Web;Soap -U"!DELPHI_PATH!\lib\Win32\debug";src;src\Managers;src\Server;src\Tools;src\Core;src\Protocol;src\Libraries;src\Resources;src\Prompts!EXTRA_UNITS! -Isrc;!TAURUS_PATH! -R!TAURUS_PATH! -E.\%PLATFORM%\%CONFIG% -N0.\%PLATFORM%\%CONFIG% -LE.\%PLATFORM%\%CONFIG% -LN.\%PLATFORM%\%CONFIG% -D%CONFIG% src\MCPServer.dpr
+    !DCC32! -B -H -W -NSWinapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;System;Xml;Data;Datasnap;Web;Soap -U"!DELPHI_PATH!\lib\Win32\debug";src;src\Managers;src\Server;src\Tools;src\Core;src\Protocol;src\Libraries;src\Resources;src\Prompts!EXTRA_UNITS! -Isrc!EXTRA_INCLUDES! !EXTRA_RES! -E.\%PLATFORM%\%CONFIG% -N0.\%PLATFORM%\%CONFIG% -LE.\%PLATFORM%\%CONFIG% -LN.\%PLATFORM%\%CONFIG% -D%CONFIG% src\MCPServer.dpr
     goto :CheckBuildResult
 ) else if "%PLATFORM%"=="Win64" (
-    !DCC64! -B -H -W -NSWinapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;System;Xml;Data;Datasnap;Web;Soap -U"!DELPHI_PATH!\lib\Win64\debug";src;src\Managers;src\Server;src\Tools;src\Core;src\Protocol;src\Libraries;src\Resources;src\Prompts!EXTRA_UNITS! -Isrc;!TAURUS_PATH! -R!TAURUS_PATH! -E.\%PLATFORM%\%CONFIG% -N0.\%PLATFORM%\%CONFIG% -LE.\%PLATFORM%\%CONFIG% -LN.\%PLATFORM%\%CONFIG% -D%CONFIG% src\MCPServer.dpr
+    !DCC64! -B -H -W -NSWinapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;System;Xml;Data;Datasnap;Web;Soap -U"!DELPHI_PATH!\lib\Win64\debug";src;src\Managers;src\Server;src\Tools;src\Core;src\Protocol;src\Libraries;src\Resources;src\Prompts!EXTRA_UNITS! -Isrc!EXTRA_INCLUDES! !EXTRA_RES! -E.\%PLATFORM%\%CONFIG% -N0.\%PLATFORM%\%CONFIG% -LE.\%PLATFORM%\%CONFIG% -LN.\%PLATFORM%\%CONFIG% -D%CONFIG% src\MCPServer.dpr
     goto :CheckBuildResult
 ) else if "%PLATFORM%"=="Linux64" (
     REM Use MSBuild for Linux64

--- a/src/Core/MCPServer.Application.pas
+++ b/src/Core/MCPServer.Application.pas
@@ -7,23 +7,15 @@ uses
   System.SyncObjs,
   MCPServer.Types,
   MCPServer.Settings,
-  MCPServer.ToolsManager,
-  MCPServer.ResourcesManager,
-  MCPServer.PromptsManager,
-  MCPServer.SubscriptionsManager;
+  MCPServer.Host;
 
 type
   TMCPServerApplication = class
   strict private
     FSettings: TMCPSettings;
-    FManagerRegistry: IMCPManagerRegistry;
-    FCoreManager: IMCPCapabilityManager;
-    FToolsManager: TMCPToolsManager;
-    FResourcesManager: TMCPResourcesManager;
-    FPromptsManager: TMCPPromptsManager;
-    FSubscriptionsManager: TMCPSubscriptionsManager;
-    procedure BuildManagers;
-    procedure HideDiagnosticsResources;
+    FHost: TMCPServerHost;
+    function GetManagerRegistry: IMCPManagerRegistry;
+    function GetCoreManager: IMCPCapabilityManager;
     procedure LogBanner(const Transport: string);
   public
     constructor Create(const WriteSettingsFile: Boolean);
@@ -33,27 +25,19 @@ type
     procedure RunStdio;
 
     property Settings: TMCPSettings read FSettings;
-    property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry;
-    property CoreManager: IMCPCapabilityManager read FCoreManager;
+    property ManagerRegistry: IMCPManagerRegistry read GetManagerRegistry;
+    property CoreManager: IMCPCapabilityManager read GetCoreManager;
   end;
 
 implementation
 
 uses
   MCPServer.Logger,
-  MCPServer.Authorization,
-  MCPServer.ManagerRegistry,
-  MCPServer.CoreManager,
-  MCPServer.CompletionManager,
-  MCPServer.IdHTTPServer,
-  MCPServer.StdioTransport;
+  MCPServer.Authorization;
 
 const
   BANNER_RULE = '================================';
   BANNER_TITLE = 'Model Context Protocol Server';
-  URI_LOGS_RECENT = 'logs://recent';
-  URI_SERVER_STATUS = 'server://status';
-  URI_TEMPLATE_LOGS_BY_LEVEL = 'logs://{level}';
 
 { TMCPServerApplication }
 
@@ -61,46 +45,25 @@ constructor TMCPServerApplication.Create(const WriteSettingsFile: Boolean);
 begin
   inherited Create;
   FSettings := TMCPSettings.Create('', WriteSettingsFile);
-  BuildManagers;
+  FHost := TMCPServerHost.Create(FSettings);
+  FHost.SeedFromGlobalRegistry := True;
 end;
 
 destructor TMCPServerApplication.Destroy;
 begin
-  FCoreManager := nil;
-  FManagerRegistry := nil;
+  FHost.Free;
   FSettings.Free;
   inherited;
 end;
 
-procedure TMCPServerApplication.BuildManagers;
+function TMCPServerApplication.GetManagerRegistry: IMCPManagerRegistry;
 begin
-  FManagerRegistry := TMCPManagerRegistry.Create;
-  FCoreManager := TMCPCoreManager.Create(FSettings);
-  FToolsManager := TMCPToolsManager.Create;
-  FResourcesManager := TMCPResourcesManager.Create;
-  FPromptsManager := TMCPPromptsManager.Create;
-  FSubscriptionsManager := TMCPSubscriptionsManager.Create;
-
-  if not FSettings.ExposeDiagnosticsResources then
-    HideDiagnosticsResources;
-
-  FToolsManager.ChangeNotifier := FSubscriptionsManager;
-  FResourcesManager.ChangeNotifier := FSubscriptionsManager;
-  FPromptsManager.ChangeNotifier := FSubscriptionsManager;
-
-  FManagerRegistry.RegisterManager(FCoreManager);
-  FManagerRegistry.RegisterManager(FToolsManager);
-  FManagerRegistry.RegisterManager(FResourcesManager);
-  FManagerRegistry.RegisterManager(FPromptsManager);
-  FManagerRegistry.RegisterManager(TMCPCompletionManager.Create(FPromptsManager, FResourcesManager));
-  FManagerRegistry.RegisterManager(FSubscriptionsManager);
+  Result := FHost.ManagerRegistry;
 end;
 
-procedure TMCPServerApplication.HideDiagnosticsResources;
+function TMCPServerApplication.GetCoreManager: IMCPCapabilityManager;
 begin
-  FResourcesManager.RemoveResource(URI_LOGS_RECENT);
-  FResourcesManager.RemoveResource(URI_SERVER_STATUS);
-  FResourcesManager.RemoveResourceTemplate(URI_TEMPLATE_LOGS_BY_LEVEL);
+  Result := FHost.CoreManager;
 end;
 
 procedure TMCPServerApplication.LogBanner(const Transport: string);
@@ -116,39 +79,23 @@ begin
   LogBanner('HTTP');
   TLogger.Info(Format('Listening on port %d', [FSettings.Port]));
 
-  const Server = TMCPIdHTTPServer.Create(nil);
-  try
-    Server.Settings := FSettings;
-    Server.ManagerRegistry := FManagerRegistry;
-    Server.CoreManager := FCoreManager;
+  const RequiresToken = (Length(FSettings.BearerTokenList) > 0);
+  if RequiresToken then
+    FHost.Authorizer := TMCPStaticBearerAuthorizer.Create(FSettings.BearerTokenList);
 
-    const RequiresToken = (Length(FSettings.BearerTokenList) > 0);
-    if RequiresToken then
-      Server.Authorizer := TMCPStaticBearerAuthorizer.Create(FSettings.BearerTokenList);
+  FHost.StartHttp;
+  TLogger.Info('Server started. Press CTRL+C to stop...');
+  Shutdown.WaitFor(INFINITE);
 
-    Server.Start;
-    TLogger.Info('Server started. Press CTRL+C to stop...');
-    Shutdown.WaitFor(INFINITE);
-
-    TLogger.Info('Shutting down server...');
-    Server.Stop;
-    TLogger.Info('Server stopped successfully');
-  finally
-    Server.Free;
-  end;
+  TLogger.Info('Shutting down server...');
+  FHost.Stop;
+  TLogger.Info('Server stopped successfully');
 end;
 
 procedure TMCPServerApplication.RunStdio;
 begin
   LogBanner('STDIO');
-
-  const Transport = TMCPStdioTransport.Create(FManagerRegistry, FCoreManager);
-  try
-    Transport.Settings := FSettings;
-    Transport.Run;
-  finally
-    Transport.Free;
-  end;
+  FHost.RunStdio;
 end;
 
 end.

--- a/src/Core/MCPServer.Settings.pas
+++ b/src/Core/MCPServer.Settings.pas
@@ -52,6 +52,7 @@ type
     procedure CreateDefaultSettingsFile;
   public
     constructor Create(const ASettingsFile: string = ''; const ACreateFile: Boolean = True);
+    constructor CreateDefaults;
     destructor Destroy; override;
 
     procedure LoadFromFile;
@@ -142,6 +143,12 @@ begin
   end;
 
   LoadFromFile;
+end;
+
+constructor TMCPSettings.CreateDefaults;
+begin
+  inherited Create;
+  LoadDefaults;
 end;
 
 destructor TMCPSettings.Destroy;
@@ -363,6 +370,10 @@ procedure TMCPSettings.SaveToFile;
 var
   IniFile: TIniFile;
 begin
+  const HasSettingsFile = (FSettingsFile <> '');
+  if not HasSettingsFile then
+    Exit;
+
   IniFile := TIniFile.Create(FSettingsFile);
   try
     IniFile.WriteInteger(SECTION_SERVER, 'Port', FPort);

--- a/src/MCPServer.dpr
+++ b/src/MCPServer.dpr
@@ -35,6 +35,7 @@ uses
   MCPServer.IdHTTPServer in 'Server\MCPServer.IdHTTPServer.pas',
   MCPServer.StdioTransport in 'Server\MCPServer.StdioTransport.pas',
   MCPServer.StdioChannel in 'Server\MCPServer.StdioChannel.pas',
+  MCPServer.Host in 'Server\MCPServer.Host.pas',
   MCPServer.JsonRpcProcessor in 'Protocol\MCPServer.JsonRpcProcessor.pas',
   MCPServer.CoreManager in 'Managers\MCPServer.CoreManager.pas',
   MCPServer.ToolsManager in 'Managers\MCPServer.ToolsManager.pas',

--- a/src/MCPServer.dproj
+++ b/src/MCPServer.dproj
@@ -164,6 +164,7 @@
         <DCCReference Include="Resources\MCPServer.Resource.Project.pas"/>
         <DCCReference Include="Tools\MCPServer.Tool.Result.pas"/>
         <DCCReference Include="Server\MCPServer.StdioChannel.pas"/>
+        <DCCReference Include="Server\MCPServer.Host.pas"/>
         <DCCReference Include="Tools\MCPServer.Tool.ContentSamples.pas"/>
         <DCCReference Include="Tools\MCPServer.Tool.InputRequiredSamples.pas"/>
         <DCCReference Include="Tools\MCPServer.Tool.SubscriptionSamples.pas"/>

--- a/src/Managers/MCPServer.PromptsManager.pas
+++ b/src/Managers/MCPServer.PromptsManager.pas
@@ -29,7 +29,8 @@ type
     function CreatePromptJSON(const Prompt: IMCPPrompt): TJSONObject;
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
   public
-    constructor Create;
+    constructor Create; overload;
+    constructor Create(const SeedFromRegistry: Boolean); overload;
     destructor Destroy; override;
 
     procedure AddPrompt(const Prompt: IMCPPrompt);
@@ -69,13 +70,19 @@ const
 
 constructor TMCPPromptsManager.Create;
 begin
-  inherited;
+  Create(True);
+end;
+
+constructor TMCPPromptsManager.Create(const SeedFromRegistry: Boolean);
+begin
+  inherited Create;
   FLock := TCriticalSection.Create;
   FPrompts := TDictionary<string, IMCPPrompt>.Create;
   FOrder := TList<string>.Create;
   FListTtlMs := 0;
   FListCacheScope := MCP_CACHE_SCOPE_PRIVATE;
-  RegisterBuiltInPrompts;
+  if SeedFromRegistry then
+    RegisterBuiltInPrompts;
 end;
 
 destructor TMCPPromptsManager.Destroy;

--- a/src/Managers/MCPServer.ResourcesManager.pas
+++ b/src/Managers/MCPServer.ResourcesManager.pas
@@ -35,7 +35,8 @@ type
     function FindResource(const URI: string): IMCPResource;
     function EraOf(const Context: IMCPRequestContext): TMCPProtocolEra;
   public
-    constructor Create;
+    constructor Create; overload;
+    constructor Create(const SeedFromRegistry: Boolean); overload;
     destructor Destroy; override;
 
     procedure AddResource(const Resource: IMCPResource);
@@ -82,15 +83,23 @@ const
 
 constructor TMCPResourcesManager.Create;
 begin
-  inherited;
+  Create(True);
+end;
+
+constructor TMCPResourcesManager.Create(const SeedFromRegistry: Boolean);
+begin
+  inherited Create;
   FLock := TCriticalSection.Create;
   FResources := TDictionary<string, IMCPResource>.Create;
   FOrder := TList<string>.Create;
   FTemplates := TList<IMCPResourceTemplate>.Create;
   FListTtlMs := 0;
   FListCacheScope := MCP_CACHE_SCOPE_PRIVATE;
-  RegisterBuiltInResources;
-  RegisterBuiltInResourceTemplates;
+  if SeedFromRegistry then
+  begin
+    RegisterBuiltInResources;
+    RegisterBuiltInResourceTemplates;
+  end;
 end;
 
 destructor TMCPResourcesManager.Destroy;

--- a/src/Managers/MCPServer.ToolsManager.pas
+++ b/src/Managers/MCPServer.ToolsManager.pas
@@ -40,7 +40,8 @@ type
     procedure RegisterTool(const Tool: IMCPTool);
     procedure RegisterBuiltInTools;
   public
-    constructor Create;
+    constructor Create; overload;
+    constructor Create(const SeedFromRegistry: Boolean); overload;
     destructor Destroy; override;
 
     procedure AddTool(const Tool: IMCPTool);
@@ -106,13 +107,19 @@ end;
 
 constructor TMCPToolsManager.Create;
 begin
-  inherited;
+  Create(True);
+end;
+
+constructor TMCPToolsManager.Create(const SeedFromRegistry: Boolean);
+begin
+  inherited Create;
   FLock := TCriticalSection.Create;
   FTools := TDictionary<string, IMCPTool>.Create;
   FOrder := TList<string>.Create;
   FListTtlMs := 0;
   FListCacheScope := MCP_CACHE_SCOPE_PRIVATE;
-  RegisterBuiltInTools;
+  if SeedFromRegistry then
+    RegisterBuiltInTools;
 end;
 
 destructor TMCPToolsManager.Destroy;

--- a/src/Protocol/MCPServer.JsonRpcProcessor.pas
+++ b/src/Protocol/MCPServer.JsonRpcProcessor.pas
@@ -108,6 +108,8 @@ const
   META_PATH_PREFIX = 'params._meta.';
   MESSAGE_PARAMS_NOT_OBJECT = 'params must be an object';
   MESSAGE_HEADER_MISMATCH = 'Header mismatch: %s header value ''%s'' does not match body value ''%s''';
+  MESSAGE_HEADER_MISSING_SUFFIX = ' header is missing';
+  MESSAGE_HEADER_INVALID_SUFFIX = ' header value is not a valid header value';
   RESULT_TYPE_COMPLETE = 'complete';
 
   LEGACY_ONLY_METHODS: array[0..4] of string = (
@@ -306,11 +308,11 @@ var
   Decoded: string;
 begin
   if not Hints.HasMethodHeader then
-    raise EMCPError.HeaderMismatch('Mcp-Method header is missing');
+    raise EMCPError.HeaderMismatch(MCP_HEADER_METHOD + MESSAGE_HEADER_MISSING_SUFFIX);
   const IsNotMethod = (Hints.MethodHeader <> Method);
   if IsNotMethod then
     raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
-      ['Mcp-Method', Hints.MethodHeader, Method]));
+      [MCP_HEADER_METHOD, Hints.MethodHeader, Method]));
 
   var SourceField := '';
   if (Method = MCP_METHOD_TOOLS_CALL) or (Method = MCP_METHOD_PROMPTS_GET) then
@@ -322,9 +324,9 @@ begin
     Exit;
 
   if not Hints.HasNameHeader then
-    raise EMCPError.HeaderMismatch('Mcp-Name header is missing');
+    raise EMCPError.HeaderMismatch(MCP_HEADER_NAME + MESSAGE_HEADER_MISSING_SUFFIX);
   if not TMCPHeaderValue.TryDecode(Hints.NameHeader, Decoded) then
-    raise EMCPError.HeaderMismatch('Mcp-Name header value is not a valid header value');
+    raise EMCPError.HeaderMismatch(MCP_HEADER_NAME + MESSAGE_HEADER_INVALID_SUFFIX);
 
   var BodyValue := '';
   if Assigned(Params) then
@@ -336,7 +338,7 @@ begin
   const IsNotBodyValue = (Decoded <> BodyValue);
   if IsNotBodyValue then
     raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
-      ['Mcp-Name', Decoded, BodyValue]));
+      [MCP_HEADER_NAME, Decoded, BodyValue]));
 end;
 
 function TMCPJsonRpcProcessor.NewContext(Era: TMCPProtocolEra; const Version, Method: string;
@@ -373,11 +375,11 @@ begin
   if Hints.HasHeaderLayer then
   begin
     if not Hints.HasProtocolVersionHeader then
-      raise EMCPError.HeaderMismatch('MCP-Protocol-Version header is missing');
+      raise EMCPError.HeaderMismatch(MCP_HEADER_PROTOCOL_VERSION + MESSAGE_HEADER_MISSING_SUFFIX);
     const IsNotVersion = (Hints.ProtocolVersionHeader <> Version);
     if IsNotVersion then
       raise EMCPError.HeaderMismatch(Format(MESSAGE_HEADER_MISMATCH,
-        ['MCP-Protocol-Version', Hints.ProtocolVersionHeader, Version]));
+        [MCP_HEADER_PROTOCOL_VERSION, Hints.ProtocolVersionHeader, Version]));
   end;
 
   if not TMCPProtocolVersion.IsModern(Version) then

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -13,22 +13,26 @@ type
   private
     const MAX_NESTING_DEPTH = 8;
     class var FContext: TRttiContext;
-    class function GetPropertyJsonName(Prop: TRttiProperty): string;
-    class function IsRequiredProperty(Prop: TRttiProperty): Boolean;
+    class function GetJsonName(const Member: TRttiNamedObject): string;
+    class function IsRequired(const Member: TRttiNamedObject): Boolean;
     class function CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
     class function ListItemType(RttiType: TRttiType): TRttiType;
     class function TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
     class procedure DescribeFloat(RttiType: TRttiType; const Schema: TJSONObject);
     class procedure DescribeSet(RttiType: TRttiType; const Schema: TJSONObject);
     class function ClassSchema(RttiType: TRttiType; Depth: Integer; const Schema: TJSONObject): TJSONObject;
-    class function ObjectSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+    class function ObjectSchema(RttiType: TRttiType; Depth: Integer; const IsRoot: Boolean): TJSONObject;
     class function NumberValue(const Value: Double): TJSONNumber;
-    class procedure ApplyAttributes(Prop: TRttiProperty; const PropSchema: TJSONObject);
+    class procedure ApplyAttributes(const Member: TRttiNamedObject; const MemberSchema: TJSONObject);
+    class procedure GuardParameterHasSchema(const Method: TRttiMethod; const Param: TRttiParameter);
   public
     class constructor Create;
     class destructor Destroy;
     class function GenerateSchema(Cls: TClass): TJSONObject;
     class function GenerateSchemaFromInstance(Instance: TObject): TJSONObject;
+    class function GenerateSchemaFromType(const RttiType: TRttiType): TJSONObject;
+    class function GenerateSchemaFromMethod(const Method: TRttiMethod): TJSONObject;
+    class function GenerateSchemaFromMethodResult(const Method: TRttiMethod): TJSONObject;
   end;
 
 implementation
@@ -50,6 +54,12 @@ const
   SCHEMA_KEY_ITEMS = 'items';
   SCHEMA_KEY_PROPERTIES = 'properties';
   SCHEMA_KEY_REQUIRED = 'required';
+  SCHEMA_KEY_RESULT = 'result';
+
+  DEPTH_ABOVE_ROOT = -1;
+
+  UNDESCRIBABLE_RESULT_KINDS = [tkUnknown, tkPointer, tkProcedure, tkMethod, tkClassRef,
+    tkInterface, tkRecord, tkMRecord];
 
 
 { TMCPSchemaGenerator }
@@ -66,7 +76,7 @@ end;
 
 class function TMCPSchemaGenerator.GenerateSchema(Cls: TClass): TJSONObject;
 begin
-  Result := ObjectSchema(FContext.GetType(Cls), 0);
+  Result := ObjectSchema(FContext.GetType(Cls), 0, True);
 end;
 
 class function TMCPSchemaGenerator.GenerateSchemaFromInstance(Instance: TObject): TJSONObject;
@@ -74,20 +84,111 @@ begin
   Result := GenerateSchema(Instance.ClassType);
 end;
 
-class function TMCPSchemaGenerator.GetPropertyJsonName(Prop: TRttiProperty): string;
+class function TMCPSchemaGenerator.GenerateSchemaFromType(const RttiType: TRttiType): TJSONObject;
 begin
-  for var Attr in Prop.GetAttributes do
+  if not Assigned(RttiType) then
+    Exit(nil);
+
+  if RttiType.TypeKind = tkClass then
+    Exit(ClassSchema(RttiType, DEPTH_ABOVE_ROOT, TJSONObject.Create));
+
+  Result := TypeSchema(RttiType, 0);
+end;
+
+class function TMCPSchemaGenerator.GenerateSchemaFromMethod(const Method: TRttiMethod): TJSONObject;
+begin
+  Result := TJSONObject.Create;
+  try
+    Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
+
+    const Properties = TJSONObject.Create;
+    Result.AddPair(SCHEMA_KEY_PROPERTIES, Properties);
+
+    const RequiredArray = TJSONArray.Create;
+    try
+      for var Param in Method.GetParameters do
+      begin
+        GuardParameterHasSchema(Method, Param);
+
+        const WireName = GetJsonName(Param);
+        const ParamSchema = GenerateSchemaFromType(Param.ParamType);
+        Properties.AddPair(WireName, ParamSchema);
+        ApplyAttributes(Param, ParamSchema);
+
+        if IsRequired(Param) then
+          RequiredArray.Add(WireName);
+      end;
+    except
+      RequiredArray.Free;
+      raise;
+    end;
+
+    const HasRequiredArray = (RequiredArray.Count > 0);
+    if HasRequiredArray then
+      Result.AddPair(SCHEMA_KEY_REQUIRED, RequiredArray)
+    else
+      RequiredArray.Free;
+
+    Result.AddPair(SCHEMA_KEY_ADDITIONAL_PROPERTIES, TJSONBool.Create(False));
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+class function TMCPSchemaGenerator.GenerateSchemaFromMethodResult(const Method: TRttiMethod): TJSONObject;
+begin
+  const ReturnType = Method.ReturnType;
+  if not Assigned(ReturnType) or (ReturnType.TypeKind in UNDESCRIBABLE_RESULT_KINDS) then
+    Exit(nil);
+
+  Result := TJSONObject.Create;
+  try
+    Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
+
+    const Properties = TJSONObject.Create;
+    Result.AddPair(SCHEMA_KEY_PROPERTIES, Properties);
+    Properties.AddPair(SCHEMA_KEY_RESULT, GenerateSchemaFromType(ReturnType));
+
+    const RequiredArray = TJSONArray.Create;
+    Result.AddPair(SCHEMA_KEY_REQUIRED, RequiredArray);
+    RequiredArray.Add(SCHEMA_KEY_RESULT);
+
+    Result.AddPair(SCHEMA_KEY_ADDITIONAL_PROPERTIES, TJSONBool.Create(False));
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+class procedure TMCPSchemaGenerator.GuardParameterHasSchema(const Method: TRttiMethod;
+  const Param: TRttiParameter);
+begin
+  if not Assigned(Param.ParamType) then
+    raise EArgumentException.CreateFmt('Parameter "%s" of %s is untyped, so it has no schema',
+      [Param.Name, Method.Name]);
+
+  const AnswersThroughTheArgument = (([pfVar, pfOut] * Param.Flags) <> []);
+  if AnswersThroughTheArgument then
+    raise EArgumentException.CreateFmt(
+      'Parameter "%s" of %s is a var or out parameter, so it has no schema: a tool answers with its result',
+      [Param.Name, Method.Name]);
+end;
+
+class function TMCPSchemaGenerator.GetJsonName(const Member: TRttiNamedObject): string;
+begin
+  for var Attr in Member.GetAttributes do
     if Attr is SchemaNameAttribute then
       begin
         Result := SchemaNameAttribute(Attr).Name;
         Exit;
       end;
-  Result := LowerCase(Prop.Name);
+  Result := LowerCase(Member.Name);
 end;
 
-class function TMCPSchemaGenerator.IsRequiredProperty(Prop: TRttiProperty): Boolean;
+class function TMCPSchemaGenerator.IsRequired(const Member: TRttiNamedObject): Boolean;
 begin
-  for var Attr in Prop.GetAttributes do
+  for var Attr in Member.GetAttributes do
     if Attr is OptionalAttribute then
       Exit(False);
   Result := True;
@@ -187,7 +288,7 @@ begin
   end;
 
   Schema.Free;
-  Result := ObjectSchema(RttiType, Depth + 1);
+  Result := ObjectSchema(RttiType, Depth + 1, False);
 end;
 
 class function TMCPSchemaGenerator.TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
@@ -249,55 +350,57 @@ begin
     Result := TJSONNumber.Create(Value);
 end;
 
-class procedure TMCPSchemaGenerator.ApplyAttributes(Prop: TRttiProperty; const PropSchema: TJSONObject);
+class procedure TMCPSchemaGenerator.ApplyAttributes(const Member: TRttiNamedObject;
+  const MemberSchema: TJSONObject);
 begin
-  for var Attr in Prop.GetAttributes do
+  for var Attr in Member.GetAttributes do
   begin
     if Attr is SchemaDescriptionAttribute then
-      PropSchema.AddPair(MCP_KEY_DESCRIPTION, SchemaDescriptionAttribute(Attr).Description)
+      MemberSchema.AddPair(MCP_KEY_DESCRIPTION, SchemaDescriptionAttribute(Attr).Description)
     else if Attr is SchemaTitleAttribute then
-      PropSchema.AddPair(MCP_KEY_TITLE, SchemaTitleAttribute(Attr).Title)
+      MemberSchema.AddPair(MCP_KEY_TITLE, SchemaTitleAttribute(Attr).Title)
     else if Attr is SchemaFormatAttribute then
     begin
-      PropSchema.RemovePair(SCHEMA_KEY_FORMAT).Free;
-      PropSchema.AddPair(SCHEMA_KEY_FORMAT, SchemaFormatAttribute(Attr).Format);
+      MemberSchema.RemovePair(SCHEMA_KEY_FORMAT).Free;
+      MemberSchema.AddPair(SCHEMA_KEY_FORMAT, SchemaFormatAttribute(Attr).Format);
     end
     else if Attr is SchemaMinimumAttribute then
-      PropSchema.AddPair('minimum', NumberValue(SchemaMinimumAttribute(Attr).Minimum))
+      MemberSchema.AddPair('minimum', NumberValue(SchemaMinimumAttribute(Attr).Minimum))
     else if Attr is SchemaMaximumAttribute then
-      PropSchema.AddPair('maximum', NumberValue(SchemaMaximumAttribute(Attr).Maximum))
+      MemberSchema.AddPair('maximum', NumberValue(SchemaMaximumAttribute(Attr).Maximum))
     else if Attr is SchemaEnumAttribute then
     begin
-      PropSchema.RemovePair(SCHEMA_KEY_ENUM).Free;
+      MemberSchema.RemovePair(SCHEMA_KEY_ENUM).Free;
       var EnumArray := TJSONArray.Create;
       for var Value in SchemaEnumAttribute(Attr).Values do
       begin
         EnumArray.Add(Value);
       end;
-      PropSchema.AddPair(SCHEMA_KEY_ENUM, EnumArray);
+      MemberSchema.AddPair(SCHEMA_KEY_ENUM, EnumArray);
     end
     else if Attr is SchemaMinLengthAttribute then
-      PropSchema.AddPair('minLength', TJSONNumber.Create(SchemaMinLengthAttribute(Attr).MinLength))
+      MemberSchema.AddPair('minLength', TJSONNumber.Create(SchemaMinLengthAttribute(Attr).MinLength))
     else if Attr is SchemaMaxLengthAttribute then
-      PropSchema.AddPair('maxLength', TJSONNumber.Create(SchemaMaxLengthAttribute(Attr).MaxLength))
+      MemberSchema.AddPair('maxLength', TJSONNumber.Create(SchemaMaxLengthAttribute(Attr).MaxLength))
     else if Attr is SchemaPatternAttribute then
-      PropSchema.AddPair('pattern', SchemaPatternAttribute(Attr).Pattern)
+      MemberSchema.AddPair('pattern', SchemaPatternAttribute(Attr).Pattern)
     else if Attr is SchemaDefaultAttribute then
     begin
       var DefaultValue := TJSONObject.ParseJSONValue(SchemaDefaultAttribute(Attr).Json);
       if not Assigned(DefaultValue) then
         raise EArgumentException.CreateFmt('[SchemaDefault] on %s is not valid JSON: %s',
-          [Prop.Name, SchemaDefaultAttribute(Attr).Json]);
-      PropSchema.AddPair('default', DefaultValue);
+          [Member.Name, SchemaDefaultAttribute(Attr).Json]);
+      MemberSchema.AddPair('default', DefaultValue);
     end;
   end;
 end;
 
-class function TMCPSchemaGenerator.ObjectSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+class function TMCPSchemaGenerator.ObjectSchema(RttiType: TRttiType; Depth: Integer;
+  const IsRoot: Boolean): TJSONObject;
 begin
   Result := TJSONObject.Create;
   try
-    if Depth = 0 then
+    if IsRoot then
       for var Attr in RttiType.GetAttributes do
         if Attr is SchemaDialectAttribute then
           Result.AddPair('$schema', SchemaDialectAttribute(Attr).Uri);
@@ -312,12 +415,12 @@ begin
       if not (RttiProp.IsReadable and RttiProp.IsWritable) then
         Continue;
 
-      var JsonName := GetPropertyJsonName(RttiProp);
+      var JsonName := GetJsonName(RttiProp);
       var PropSchema := TypeSchema(RttiProp.PropertyType, Depth);
       Properties.AddPair(JsonName, PropSchema);
       ApplyAttributes(RttiProp, PropSchema);
 
-      if IsRequiredProperty(RttiProp) then
+      if IsRequired(RttiProp) then
         RequiredArray.Add(JsonName);
     end;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -36,6 +36,9 @@ type
 
     class function NormalizeKey(const Name: string): string; inline;
     class function IsRequiredProperty(const Prop: TRttiProperty): Boolean;
+
+    class procedure CollectCreatedObjects(const Value: TValue; const RttiType: TRttiType;
+      const Owned: TList<TObject>);
   public
     class constructor Create;
     class destructor Destroy;
@@ -44,6 +47,10 @@ type
 
     class function Deserialize<T: class, constructor>(const Json: TJSONObject): T;
     class procedure Serialize(Obj: TObject; Json: TJSONObject);
+
+    class function JsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType;
+      const Owned: TList<TObject>): TValue;
+    class function ValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
 
     class function SerializeToString(Obj: TObject): string;
   end;
@@ -208,6 +215,53 @@ begin
   end;
 end;
 
+class procedure TMCPSerializer.CollectCreatedObjects(const Value: TValue; const RttiType: TRttiType;
+  const Owned: TList<TObject>);
+begin
+  if not Assigned(Owned) or Value.IsEmpty then
+    Exit;
+
+  case RttiType.TypeKind of
+    tkClass:
+      if Value.IsObject and (Value.AsObject <> nil) then
+        Owned.Add(Value.AsObject);
+
+    tkDynArray:
+      begin
+        const ElementType = TRttiDynamicArrayType(RttiType).ElementType;
+        if not Assigned(ElementType) or (ElementType.TypeKind <> tkClass) then
+          Exit;
+
+        for var I := 0 to Value.GetArrayLength - 1 do
+        begin
+          const Element = Value.GetArrayElement(I);
+          if Element.IsObject and (Element.AsObject <> nil) then
+            Owned.Add(Element.AsObject);
+        end;
+      end;
+  end;
+end;
+
+class function TMCPSerializer.JsonToValue(const JsonValue: TJSONValue; const RttiType: TRttiType;
+  const Owned: TList<TObject>): TValue;
+begin
+  Result := TValue.Empty;
+  if not Assigned(RttiType) then
+    Exit;
+
+  Result := ConvertJsonToValue(JsonValue, RttiType);
+  CollectCreatedObjects(Result, RttiType, Owned);
+end;
+
+class function TMCPSerializer.ValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
+begin
+  Result := nil;
+  if not Assigned(RttiType) then
+    Exit;
+
+  Result := ConvertValueToJson(Value, RttiType);
+end;
+
 class function TMCPSerializer.SerializeToString(Obj: TObject): string;
 var
   Json: TJSONObject;
@@ -260,6 +314,8 @@ begin
     Result := TValue.From<TDateTime>(ISO8601ToDate(JsonValue.Value, False));
   except
     on E: EConvertError do
+      raise EArgumentException.Create('expected an ISO 8601 date-time');
+    on E: EDateTimeException do
       raise EArgumentException.Create('expected an ISO 8601 date-time');
   end;
 end;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -81,6 +81,11 @@ const
   MEDIA_TYPE_EVENT_STREAM = 'text/event-stream';
   CHARSET_UTF8 = 'utf-8';
 
+  MCP_HEADER_SESSION_ID = 'Mcp-Session-Id';
+  MCP_HEADER_PROTOCOL_VERSION = 'MCP-Protocol-Version';
+  MCP_HEADER_METHOD = 'Mcp-Method';
+  MCP_HEADER_NAME = 'Mcp-Name';
+
   MCP_KEY_JSONRPC = 'jsonrpc';
   MCP_KEY_ID = 'id';
   MCP_KEY_METHOD = 'method';

--- a/src/Server/MCPServer.Host.pas
+++ b/src/Server/MCPServer.Host.pas
@@ -1,0 +1,277 @@
+unit MCPServer.Host;
+
+interface
+
+uses
+  System.Classes,
+  MCPServer.Types,
+  MCPServer.Settings,
+  MCPServer.Authorization,
+  MCPServer.Tool.Base,
+  MCPServer.Resource.Base,
+  MCPServer.Prompt.Base,
+  MCPServer.ToolsManager,
+  MCPServer.ResourcesManager,
+  MCPServer.PromptsManager,
+  MCPServer.SubscriptionsManager,
+  MCPServer.IdHTTPServer;
+
+type
+  TMCPServerHost = class
+  strict private
+    FSettings: TMCPSettings;
+    FOwnsSettings: Boolean;
+    FManagerRegistry: IMCPManagerRegistry;
+    FCoreManager: IMCPCapabilityManager;
+    FToolsManager: TMCPToolsManager;
+    FResourcesManager: TMCPResourcesManager;
+    FPromptsManager: TMCPPromptsManager;
+    FSubscriptionsManager: TMCPSubscriptionsManager;
+    FServer: TMCPIdHTTPServer;
+    FAuthorizer: IMCPAuthorizer;
+    FSeedFromGlobalRegistry: Boolean;
+    FActive: Boolean;
+    procedure BuildManagers;
+    procedure HideDiagnosticsResources;
+    procedure EnsureManagers;
+    function GetManagerRegistry: IMCPManagerRegistry;
+    function GetCoreManager: IMCPCapabilityManager;
+    procedure SetSeedFromGlobalRegistry(const Value: Boolean);
+  public
+    constructor Create; overload;
+    constructor Create(const SettingsFile: string); overload;
+    constructor Create(const Settings: TMCPSettings); overload;
+    destructor Destroy; override;
+
+    procedure AddTool(const Tool: IMCPTool);
+    procedure RemoveTool(const Name: string);
+    function HasTool(const Name: string): Boolean;
+    procedure AddResource(const Resource: IMCPResource);
+    procedure AddPrompt(const Prompt: IMCPPrompt);
+
+    procedure StartHttp;
+    procedure Stop;
+    function BoundPort: Word;
+
+    procedure RunStdio;
+    procedure RunStdioWith(const Input, Output: TStream);
+
+    property Settings: TMCPSettings read FSettings;
+    property Authorizer: IMCPAuthorizer read FAuthorizer write FAuthorizer;
+    property Active: Boolean read FActive;
+    property ManagerRegistry: IMCPManagerRegistry read GetManagerRegistry;
+    property CoreManager: IMCPCapabilityManager read GetCoreManager;
+    property SeedFromGlobalRegistry: Boolean read FSeedFromGlobalRegistry write SetSeedFromGlobalRegistry;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Errors,
+  MCPServer.ManagerRegistry,
+  MCPServer.CoreManager,
+  MCPServer.CompletionManager,
+  MCPServer.StdioTransport;
+
+const
+  URI_LOGS_RECENT = 'logs://recent';
+  URI_SERVER_STATUS = 'server://status';
+  URI_TEMPLATE_LOGS_BY_LEVEL = 'logs://{level}';
+
+{ TMCPServerHost }
+
+constructor TMCPServerHost.Create;
+begin
+  Create('');
+end;
+
+constructor TMCPServerHost.Create(const SettingsFile: string);
+begin
+  inherited Create;
+
+  const ReadsAFile = (SettingsFile <> '');
+  if ReadsAFile then
+    FSettings := TMCPSettings.Create(SettingsFile, False)
+  else
+    FSettings := TMCPSettings.CreateDefaults;
+
+  FOwnsSettings := True;
+  FSeedFromGlobalRegistry := False;
+end;
+
+constructor TMCPServerHost.Create(const Settings: TMCPSettings);
+begin
+  inherited Create;
+
+  if not Assigned(Settings) then
+    raise EArgumentNilException.Create('A host built on settings needs a settings instance');
+
+  FSettings := Settings;
+  FOwnsSettings := False;
+  FSeedFromGlobalRegistry := False;
+end;
+
+destructor TMCPServerHost.Destroy;
+begin
+  Stop;
+  FServer.Free;
+  FCoreManager := nil;
+  FManagerRegistry := nil;
+  if FOwnsSettings then
+    FSettings.Free;
+  inherited;
+end;
+
+procedure TMCPServerHost.BuildManagers;
+begin
+  FManagerRegistry := TMCPManagerRegistry.Create;
+  FCoreManager := TMCPCoreManager.Create(FSettings);
+  FToolsManager := TMCPToolsManager.Create(FSeedFromGlobalRegistry);
+  FResourcesManager := TMCPResourcesManager.Create(FSeedFromGlobalRegistry);
+  FPromptsManager := TMCPPromptsManager.Create(FSeedFromGlobalRegistry);
+  FSubscriptionsManager := TMCPSubscriptionsManager.Create;
+
+  if not FSettings.ExposeDiagnosticsResources then
+    HideDiagnosticsResources;
+
+  FToolsManager.ChangeNotifier := FSubscriptionsManager;
+  FResourcesManager.ChangeNotifier := FSubscriptionsManager;
+  FPromptsManager.ChangeNotifier := FSubscriptionsManager;
+
+  FManagerRegistry.RegisterManager(FCoreManager);
+  FManagerRegistry.RegisterManager(FToolsManager);
+  FManagerRegistry.RegisterManager(FResourcesManager);
+  FManagerRegistry.RegisterManager(FPromptsManager);
+  FManagerRegistry.RegisterManager(TMCPCompletionManager.Create(FPromptsManager, FResourcesManager));
+  FManagerRegistry.RegisterManager(FSubscriptionsManager);
+end;
+
+procedure TMCPServerHost.HideDiagnosticsResources;
+begin
+  FResourcesManager.RemoveResource(URI_LOGS_RECENT);
+  FResourcesManager.RemoveResource(URI_SERVER_STATUS);
+  FResourcesManager.RemoveResourceTemplate(URI_TEMPLATE_LOGS_BY_LEVEL);
+end;
+
+procedure TMCPServerHost.EnsureManagers;
+begin
+  if not Assigned(FManagerRegistry) then
+    BuildManagers;
+end;
+
+function TMCPServerHost.GetManagerRegistry: IMCPManagerRegistry;
+begin
+  EnsureManagers;
+  Result := FManagerRegistry;
+end;
+
+function TMCPServerHost.GetCoreManager: IMCPCapabilityManager;
+begin
+  EnsureManagers;
+  Result := FCoreManager;
+end;
+
+procedure TMCPServerHost.SetSeedFromGlobalRegistry(const Value: Boolean);
+begin
+  if Value = FSeedFromGlobalRegistry then
+    Exit;
+
+  if Assigned(FManagerRegistry) then
+    raise EMCPConfigurationError.Create('SeedFromGlobalRegistry must be set before the host builds its managers');
+
+  FSeedFromGlobalRegistry := Value;
+end;
+
+procedure TMCPServerHost.AddTool(const Tool: IMCPTool);
+begin
+  EnsureManagers;
+  FToolsManager.AddTool(Tool);
+end;
+
+procedure TMCPServerHost.RemoveTool(const Name: string);
+begin
+  EnsureManagers;
+  FToolsManager.RemoveTool(Name);
+end;
+
+function TMCPServerHost.HasTool(const Name: string): Boolean;
+begin
+  EnsureManagers;
+  Result := FToolsManager.HasTool(Name);
+end;
+
+procedure TMCPServerHost.AddResource(const Resource: IMCPResource);
+begin
+  EnsureManagers;
+  FResourcesManager.AddResource(Resource);
+end;
+
+procedure TMCPServerHost.AddPrompt(const Prompt: IMCPPrompt);
+begin
+  EnsureManagers;
+  FPromptsManager.AddPrompt(Prompt);
+end;
+
+procedure TMCPServerHost.StartHttp;
+begin
+  if FActive then
+    Exit;
+
+  EnsureManagers;
+
+  if not Assigned(FServer) then
+    FServer := TMCPIdHTTPServer.Create(nil);
+
+  FServer.Settings := FSettings;
+  FServer.ManagerRegistry := FManagerRegistry;
+  FServer.CoreManager := FCoreManager;
+  FServer.Authorizer := FAuthorizer;
+  FServer.Start;
+  FActive := True;
+end;
+
+procedure TMCPServerHost.Stop;
+begin
+  if not FActive then
+    Exit;
+
+  FActive := False;
+  FServer.Stop;
+end;
+
+function TMCPServerHost.BoundPort: Word;
+begin
+  if Assigned(FServer) then
+    Result := FServer.BoundPort
+  else
+    Result := Word(FSettings.Port);
+end;
+
+procedure TMCPServerHost.RunStdio;
+begin
+  EnsureManagers;
+
+  const Transport = TMCPStdioTransport.Create(FManagerRegistry, FCoreManager);
+  try
+    Transport.Settings := FSettings;
+    Transport.Run;
+  finally
+    Transport.Free;
+  end;
+end;
+
+procedure TMCPServerHost.RunStdioWith(const Input, Output: TStream);
+begin
+  EnsureManagers;
+
+  const Transport = TMCPStdioTransport.Create(FManagerRegistry, FCoreManager);
+  try
+    Transport.Settings := FSettings;
+    Transport.RunWith(Input, Output);
+  finally
+    Transport.Free;
+  end;
+end;
+
+end.

--- a/src/Server/MCPServer.HttpHeaders.pas
+++ b/src/Server/MCPServer.HttpHeaders.pas
@@ -10,6 +10,7 @@ type
     const SENTINEL_PREFIX = '=?base64?';
     const SENTINEL_SUFFIX = '?=';
 
+    class function Encode(const Value: string): string; static;
     class function IsHeaderSafe(const Value: string): Boolean; static;
     class function IsSentinel(const Value: string): Boolean; static;
     class function TryDecodeBase64(const Text: string; out Bytes: TBytes): Boolean; static;
@@ -57,6 +58,15 @@ const
 
 
 { TMCPHeaderValue }
+
+class function TMCPHeaderValue.Encode(const Value: string): string;
+begin
+  if IsHeaderSafe(Value) and not IsSentinel(Value) then
+    Exit(Value);
+
+  const Bytes = TEncoding.UTF8.GetBytes(Value);
+  Result := SENTINEL_PREFIX + TNetEncoding.Base64String.EncodeBytesToString(Bytes) + SENTINEL_SUFFIX;
+end;
 
 class function TMCPHeaderValue.IsHeaderSafe(const Value: string): Boolean;
 begin

--- a/src/Server/MCPServer.IdHTTPServer.pas
+++ b/src/Server/MCPServer.IdHTTPServer.pas
@@ -55,6 +55,8 @@ type
     procedure ConfigureSSL;
     procedure ConfigureBindings;
     procedure AddBinding(const IP: string; IPVersion: TIdIPVersion);
+    procedure AddDualStackBindings(const IPv4Address, IPv6Address: string);
+    function ClaimEphemeralPort(const IP: string): Word;
     procedure HandleQuerySSLPort(APort: Word; var VUseSSL: Boolean);
     procedure HandleParseAuthentication(Context: TIdContext; const AuthType, AuthData: string;
       var VUsername, VPassword: string; var VHandled: Boolean);
@@ -99,6 +101,7 @@ type
     procedure Start;
     procedure Stop;
     function BoundAddresses: TArray<string>;
+    function BoundPort: Word;
     property Port: Word read FPort write FPort;
     property Active: Boolean read FActive;
     property ManagerRegistry: IMCPManagerRegistry read FManagerRegistry write FManagerRegistry;
@@ -135,8 +138,9 @@ const
 
   CORS_MAX_AGE = 86400;
   CORS_ALLOW_METHODS = 'POST, OPTIONS';
-  CORS_ALLOW_HEADERS = 'Accept, Content-Type, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id, Last-Event-ID';
-  CORS_EXPOSE_HEADERS = 'Mcp-Session-Id, WWW-Authenticate';
+  CORS_ALLOW_HEADERS = 'Accept, Content-Type, Authorization, ' + MCP_HEADER_PROTOCOL_VERSION + ', ' +
+    MCP_HEADER_METHOD + ', ' + MCP_HEADER_NAME + ', ' + MCP_HEADER_SESSION_ID + ', Last-Event-ID';
+  CORS_EXPOSE_HEADERS = MCP_HEADER_SESSION_ID + ', WWW-Authenticate';
   ALLOW_HEADER = 'POST, OPTIONS';
 
   HEADER_ORIGIN = 'Origin';
@@ -145,10 +149,6 @@ const
   BEARER_PREFIX = 'Bearer ';
   METADATA_CACHE_CONTROL = 'max-age=3600';
   HEADER_ACCEPT = 'Accept';
-  HEADER_SESSION_ID = 'Mcp-Session-Id';
-  HEADER_PROTOCOL_VERSION = 'MCP-Protocol-Version';
-  HEADER_METHOD = 'Mcp-Method';
-  HEADER_NAME = 'Mcp-Name';
 
 
   LOOPBACK_IPV4 = '127.0.0.1';
@@ -269,12 +269,48 @@ begin
   end;
 end;
 
+function TMCPIdHTTPServer.BoundPort: Word;
+begin
+  if FHTTPServer.Bindings.Count > 0 then
+    Result := Word(FHTTPServer.Bindings[0].Port)
+  else
+    Result := FPort;
+end;
+
 procedure TMCPIdHTTPServer.AddBinding(const IP: string; IPVersion: TIdIPVersion);
 begin
   var Binding := FHTTPServer.Bindings.Add;
   Binding.IP := IP;
   Binding.Port := FPort;
   Binding.IPVersion := IPVersion;
+end;
+
+function TMCPIdHTTPServer.ClaimEphemeralPort(const IP: string): Word;
+begin
+  const Probe = TIdSocketHandle.Create(nil);
+  try
+    Probe.IPVersion := Id_IPv4;
+    Probe.IP := IP;
+    Probe.Port := 0;
+    Probe.AllocateSocket;
+    Probe.Bind;
+    Result := Word(Probe.Port);
+    Probe.CloseSocket;
+  finally
+    Probe.Free;
+  end;
+end;
+
+procedure TMCPIdHTTPServer.AddDualStackBindings(const IPv4Address, IPv6Address: string);
+begin
+  const BindsBothFamilies = GStack.SupportsIPv6;
+  const SystemPicksThePort = (FPort = 0);
+  if BindsBothFamilies and SystemPicksThePort then
+    FPort := ClaimEphemeralPort(IPv4Address);
+
+  AddBinding(IPv4Address, Id_IPv4);
+  if BindsBothFamilies then
+    AddBinding(IPv6Address, Id_IPv6);
 end;
 
 procedure TMCPIdHTTPServer.ConfigureBindings;
@@ -303,16 +339,12 @@ begin
 
   if SameText(Host, HOST_LOCALHOST) or (Host = LOOPBACK_IPV4) or (Host = LOOPBACK_IPV6) then
   begin
-    AddBinding(LOOPBACK_IPV4, Id_IPv4);
-    if GStack.SupportsIPv6 then
-      AddBinding(LOOPBACK_IPV6, Id_IPv6);
+    AddDualStackBindings(LOOPBACK_IPV4, LOOPBACK_IPV6);
   end
   else
   begin
     TLogger.Info('Host ' + Host + ' is not loopback; listening on every network interface (set BindAddress to narrow this)');
-    AddBinding(ANY_IPV4, Id_IPv4);
-    if GStack.SupportsIPv6 then
-      AddBinding(ANY_IPV6, Id_IPv6);
+    AddDualStackBindings(ANY_IPV4, ANY_IPV6);
   end;
 end;
 
@@ -651,19 +683,19 @@ end;
 function TMCPIdHTTPServer.BuildTransportHints(RequestInfo: TIdHTTPRequestInfo): TMCPTransportHints;
 begin
   Result := TMCPTransportHints.ForHttp(
-    HeaderPresent(RequestInfo, HEADER_PROTOCOL_VERSION), HeaderValue(RequestInfo, HEADER_PROTOCOL_VERSION));
-  Result.HasMethodHeader := HeaderPresent(RequestInfo, HEADER_METHOD);
-  Result.MethodHeader := HeaderValue(RequestInfo, HEADER_METHOD);
-  Result.HasNameHeader := HeaderPresent(RequestInfo, HEADER_NAME);
-  Result.NameHeader := HeaderValue(RequestInfo, HEADER_NAME);
+    HeaderPresent(RequestInfo, MCP_HEADER_PROTOCOL_VERSION), HeaderValue(RequestInfo, MCP_HEADER_PROTOCOL_VERSION));
+  Result.HasMethodHeader := HeaderPresent(RequestInfo, MCP_HEADER_METHOD);
+  Result.MethodHeader := HeaderValue(RequestInfo, MCP_HEADER_METHOD);
+  Result.HasNameHeader := HeaderPresent(RequestInfo, MCP_HEADER_NAME);
+  Result.NameHeader := HeaderValue(RequestInfo, MCP_HEADER_NAME);
   Result.RemoteAddress := RequestInfo.RemoteIP;
 end;
 
 procedure TMCPIdHTTPServer.EchoLegacySessionId(RequestInfo: TIdHTTPRequestInfo; ResponseInfo: TIdHTTPResponseInfo);
 begin
-  var SessionId := HeaderValue(RequestInfo, HEADER_SESSION_ID);
+  var SessionId := HeaderValue(RequestInfo, MCP_HEADER_SESSION_ID);
   if (SessionId <> '') and TMCPHeaderValue.IsHeaderSafe(SessionId) and not SessionId.Contains(' ') then
-    ResponseInfo.CustomHeaders.Values[HEADER_SESSION_ID] := SessionId;
+    ResponseInfo.CustomHeaders.Values[MCP_HEADER_SESSION_ID] := SessionId;
 end;
 
 procedure TMCPIdHTTPServer.HandlePostRequest(Context: TIdContext; RequestInfo: TIdHTTPRequestInfo;

--- a/src/Tools/MCPServer.Tool.Method.pas
+++ b/src/Tools/MCPServer.Tool.Method.pas
@@ -1,0 +1,290 @@
+unit MCPServer.Tool.Method;
+
+interface
+
+uses
+  System.Rtti,
+  System.JSON,
+  System.Generics.Collections,
+  MCPServer.Types,
+  MCPServer.Tool.Base;
+
+type
+  TMCPMethodTool = class(TInterfacedObject, IMCPTool, IMCPToolMetadata)
+  protected
+    FContext: TRttiContext;
+    FInstance: TValue;
+    FMethod: TRttiMethod;
+    FName: string;
+    FTitle: string;
+    FDescription: string;
+    FAnnotations: TJSONObject;
+    FIcons: TJSONArray;
+    FInputSchema: TJSONObject;
+
+    function MarshalArgument(const Param: TRttiParameter; const Arguments: TJSONObject;
+      const Owned: TList<TObject>): TValue; virtual;
+    function ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue; virtual;
+    procedure ReleaseResult(const Value: TValue; const ResultType: TRttiType); virtual;
+    procedure ReleaseArguments(const Owned: TList<TObject>); virtual;
+
+    procedure ValidateArguments(const Arguments: TJSONObject);
+    function MarshalArguments(const Arguments: TJSONObject;
+      const Owned: TList<TObject>): TArray<TValue>;
+    function InvokeToJson(const Arguments: TJSONObject): TJSONValue;
+  public
+    constructor Create(const Instance: TValue; const Method: TRttiMethod;
+      const Name, Description: string);
+    destructor Destroy; override;
+
+    function GetName: string;
+    function GetTitle: string;
+    function GetDescription: string;
+    function GetInputSchema: TJSONObject;
+    function GetOutputSchema: TJSONObject; virtual;
+    function Execute(const Arguments: TJSONObject): TValue;
+
+    function GetAnnotations: TJSONObject;
+    function GetIcons: TJSONArray;
+
+    procedure MarkReadOnly(const OpenWorld: Boolean = False);
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.TypInfo,
+  MCPServer.Schema.Generator,
+  MCPServer.Schema.Validator,
+  MCPServer.Serializer;
+
+const
+  RESULT_KEY_OK = 'ok';
+
+function ParameterWireName(const Param: TRttiParameter): string;
+begin
+  for var Attr in Param.GetAttributes do
+    if Attr is SchemaNameAttribute then
+      Exit(SchemaNameAttribute(Attr).Name);
+
+  Result := LowerCase(Param.Name);
+end;
+
+function IsObjectElementArray(const RttiType: TRttiType): Boolean;
+begin
+  if RttiType.TypeKind <> tkDynArray then
+    Exit(False);
+
+  const ElementType = TRttiDynamicArrayType(RttiType).ElementType;
+  Result := Assigned(ElementType) and (ElementType.TypeKind = tkClass);
+end;
+
+{ TMCPMethodTool }
+
+constructor TMCPMethodTool.Create(const Instance: TValue; const Method: TRttiMethod;
+  const Name, Description: string);
+begin
+  inherited Create;
+
+  if not Assigned(Method) then
+    raise EArgumentNilException.Create('A method tool needs a method');
+
+  FContext := TRttiContext.Create;
+  FContext.GetType(TypeInfo(TObject));
+
+  FInstance := Instance;
+  FMethod := Method;
+  FName := Name;
+  FDescription := Description;
+  FInputSchema := TMCPSchemaGenerator.GenerateSchemaFromMethod(Method);
+end;
+
+destructor TMCPMethodTool.Destroy;
+begin
+  FInputSchema.Free;
+  FAnnotations.Free;
+  FIcons.Free;
+  FContext.Free;
+  inherited;
+end;
+
+function TMCPMethodTool.GetName: string;
+begin
+  Result := FName;
+end;
+
+function TMCPMethodTool.GetTitle: string;
+begin
+  if FTitle <> '' then
+    Result := FTitle
+  else
+    Result := FName;
+end;
+
+function TMCPMethodTool.GetDescription: string;
+begin
+  Result := FDescription;
+end;
+
+function TMCPMethodTool.GetInputSchema: TJSONObject;
+begin
+  Result := TJSONObject(FInputSchema.Clone);
+end;
+
+function TMCPMethodTool.GetOutputSchema: TJSONObject;
+begin
+  Result := TMCPSchemaGenerator.GenerateSchemaFromMethodResult(FMethod);
+end;
+
+function TMCPMethodTool.GetAnnotations: TJSONObject;
+begin
+  Result := FAnnotations;
+end;
+
+function TMCPMethodTool.GetIcons: TJSONArray;
+begin
+  Result := FIcons;
+end;
+
+procedure TMCPMethodTool.MarkReadOnly(const OpenWorld: Boolean);
+begin
+  TMCPToolAnnotationWriter.ReadOnly(FAnnotations, OpenWorld);
+end;
+
+procedure TMCPMethodTool.ValidateArguments(const Arguments: TJSONObject);
+begin
+  var OwnedArguments: TJSONObject := nil;
+  var Effective := Arguments;
+  if not Assigned(Effective) then
+  begin
+    OwnedArguments := TJSONObject.Create;
+    Effective := OwnedArguments;
+  end;
+
+  try
+    var Errors: TArray<string>;
+    if not TMCPSchemaValidator.TryValidate(FInputSchema, Effective, Errors) then
+      raise EArgumentException.Create(string.Join('; ', Errors));
+  finally
+    OwnedArguments.Free;
+  end;
+end;
+
+function TMCPMethodTool.MarshalArgument(const Param: TRttiParameter; const Arguments: TJSONObject;
+  const Owned: TList<TObject>): TValue;
+begin
+  const WireName = ParameterWireName(Param);
+
+  var JsonValue: TJSONValue := nil;
+  if Assigned(Arguments) then
+    JsonValue := Arguments.GetValue(WireName);
+
+  const IsAbsent = not Assigned(JsonValue) or (JsonValue is TJSONNull);
+  if IsAbsent then
+  begin
+    TValue.Make(nil, Param.ParamType.Handle, Result);
+    Exit;
+  end;
+
+  try
+    Result := TMCPSerializer.JsonToValue(JsonValue, Param.ParamType, Owned);
+  except
+    on E: EArgumentException do
+      raise EArgumentException.CreateFmt('Parameter "%s": %s', [WireName, E.Message]);
+  end;
+end;
+
+function TMCPMethodTool.MarshalArguments(const Arguments: TJSONObject;
+  const Owned: TList<TObject>): TArray<TValue>;
+begin
+  const Parameters = FMethod.GetParameters;
+  SetLength(Result, Length(Parameters));
+  for var Index := 0 to High(Parameters) do
+    Result[Index] := MarshalArgument(Parameters[Index], Arguments, Owned);
+end;
+
+function TMCPMethodTool.ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue;
+begin
+  Result := TJSONObject.Create;
+  try
+    if not Assigned(ResultType) then
+    begin
+      TJSONObject(Result).AddPair(RESULT_KEY_OK, TJSONBool.Create(True));
+      Exit;
+    end;
+
+    var Converted := TMCPSerializer.ValueToJson(Value, ResultType);
+    if not Assigned(Converted) then
+      Converted := TJSONNull.Create;
+    TJSONObject(Result).AddPair(MCP_KEY_RESULT, Converted);
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+procedure TMCPMethodTool.ReleaseResult(const Value: TValue; const ResultType: TRttiType);
+begin
+  if not Assigned(ResultType) or Value.IsEmpty then
+    Exit;
+
+  if ResultType.TypeKind = tkClass then
+  begin
+    if Value.IsObject then
+      Value.AsObject.Free;
+    Exit;
+  end;
+
+  if not IsObjectElementArray(ResultType) then
+    Exit;
+
+  for var Index := 0 to Value.GetArrayLength - 1 do
+  begin
+    const Element = Value.GetArrayElement(Index);
+    if Element.IsObject then
+      Element.AsObject.Free;
+  end;
+end;
+
+procedure TMCPMethodTool.ReleaseArguments(const Owned: TList<TObject>);
+begin
+  for var Item in Owned do
+  begin
+    Item.Free;
+  end;
+end;
+
+function TMCPMethodTool.InvokeToJson(const Arguments: TJSONObject): TJSONValue;
+begin
+  const Owned = TList<TObject>.Create;
+  try
+    var Args := MarshalArguments(Arguments, Owned);
+    const ReturnType = FMethod.ReturnType;
+    var ReturnValue := FMethod.Invoke(FInstance, Args);
+    try
+      Result := ResultToJson(ReturnValue, ReturnType);
+    finally
+      ReleaseResult(ReturnValue, ReturnType);
+    end;
+  finally
+    ReleaseArguments(Owned);
+    Owned.Free;
+  end;
+end;
+
+function TMCPMethodTool.Execute(const Arguments: TJSONObject): TValue;
+begin
+  ValidateArguments(Arguments);
+
+  const Json = InvokeToJson(Arguments);
+  if not (Json is TJSONObject) then
+  begin
+    Json.Free;
+    raise EInvalidOpException.CreateFmt('%s.ResultToJson must return a TJSONObject', [ClassName]);
+  end;
+
+  Result := TValue.From<TJSONObject>(TJSONObject(Json));
+end;
+
+end.

--- a/tests/MCPServer.Tests.HeaderEncoding.pas
+++ b/tests/MCPServer.Tests.HeaderEncoding.pas
@@ -1,0 +1,133 @@
+unit MCPServer.Tests.HeaderEncoding;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  THeaderEncodingTests = class
+  public
+    [Test]
+    procedure HeaderConstants_HaveSpecNames;
+
+    [Test]
+    procedure Encode_PlainAsciiValue_IsVerbatim;
+
+    [Test]
+    procedure Encode_EmptyValue_IsVerbatim;
+
+    [Test]
+    procedure Encode_NonAsciiValue_RoundTrips;
+
+    [Test]
+    procedure Encode_ControlCharacters_RoundTrip;
+
+    [Test]
+    procedure Encode_LiteralSentinelPattern_RoundTrips;
+
+    [Test]
+    procedure Encode_MatchesTheSpecTable;
+
+    [Test]
+    procedure Encode_LongNonAsciiValue_StaysOnOneLine;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Types,
+  MCPServer.HttpHeaders;
+
+const
+  WORLD = #$4E16#$754C;
+
+{ THeaderEncodingTests }
+
+procedure THeaderEncodingTests.HeaderConstants_HaveSpecNames;
+begin
+  Assert.AreEqual('Mcp-Session-Id', MCP_HEADER_SESSION_ID);
+  Assert.AreEqual('MCP-Protocol-Version', MCP_HEADER_PROTOCOL_VERSION);
+  Assert.AreEqual('Mcp-Method', MCP_HEADER_METHOD);
+  Assert.AreEqual('Mcp-Name', MCP_HEADER_NAME);
+end;
+
+procedure THeaderEncodingTests.Encode_PlainAsciiValue_IsVerbatim;
+begin
+  Assert.AreEqual('us-west1', TMCPHeaderValue.Encode('us-west1'));
+  Assert.AreEqual('file:///projects/myapp/config.json',
+    TMCPHeaderValue.Encode('file:///projects/myapp/config.json'));
+  Assert.AreEqual('tools/call', TMCPHeaderValue.Encode('tools/call'));
+end;
+
+procedure THeaderEncodingTests.Encode_EmptyValue_IsVerbatim;
+begin
+  Assert.AreEqual('', TMCPHeaderValue.Encode(''));
+
+  var Decoded: string;
+  Assert.IsTrue(TMCPHeaderValue.TryDecode(TMCPHeaderValue.Encode(''), Decoded));
+  Assert.AreEqual('', Decoded);
+end;
+
+procedure THeaderEncodingTests.Encode_NonAsciiValue_RoundTrips;
+begin
+  const Original = 'Hello, ' + WORLD;
+  const Encoded = TMCPHeaderValue.Encode(Original);
+
+  Assert.IsTrue(TMCPHeaderValue.IsSentinel(Encoded), 'a non-ASCII value must be wrapped');
+  Assert.IsTrue(TMCPHeaderValue.IsHeaderSafe(Encoded), 'the wrapped value must be header safe');
+
+  var Decoded: string;
+  Assert.IsTrue(TMCPHeaderValue.TryDecode(Encoded, Decoded));
+  Assert.AreEqual(Original, Decoded);
+end;
+
+procedure THeaderEncodingTests.Encode_ControlCharacters_RoundTrip;
+begin
+  const Original = 'line1'#10'line2';
+  const Encoded = TMCPHeaderValue.Encode(Original);
+
+  Assert.IsTrue(TMCPHeaderValue.IsSentinel(Encoded));
+
+  var Decoded: string;
+  Assert.IsTrue(TMCPHeaderValue.TryDecode(Encoded, Decoded));
+  Assert.AreEqual(Original, Decoded);
+end;
+
+procedure THeaderEncodingTests.Encode_LiteralSentinelPattern_RoundTrips;
+begin
+  const Original = '=?base64?literal?=';
+  const Encoded = TMCPHeaderValue.Encode(Original);
+
+  Assert.AreNotEqual(Original, Encoded, 'a value that looks like a sentinel must be wrapped');
+  Assert.AreEqual('=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=', Encoded);
+
+  var Decoded: string;
+  Assert.IsTrue(TMCPHeaderValue.TryDecode(Encoded, Decoded));
+  Assert.AreEqual(Original, Decoded);
+end;
+
+procedure THeaderEncodingTests.Encode_MatchesTheSpecTable;
+begin
+  Assert.AreEqual('=?base64?SGVsbG8sIOS4lueVjA==?=', TMCPHeaderValue.Encode('Hello, ' + WORLD));
+  Assert.AreEqual('=?base64?bGluZTEKbGluZTI=?=', TMCPHeaderValue.Encode('line1'#10'line2'));
+end;
+
+procedure THeaderEncodingTests.Encode_LongNonAsciiValue_StaysOnOneLine;
+begin
+  var Original := '';
+  for var I := 1 to 80 do
+    Original := Original + WORLD;
+
+  const Encoded = TMCPHeaderValue.Encode(Original);
+  Assert.AreEqual(-1, Encoded.IndexOf(#13), 'the base64 payload must not be wrapped');
+  Assert.AreEqual(-1, Encoded.IndexOf(#10), 'the base64 payload must not be wrapped');
+
+  var Decoded: string;
+  Assert.IsTrue(TMCPHeaderValue.TryDecode(Encoded, Decoded));
+  Assert.AreEqual(Original, Decoded);
+end;
+
+end.

--- a/tests/MCPServer.Tests.Host.pas
+++ b/tests/MCPServer.Tests.Host.pas
@@ -1,0 +1,557 @@
+unit MCPServer.Tests.Host;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Rtti,
+  System.JSON,
+  MCPServer.Tool.Base,
+  MCPServer.Resource.Base,
+  MCPServer.Prompt.Base,
+  MCPServer.Host;
+
+type
+  TNamedTool = class(TMCPToolBase)
+  protected
+    function BuildSchema: TJSONObject; override;
+    function DoExecute(const Arguments: TJSONObject): TValue; override;
+  public
+    constructor CreateNamed(const AName: string);
+  end;
+
+  TNamedResourceData = class
+  private
+    FValue: string;
+  public
+    property Value: string read FValue write FValue;
+  end;
+
+  TNamedResource = class(TMCPResourceBase<TNamedResourceData>)
+  protected
+    function GetResourceData: TNamedResourceData; override;
+  public
+    constructor CreateNamed(const AUri: string);
+  end;
+
+  TNamedPromptParams = class
+  private
+    FText: string;
+  public
+    property Text: string read FText write FText;
+  end;
+
+  TNamedPrompt = class(TMCPPromptBase<TNamedPromptParams>)
+  protected
+    function ExecuteWithParams(const Params: TNamedPromptParams; Messages: TMCPPromptMessages): string; override;
+  public
+    constructor CreateNamed(const AName: string);
+  end;
+
+  [TestFixture]
+  TServerHostTests = class
+  private
+    FHost: TMCPServerHost;
+    FOther: TMCPServerHost;
+    function PostTo(const Url: string): string;
+    function ToolNamesOverHttp: TArray<string>;
+    function NamesOverStdio(const Host: TMCPServerHost;
+      const Method, ListKey, NameKey: string): TArray<string>;
+    function ToolNamesOverStdio(const Host: TMCPServerHost): TArray<string>;
+    function ResourceUrisOverStdio(const Host: TMCPServerHost): TArray<string>;
+    function TemplateUrisOverStdio(const Host: TMCPServerHost): TArray<string>;
+    function PromptNamesOverStdio(const Host: TMCPServerHost): TArray<string>;
+    function ToolNamesOf(const Response: string): TArray<string>;
+    procedure StartOnAnyPort;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Default_PublishesNoToolAtAll;
+
+    [Test]
+    procedure Default_PublishesNoResourceTemplateOrPrompt;
+
+    [Test]
+    procedure TwoHostsInOneProcess_HaveDisjointToolSets;
+
+    [Test]
+    procedure TwoHostsInOneProcess_HaveDisjointResourceAndPromptSets;
+
+    [Test]
+    procedure SeedFromGlobalRegistry_TakesTheGlobalTools;
+
+    [Test]
+    procedure SeedFromGlobalRegistry_TakesTheGlobalResourcesTemplatesAndPrompts;
+
+    [Test]
+    procedure DiagnosticsResourcesOff_DropsThemFromASeededHost;
+
+    [Test]
+    procedure DiagnosticsResourcesOn_KeepsThemOnASeededHost;
+
+    [Test]
+    procedure SeedFromGlobalRegistry_AfterTheManagersExist_IsAConfigurationError;
+
+    [Test]
+    procedure RemoveTool_TakesTheToolBackOut;
+
+    [Test]
+    procedure Create_WithoutSettings_ReadsNoSettingsFile;
+
+    [Test]
+    procedure Create_WithASettingsFile_ReadsThatFile;
+
+    [Test]
+    procedure Create_WithSettings_UsesThemAndLeavesThemToTheCaller;
+
+    [Test]
+    procedure StartHttp_OnPortZero_ReportsTheBoundPort;
+
+    [Test]
+    procedure StartHttp_OnPortZero_AnswersTheHostNameOnEveryLoopbackFamily;
+
+    [Test]
+    procedure StartHttp_IsIdempotent;
+
+    [Test]
+    procedure Stop_IsIdempotent_BeforeAndAfterStart;
+
+    [Test]
+    procedure ToolsList_OverHttp_ListsOnlyTheAddedTools;
+
+    [Test]
+    procedure ToolsList_OverStdioStreams_ListsTheSameTools;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.IOUtils,
+  IdHTTP,
+  IdStack,
+  MCPServer.Errors,
+  MCPServer.Registration,
+  MCPServer.Settings,
+  MCPServer.Tests.Support;
+
+const
+  TOOLS_LIST = '{"jsonrpc":"2.0","id":1,"method":"tools/list"}';
+  URI_SERVER_STATUS = 'server://status';
+  URI_LOGS_RECENT = 'logs://recent';
+  URI_TEMPLATE_LOGS_BY_LEVEL = 'logs://{level}';
+  SETTINGS_WITH_ANOTHER_PORT = '[Server]'#13#10'Port=4242'#13#10;
+  ANOTHER_PORT = 4242;
+  DEFAULT_PORT = 3000;
+
+{ TNamedTool }
+
+constructor TNamedTool.CreateNamed(const AName: string);
+begin
+  inherited Create;
+  FName := AName;
+  FDescription := 'A tool handed to a single host';
+end;
+
+function TNamedTool.BuildSchema: TJSONObject;
+begin
+  Result := TJSONObject.ParseJSONValue(
+    '{"type":"object","properties":{},"additionalProperties":false}') as TJSONObject;
+end;
+
+function TNamedTool.DoExecute(const Arguments: TJSONObject): TValue;
+begin
+  Result := TValue.From<string>(FName + ' ran');
+end;
+
+{ TNamedResource }
+
+constructor TNamedResource.CreateNamed(const AUri: string);
+begin
+  inherited Create;
+  FURI := AUri;
+  FName := 'A resource handed to a single host';
+  FMimeType := 'application/json';
+end;
+
+function TNamedResource.GetResourceData: TNamedResourceData;
+begin
+  Result := TNamedResourceData.Create;
+  Result.Value := FURI;
+end;
+
+{ TNamedPrompt }
+
+constructor TNamedPrompt.CreateNamed(const AName: string);
+begin
+  inherited Create;
+  FName := AName;
+  FDescription := 'A prompt handed to a single host';
+end;
+
+function TNamedPrompt.ExecuteWithParams(const Params: TNamedPromptParams;
+  Messages: TMCPPromptMessages): string;
+begin
+  Messages.AddText('user', FName);
+  Result := FName;
+end;
+
+{ TServerHostTests }
+
+procedure TServerHostTests.Setup;
+begin
+  FHost := TMCPServerHost.Create;
+  FHost.Settings.Port := 0;
+  FHost.Settings.CorsEnabled := False;
+  FOther := nil;
+end;
+
+procedure TServerHostTests.TearDown;
+begin
+  FOther.Free;
+  FHost.Free;
+end;
+
+procedure TServerHostTests.StartOnAnyPort;
+begin
+  FHost.StartHttp;
+end;
+
+function TServerHostTests.ToolNamesOf(const Response: string): TArray<string>;
+begin
+  Result := nil;
+  const Json = TMCPTestJson.ParseObject(Response);
+  try
+    const Outcome = Json.GetValue('result') as TJSONObject;
+    Assert.IsNotNull(Outcome, 'the response carries no result: ' + Response);
+    for var Tool in Outcome.GetValue('tools') as TJSONArray do
+    begin
+      Result := Result + [(Tool as TJSONObject).GetValue<string>('name')];
+    end;
+  finally
+    Json.Free;
+  end;
+end;
+
+function TServerHostTests.PostTo(const Url: string): string;
+begin
+  const Http = TIdHTTP.Create(nil);
+  const Request = TStringStream.Create(TOOLS_LIST, TEncoding.UTF8);
+  try
+    Http.Request.ContentType := 'application/json';
+    Http.Request.Accept := 'application/json';
+    Result := Http.Post(Url, Request);
+  finally
+    Request.Free;
+    Http.Free;
+  end;
+end;
+
+function TServerHostTests.ToolNamesOverHttp: TArray<string>;
+begin
+  if not FHost.Active then
+    StartOnAnyPort;
+
+  Result := ToolNamesOf(PostTo(Format('http://127.0.0.1:%d/mcp', [FHost.BoundPort])));
+end;
+
+function TServerHostTests.NamesOverStdio(const Host: TMCPServerHost;
+  const Method, ListKey, NameKey: string): TArray<string>;
+begin
+  Result := nil;
+  const Request = Format('{"jsonrpc":"2.0","id":1,"method":"%s"}', [Method]);
+  const Input = TStringStream.Create(Request + #10, TEncoding.UTF8);
+  const Output = TStringStream.Create('', TEncoding.UTF8);
+  try
+    Host.RunStdioWith(Input, Output);
+    const Lines = Output.DataString.Split([#10], TStringSplitOptions.ExcludeEmpty);
+    Assert.AreEqual(1, Integer(Length(Lines)), 'stdio answered with more than one line: ' + Output.DataString);
+
+    const Json = TMCPTestJson.ParseObject(Lines[0]);
+    try
+      const Outcome = Json.GetValue('result') as TJSONObject;
+      Assert.IsNotNull(Outcome, 'the response carries no result: ' + Lines[0]);
+      for var Entry in Outcome.GetValue(ListKey) as TJSONArray do
+      begin
+        Result := Result + [(Entry as TJSONObject).GetValue<string>(NameKey)];
+      end;
+    finally
+      Json.Free;
+    end;
+  finally
+    Output.Free;
+    Input.Free;
+  end;
+end;
+
+function TServerHostTests.ToolNamesOverStdio(const Host: TMCPServerHost): TArray<string>;
+begin
+  Result := NamesOverStdio(Host, 'tools/list', 'tools', 'name');
+end;
+
+function TServerHostTests.ResourceUrisOverStdio(const Host: TMCPServerHost): TArray<string>;
+begin
+  Result := NamesOverStdio(Host, 'resources/list', 'resources', 'uri');
+end;
+
+function TServerHostTests.TemplateUrisOverStdio(const Host: TMCPServerHost): TArray<string>;
+begin
+  Result := NamesOverStdio(Host, 'resources/templates/list', 'resourceTemplates', 'uriTemplate');
+end;
+
+function TServerHostTests.PromptNamesOverStdio(const Host: TMCPServerHost): TArray<string>;
+begin
+  Result := NamesOverStdio(Host, 'prompts/list', 'prompts', 'name');
+end;
+
+procedure TServerHostTests.Default_PublishesNoToolAtAll;
+begin
+  Assert.IsTrue(Length(TMCPRegistry.GetToolNames) > 0, 'no tool is registered globally, so the test proves nothing');
+  Assert.AreEqual(0, Integer(Length(ToolNamesOverStdio(FHost))), 'a fresh host publishes a tool it was never given');
+end;
+
+procedure TServerHostTests.Default_PublishesNoResourceTemplateOrPrompt;
+begin
+  Assert.IsTrue(Length(TMCPRegistry.GetResourceURIs) > 0, 'no resource is registered globally, so the test proves nothing');
+  Assert.IsTrue(Length(TMCPRegistry.GetResourceTemplateURIs) > 0, 'no resource template is registered globally');
+  Assert.IsTrue(Length(TMCPRegistry.GetPromptNames) > 0, 'no prompt is registered globally');
+
+  Assert.AreEqual(0, Integer(Length(ResourceUrisOverStdio(FHost))),
+    'a fresh host publishes a resource it was never given');
+  Assert.AreEqual(0, Integer(Length(TemplateUrisOverStdio(FHost))),
+    'a fresh host publishes a resource template it was never given');
+  Assert.AreEqual(0, Integer(Length(PromptNamesOverStdio(FHost))),
+    'a fresh host publishes a prompt it was never given');
+end;
+
+procedure TServerHostTests.TwoHostsInOneProcess_HaveDisjointToolSets;
+begin
+  FOther := TMCPServerHost.Create;
+
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  FOther.AddTool(TNamedTool.CreateNamed('second_tool'));
+
+  Assert.IsTrue(FHost.HasTool('first_tool'));
+  Assert.IsFalse(FHost.HasTool('second_tool'), 'the first host sees the second host tool');
+  Assert.IsTrue(FOther.HasTool('second_tool'));
+  Assert.IsFalse(FOther.HasTool('first_tool'), 'the second host sees the first host tool');
+
+  Assert.AreEqual('first_tool', string.Join(',', ToolNamesOverStdio(FHost)));
+  Assert.AreEqual('second_tool', string.Join(',', ToolNamesOverStdio(FOther)));
+end;
+
+procedure TServerHostTests.TwoHostsInOneProcess_HaveDisjointResourceAndPromptSets;
+begin
+  FOther := TMCPServerHost.Create;
+
+  FHost.AddResource(TNamedResource.CreateNamed('first://resource'));
+  FHost.AddPrompt(TNamedPrompt.CreateNamed('first_prompt'));
+  FOther.AddResource(TNamedResource.CreateNamed('second://resource'));
+  FOther.AddPrompt(TNamedPrompt.CreateNamed('second_prompt'));
+
+  Assert.AreEqual('first://resource', string.Join(',', ResourceUrisOverStdio(FHost)));
+  Assert.AreEqual('first_prompt', string.Join(',', PromptNamesOverStdio(FHost)));
+  Assert.AreEqual('second://resource', string.Join(',', ResourceUrisOverStdio(FOther)));
+  Assert.AreEqual('second_prompt', string.Join(',', PromptNamesOverStdio(FOther)));
+end;
+
+procedure TServerHostTests.SeedFromGlobalRegistry_TakesTheGlobalTools;
+begin
+  FHost.SeedFromGlobalRegistry := True;
+  Assert.AreEqual(Integer(Length(TMCPRegistry.GetToolNames)), Integer(Length(ToolNamesOverStdio(FHost))));
+end;
+
+procedure TServerHostTests.SeedFromGlobalRegistry_TakesTheGlobalResourcesTemplatesAndPrompts;
+begin
+  FHost.SeedFromGlobalRegistry := True;
+
+  Assert.AreEqual(Integer(Length(TMCPRegistry.GetResourceURIs)),
+    Integer(Length(ResourceUrisOverStdio(FHost))));
+  Assert.AreEqual(Integer(Length(TMCPRegistry.GetResourceTemplateURIs)),
+    Integer(Length(TemplateUrisOverStdio(FHost))));
+  Assert.AreEqual(Integer(Length(TMCPRegistry.GetPromptNames)),
+    Integer(Length(PromptNamesOverStdio(FHost))));
+end;
+
+procedure TServerHostTests.DiagnosticsResourcesOff_DropsThemFromASeededHost;
+begin
+  FHost.Settings.ExposeDiagnosticsResources := False;
+  FHost.SeedFromGlobalRegistry := True;
+
+  const Uris = string.Join(',', ResourceUrisOverStdio(FHost));
+  const Templates = string.Join(',', TemplateUrisOverStdio(FHost));
+
+  Assert.IsFalse(Uris.Contains(URI_SERVER_STATUS), URI_SERVER_STATUS + ' survived ExposeDiagnosticsResources=False');
+  Assert.IsFalse(Uris.Contains(URI_LOGS_RECENT), URI_LOGS_RECENT + ' survived ExposeDiagnosticsResources=False');
+  Assert.IsFalse(Templates.Contains(URI_TEMPLATE_LOGS_BY_LEVEL),
+    URI_TEMPLATE_LOGS_BY_LEVEL + ' survived ExposeDiagnosticsResources=False');
+  Assert.IsTrue(Uris <> '', 'the setting emptied the resource list instead of hiding the diagnostics');
+end;
+
+procedure TServerHostTests.DiagnosticsResourcesOn_KeepsThemOnASeededHost;
+begin
+  FHost.SeedFromGlobalRegistry := True;
+
+  const Uris = string.Join(',', ResourceUrisOverStdio(FHost));
+  const Templates = string.Join(',', TemplateUrisOverStdio(FHost));
+
+  Assert.IsTrue(FHost.Settings.ExposeDiagnosticsResources, 'the diagnostics resources are exposed by default');
+  Assert.IsTrue(Uris.Contains(URI_SERVER_STATUS), URI_SERVER_STATUS + ' is missing from a seeded host');
+  Assert.IsTrue(Uris.Contains(URI_LOGS_RECENT), URI_LOGS_RECENT + ' is missing from a seeded host');
+  Assert.IsTrue(Templates.Contains(URI_TEMPLATE_LOGS_BY_LEVEL),
+    URI_TEMPLATE_LOGS_BY_LEVEL + ' is missing from a seeded host');
+end;
+
+procedure TServerHostTests.SeedFromGlobalRegistry_AfterTheManagersExist_IsAConfigurationError;
+begin
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  Assert.WillRaise(
+    procedure
+    begin
+      FHost.SeedFromGlobalRegistry := True;
+    end, EMCPConfigurationError);
+end;
+
+procedure TServerHostTests.RemoveTool_TakesTheToolBackOut;
+begin
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  FHost.RemoveTool('first_tool');
+  Assert.IsFalse(FHost.HasTool('first_tool'));
+  Assert.AreEqual(0, Integer(Length(ToolNamesOverStdio(FHost))));
+end;
+
+procedure TServerHostTests.Create_WithoutSettings_ReadsNoSettingsFile;
+begin
+  const NextToTheExecutable = TPath.Combine(TPath.GetDirectoryName(ParamStr(0)), 'settings.ini');
+  const AlreadyThere = TFile.Exists(NextToTheExecutable);
+  var Saved := '';
+  if AlreadyThere then
+    Saved := TFile.ReadAllText(NextToTheExecutable);
+
+  TFile.WriteAllText(NextToTheExecutable, SETTINGS_WITH_ANOTHER_PORT);
+  try
+    const Host = TMCPServerHost.Create;
+    try
+      Assert.AreEqual('', Host.Settings.SettingsFile, 'a host given no settings named a settings file');
+      Assert.AreEqual<Integer>(DEFAULT_PORT, Host.Settings.Port,
+        'a host given no settings read settings.ini from the executable directory');
+    finally
+      Host.Free;
+    end;
+  finally
+    if AlreadyThere then
+      TFile.WriteAllText(NextToTheExecutable, Saved)
+    else
+      TFile.Delete(NextToTheExecutable);
+  end;
+end;
+
+procedure TServerHostTests.Create_WithASettingsFile_ReadsThatFile;
+begin
+  const Directory = TPath.Combine(TPath.GetTempPath, 'mcp-host-' + TGuid.NewGuid.ToString);
+  TDirectory.CreateDirectory(Directory);
+  try
+    const Path = TPath.Combine(Directory, 'settings.ini');
+    TFile.WriteAllText(Path, SETTINGS_WITH_ANOTHER_PORT);
+
+    const Host = TMCPServerHost.Create(Path);
+    try
+      Assert.AreEqual(Path, Host.Settings.SettingsFile);
+      Assert.AreEqual<Integer>(ANOTHER_PORT, Host.Settings.Port, 'the host ignored the settings file it was given');
+    finally
+      Host.Free;
+    end;
+  finally
+    TDirectory.Delete(Directory, True);
+  end;
+end;
+
+procedure TServerHostTests.Create_WithSettings_UsesThemAndLeavesThemToTheCaller;
+begin
+  const Settings = TMCPSettings.CreateDefaults;
+  try
+    Settings.Port := ANOTHER_PORT;
+
+    const Host = TMCPServerHost.Create(Settings);
+    try
+      Assert.AreEqual<Integer>(ANOTHER_PORT, Host.Settings.Port, 'the host ignored the settings it was given');
+    finally
+      Host.Free;
+    end;
+
+    Assert.AreEqual<Integer>(ANOTHER_PORT, Settings.Port, 'the settings did not survive the host');
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TServerHostTests.StartHttp_OnPortZero_ReportsTheBoundPort;
+begin
+  Assert.AreEqual(0, Integer(FHost.BoundPort), 'a host that never started reports a port');
+  StartOnAnyPort;
+  Assert.IsTrue(FHost.BoundPort > 0, 'StartHttp on port 0 reports no bound port');
+  Assert.IsTrue(FHost.Active);
+end;
+
+procedure TServerHostTests.StartHttp_OnPortZero_AnswersTheHostNameOnEveryLoopbackFamily;
+begin
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  StartOnAnyPort;
+
+  Assert.AreEqual('first_tool',
+    string.Join(',', ToolNamesOf(PostTo(Format('http://localhost:%d/mcp', [FHost.BoundPort])))),
+    'the host name does not answer on the port the host reports');
+
+  if not GStack.SupportsIPv6 then
+    Exit;
+
+  Assert.AreEqual('first_tool',
+    string.Join(',', ToolNamesOf(PostTo(Format('http://[::1]:%d/mcp', [FHost.BoundPort])))),
+    'the IPv6 loopback, which localhost resolves to first on Windows, listens on another port');
+end;
+
+procedure TServerHostTests.StartHttp_IsIdempotent;
+begin
+  StartOnAnyPort;
+  const FirstPort = FHost.BoundPort;
+  FHost.StartHttp;
+  Assert.AreEqual(Integer(FirstPort), Integer(FHost.BoundPort), 'the second StartHttp rebound the server');
+  Assert.IsTrue(FHost.Active);
+  Assert.AreEqual(0, Integer(Length(ToolNamesOverHttp)), 'the server stopped answering after the second StartHttp');
+end;
+
+procedure TServerHostTests.Stop_IsIdempotent_BeforeAndAfterStart;
+begin
+  FHost.Stop;
+  Assert.IsFalse(FHost.Active);
+
+  StartOnAnyPort;
+  FHost.Stop;
+  FHost.Stop;
+  Assert.IsFalse(FHost.Active);
+end;
+
+procedure TServerHostTests.ToolsList_OverHttp_ListsOnlyTheAddedTools;
+begin
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  FHost.AddTool(TNamedTool.CreateNamed('second_tool'));
+  Assert.AreEqual('first_tool,second_tool', string.Join(',', ToolNamesOverHttp));
+end;
+
+procedure TServerHostTests.ToolsList_OverStdioStreams_ListsTheSameTools;
+begin
+  FHost.AddTool(TNamedTool.CreateNamed('first_tool'));
+  FHost.AddTool(TNamedTool.CreateNamed('second_tool'));
+
+  const OverHttp = string.Join(',', ToolNamesOverHttp);
+  const OverStdio = string.Join(',', ToolNamesOverStdio(FHost));
+  Assert.AreEqual('first_tool,second_tool', OverStdio);
+  Assert.AreEqual(OverHttp, OverStdio, 'HTTP and stdio disagree about the tool set');
+end;
+
+end.

--- a/tests/MCPServer.Tests.HttpCancellation.pas
+++ b/tests/MCPServer.Tests.HttpCancellation.pas
@@ -1,0 +1,300 @@
+unit MCPServer.Tests.HttpCancellation;
+
+// What cancels a running tool over HTTP, asserted against this server with nothing but an HTTP
+// client, because both claims are about the server and not about whatever is calling it.
+//
+// README.md and MIGRATION.md state two things a reader is entitled to rely on:
+//
+//   1. Closing the response stream cancels the request. The server's next write to the stream
+//      fails, MCPServer.HttpStream cancels the request the tool is running, and the tool's
+//      IsCancelled turns True.
+//   2. A notifications/cancelled naming a request that is still in flight arrives on a connection
+//      of its own, is answered 202 and is dropped, because the tracker a request consults is its
+//      own response stream. The running tool never hears about it and answers as it would have.
+//
+// TCancelWatchTool is what makes both visible. It reports progress on every step, which is what
+// turns the response into a chunked event stream and what gives the server a write that can fail,
+// and it records whether it saw its request cancelled or ran to the end.
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.SyncObjs,
+  System.Rtti,
+  DUnitX.TestFramework,
+  MCPServer.Types,
+  MCPServer.RequestContext,
+  MCPServer.Tool.Base,
+  MCPServer.Host;
+
+type
+  TNoParams = class
+  end;
+
+  { Runs until the test releases it or its request is cancelled, and remembers which of the two
+    happened. }
+  TCancelWatchTool = class(TMCPToolBase<TNoParams>)
+  strict private
+    FStarted: TEvent;
+    FRelease: TEvent;
+    FCancelSeen: TEvent;
+    FRequestId: string;
+  protected
+    function ExecuteWithContext(const Params: TNoParams;
+      const Context: IMCPRequestContext): TValue; override;
+  public
+    constructor Create; override;
+    destructor Destroy; override;
+
+    function WaitForStart(const TimeoutMs: Cardinal): Boolean;
+    function WaitForCancellation(const TimeoutMs: Cardinal): Boolean;
+    function SawCancellation: Boolean;
+    procedure Release;
+
+    { The id the server gave this request, which is what a notifications/cancelled has to name.
+      Written before the start is signalled, so a test that waited for the start may read it. }
+    property RequestId: string read FRequestId;
+  end;
+
+  [TestFixture]
+  TMCPHttpCancellationTests = class
+  private
+    FHost: TMCPServerHost;
+    FWatch: TCancelWatchTool;
+    FWatchTool: IMCPTool;
+    function Url: string;
+    function Post(const Body: string; out StatusCode: Integer): string;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure ADroppedConnection_CancelsTheRunningTool;
+
+    [Test]
+    procedure ACancellationOnASecondConnection_IsAcceptedAndTheToolRunsOn;
+  end;
+
+implementation
+
+uses
+  IdHTTP,
+  IdTCPClient,
+  IdGlobal,
+  MCPServer.Errors,
+  MCPServer.Tool.Result;
+
+const
+  LOOPBACK = '127.0.0.1';
+  ENDPOINT = '/mcp';
+  URL_TEMPLATE = 'http://%s:%d%s';
+  ACCEPT_STREAM = 'application/json, text/event-stream';
+
+  TOOL_CANCEL_WATCH = 'test_cancel_watch';
+
+  WATCH_STEPS = 200;
+  WATCH_STEP_MS = 25;
+  WATCH_WAIT_MS = 5000;
+  WATCH_STEP_MESSAGE = 'still working';
+  WATCH_ANSWER = 'the watch tool ran to the end';
+
+  { The call both tests make. Nothing negotiates first: over HTTP a legacy request stands on its
+    own, which is what lets a raw socket send one. The progress token is not decoration: without
+    one ReportProgress sends nothing, the response stays a single JSON object, and there is no
+    stream to close. }
+  CALL_REQUEST =
+    '{"jsonrpc":"2.0","id":1,"method":"tools/call",' +
+    '"params":{"name":"' + TOOL_CANCEL_WATCH + '","arguments":{},' +
+    '"_meta":{"progressToken":"watch"}}}';
+
+  CANCEL_NOTIFICATION =
+    '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":%s,' +
+    '"reason":"a second connection"}}';
+
+  { Long enough for the server to have written its first progress frame, so the write that fails
+    is a later one and not the first. }
+  STREAM_SETTLE_MS = 300;
+
+{ TCancelWatchTool }
+
+constructor TCancelWatchTool.Create;
+begin
+  inherited;
+  FName := TOOL_CANCEL_WATCH;
+  FDescription := 'Reports progress until the caller goes away or the test releases it';
+  FStarted := TEvent.Create(nil, True, False, '');
+  FRelease := TEvent.Create(nil, True, False, '');
+  FCancelSeen := TEvent.Create(nil, True, False, '');
+end;
+
+destructor TCancelWatchTool.Destroy;
+begin
+  FCancelSeen.Free;
+  FRelease.Free;
+  FStarted.Free;
+  inherited;
+end;
+
+function TCancelWatchTool.ExecuteWithContext(const Params: TNoParams;
+  const Context: IMCPRequestContext): TValue;
+begin
+  FRequestId := Context.RequestId.AsText;
+  FStarted.SetEvent;
+
+  for var Step := 1 to WATCH_STEPS do
+  begin
+    if Context.IsCancelled then
+    begin
+      FCancelSeen.SetEvent;
+      Break;
+    end;
+
+    Context.ReportProgress(Step, WATCH_STEPS, WATCH_STEP_MESSAGE);
+
+    if FRelease.WaitFor(WATCH_STEP_MS) = TWaitResult.wrSignaled then
+      Break;
+  end;
+
+  Result := TMCPToolResult.Text(WATCH_ANSWER);
+end;
+
+function TCancelWatchTool.WaitForStart(const TimeoutMs: Cardinal): Boolean;
+begin
+  Result := (FStarted.WaitFor(TimeoutMs) = TWaitResult.wrSignaled);
+end;
+
+function TCancelWatchTool.WaitForCancellation(const TimeoutMs: Cardinal): Boolean;
+begin
+  Result := (FCancelSeen.WaitFor(TimeoutMs) = TWaitResult.wrSignaled);
+end;
+
+function TCancelWatchTool.SawCancellation: Boolean;
+begin
+  Result := (FCancelSeen.WaitFor(0) = TWaitResult.wrSignaled);
+end;
+
+procedure TCancelWatchTool.Release;
+begin
+  FRelease.SetEvent;
+end;
+
+{ TMCPHttpCancellationTests }
+
+procedure TMCPHttpCancellationTests.Setup;
+begin
+  FWatch := TCancelWatchTool.Create;
+  FWatchTool := FWatch;
+
+  FHost := TMCPServerHost.Create;
+  FHost.Settings.Port := 0;
+  FHost.Settings.CorsEnabled := False;
+  FHost.AddTool(FWatchTool);
+  FHost.StartHttp;
+end;
+
+procedure TMCPHttpCancellationTests.TearDown;
+begin
+  // A tool still counting its steps would hold the host open for as long as its budget lasts.
+  FWatch.Release;
+  FreeAndNil(FHost);
+  FWatch := nil;
+  FWatchTool := nil;
+end;
+
+function TMCPHttpCancellationTests.Url: string;
+begin
+  Result := Format(URL_TEMPLATE, [LOOPBACK, FHost.BoundPort, ENDPOINT]);
+end;
+
+function TMCPHttpCancellationTests.Post(const Body: string; out StatusCode: Integer): string;
+begin
+  const Http = TIdHTTP.Create(nil);
+  const Request = TStringStream.Create(Body, TEncoding.UTF8);
+  try
+    Http.HTTPOptions := Http.HTTPOptions + [hoNoProtocolErrorException];
+    Http.Request.ContentType := MEDIA_TYPE_JSON;
+    Http.Request.Accept := ACCEPT_STREAM;
+    Result := Http.Post(Url, Request);
+    StatusCode := Http.ResponseCode;
+  finally
+    Request.Free;
+    Http.Free;
+  end;
+end;
+
+procedure TMCPHttpCancellationTests.ADroppedConnection_CancelsTheRunningTool;
+begin
+  const Socket = TIdTCPClient.Create(nil);
+  try
+    Socket.Host := LOOPBACK;
+    Socket.Port := FHost.BoundPort;
+    Socket.Connect;
+
+    const Payload = TEncoding.UTF8.GetBytes(CALL_REQUEST);
+    Socket.IOHandler.WriteLn('POST ' + ENDPOINT + ' HTTP/1.1');
+    Socket.IOHandler.WriteLn(Format('Host: %s:%d', [LOOPBACK, FHost.BoundPort]));
+    Socket.IOHandler.WriteLn('Content-Type: ' + MEDIA_TYPE_JSON);
+    Socket.IOHandler.WriteLn('Accept: ' + ACCEPT_STREAM);
+    Socket.IOHandler.WriteLn(Format('Content-Length: %d', [Length(Payload)]));
+    Socket.IOHandler.WriteLn('Connection: close');
+    Socket.IOHandler.WriteLn;
+    Socket.IOHandler.Write(TIdBytes(Payload));
+
+    Assert.IsTrue(FWatch.WaitForStart(WATCH_WAIT_MS), 'the tool never started');
+
+    // Let the stream get going, so the write that fails is a later one and not the first.
+    Socket.IOHandler.CheckForDataOnSource(STREAM_SETTLE_MS);
+    Socket.Disconnect;
+  finally
+    Socket.Free;
+  end;
+
+  Assert.IsTrue(FWatch.WaitForCancellation(WATCH_WAIT_MS),
+    'the tool never saw its request cancelled, so the closed stream cancelled nothing');
+end;
+
+procedure TMCPHttpCancellationTests.ACancellationOnASecondConnection_IsAcceptedAndTheToolRunsOn;
+begin
+  var Answer := '';
+  var Failure := '';
+  var CallStatus := 0;
+
+  const Caller = TThread.CreateAnonymousThread(
+    procedure
+    begin
+      try
+        Answer := Post(CALL_REQUEST, CallStatus);
+      except
+        on E: Exception do
+          Failure := E.ClassName + ': ' + E.Message;
+      end;
+    end);
+  Caller.FreeOnTerminate := False;
+  Caller.Start;
+  try
+    Assert.IsTrue(FWatch.WaitForStart(WATCH_WAIT_MS), 'the tool never started');
+
+    var NotifiedStatus := 0;
+    Post(Format(CANCEL_NOTIFICATION, [FWatch.RequestId]), NotifiedStatus);
+    Assert.AreEqual(HTTP_STATUS_ACCEPTED, NotifiedStatus,
+      'the server answered the cancellation with something other than 202');
+
+    // The tool has now outlived the notification, which is the whole point; it may stop.
+    FWatch.Release;
+  finally
+    Caller.WaitFor;
+    Caller.Free;
+  end;
+
+  Assert.AreEqual('', Failure, 'the call itself failed');
+  Assert.IsFalse(FWatch.SawCancellation,
+    'the notification reached the running request after all, which the documents deny');
+  Assert.IsTrue(Answer.Contains(WATCH_ANSWER),
+    'the tool did not answer after the cancellation it never heard: ' + Answer);
+end;
+
+end.

--- a/tests/MCPServer.Tests.Marshal.pas
+++ b/tests/MCPServer.Tests.Marshal.pas
@@ -1,0 +1,413 @@
+unit MCPServer.Tests.Marshal;
+
+interface
+
+uses
+  System.Rtti,
+  System.TypInfo,
+  System.Generics.Collections,
+  DUnitX.TestFramework,
+  MCPServer.Types;
+
+type
+  TMarshalColour = (mcRed, mcGreen, mcBlue);
+
+  TMarshalPoint = class
+  private
+    FX: Integer;
+    FY: Integer;
+  public
+    property X: Integer read FX write FX;
+    property Y: Integer read FY write FY;
+  end;
+
+  TMarshalLine = class
+  private
+    FName: string;
+    FOrigin: TMarshalPoint;
+  public
+    destructor Destroy; override;
+    property Name: string read FName write FName;
+    [Optional]
+    property Origin: TMarshalPoint read FOrigin write FOrigin;
+  end;
+
+  TMarshalIntegerArray = TArray<Integer>;
+  TMarshalStringArray = TArray<string>;
+  TMarshalPointArray = TArray<TMarshalPoint>;
+  TMarshalIntegerList = TList<Integer>;
+  TMarshalPointList = TObjectList<TMarshalPoint>;
+
+  [TestFixture]
+  TMarshalTests = class
+  private
+    FContext: TRttiContext;
+    FOwned: TList<TObject>;
+
+    function RttiTypeOf(const Info: PTypeInfo): TRttiType;
+    function FromJson(const Json: string; const RttiType: TRttiType): TValue;
+    function FromJsonUnowned(const Json: string; const RttiType: TRttiType): TValue;
+    function ToJsonText(const Value: TValue; const RttiType: TRttiType): string;
+    procedure ExpectArgumentError(const Json: string; const RttiType: TRttiType; const Fragment: string);
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Integer_RoundTrip;
+
+    [Test]
+    procedure Int64_RoundTrip;
+
+    [Test]
+    procedure String_RoundTrip;
+
+    [Test]
+    procedure Float_RoundTrip;
+
+    [Test]
+    procedure Boolean_RoundTrip;
+
+    [Test]
+    procedure Enum_ByName_RoundTrip;
+
+    [Test]
+    procedure Enum_UnknownName_Raises;
+
+    [Test]
+    procedure DateTime_Iso8601_RoundTrip;
+
+    [Test]
+    procedure WrongType_MessagesKeepTheirShape;
+
+    [Test]
+    procedure NestedClass_JsonToValue;
+
+    [Test]
+    procedure NestedClass_ValueToJson;
+
+    [Test]
+    procedure NestedClass_ErrorNamesTheParameter;
+
+    [Test]
+    procedure StringArray_RoundTrip;
+
+    [Test]
+    procedure IntegerArray_ValueToJson;
+
+    [Test]
+    procedure ObjectArray_OwnedHoldsEveryElement;
+
+    [Test]
+    procedure PrimitiveArray_OwnedStaysEmpty;
+
+    [Test]
+    procedure Owned_HoldsOnlyTheRootOfANestedClass;
+
+    [Test]
+    procedure Owned_Nil_LeavesTheObjectToTheCaller;
+
+    [Test]
+    procedure List_ValueToJson;
+
+    [Test]
+    procedure ObjectList_ValueToJson;
+
+    [Test]
+    procedure EmptyValue_IsNullForAClassAndEmptyForAnArray;
+
+    [Test]
+    procedure NoType_IsSafe;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.DateUtils,
+  System.JSON,
+  MCPServer.Serializer;
+
+{ TMarshalLine }
+
+destructor TMarshalLine.Destroy;
+begin
+  FOrigin.Free;
+  inherited;
+end;
+
+{ TMarshalTests }
+
+procedure TMarshalTests.Setup;
+begin
+  FOwned := TList<TObject>.Create;
+end;
+
+procedure TMarshalTests.TearDown;
+begin
+  for var Obj in FOwned do
+    Obj.Free;
+  FOwned.Free;
+end;
+
+function TMarshalTests.RttiTypeOf(const Info: PTypeInfo): TRttiType;
+begin
+  Result := FContext.GetType(Info);
+end;
+
+function TMarshalTests.FromJson(const Json: string; const RttiType: TRttiType): TValue;
+begin
+  const Parsed = TJSONObject.ParseJSONValue(Json);
+  Assert.IsNotNull(Parsed, 'the test json does not parse: ' + Json);
+  try
+    Result := TMCPSerializer.JsonToValue(Parsed, RttiType, FOwned);
+  finally
+    Parsed.Free;
+  end;
+end;
+
+function TMarshalTests.FromJsonUnowned(const Json: string; const RttiType: TRttiType): TValue;
+begin
+  const Parsed = TJSONObject.ParseJSONValue(Json);
+  Assert.IsNotNull(Parsed, 'the test json does not parse: ' + Json);
+  try
+    Result := TMCPSerializer.JsonToValue(Parsed, RttiType, nil);
+  finally
+    Parsed.Free;
+  end;
+end;
+
+function TMarshalTests.ToJsonText(const Value: TValue; const RttiType: TRttiType): string;
+begin
+  const Json = TMCPSerializer.ValueToJson(Value, RttiType);
+  Assert.IsNotNull(Json, 'ValueToJson returned nil');
+  try
+    Result := Json.ToJSON;
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMarshalTests.ExpectArgumentError(const Json: string; const RttiType: TRttiType; const Fragment: string);
+begin
+  try
+    FromJson(Json, RttiType);
+    Assert.Fail('expected EArgumentException for ' + Json);
+  except
+    on E: EArgumentException do
+      Assert.IsTrue(E.Message.Contains(Fragment), E.Message + ' does not mention ' + Fragment);
+  end;
+end;
+
+procedure TMarshalTests.Integer_RoundTrip;
+begin
+  const IntegerType = RttiTypeOf(TypeInfo(Integer));
+  const Value = FromJson('42', IntegerType);
+  Assert.AreEqual(42, Value.AsInteger);
+  Assert.AreEqual('42', ToJsonText(Value, IntegerType));
+end;
+
+procedure TMarshalTests.Int64_RoundTrip;
+begin
+  const Int64Type = RttiTypeOf(TypeInfo(Int64));
+  const Value = FromJson('9007199254740992', Int64Type);
+  Assert.AreEqual(Int64(9007199254740992), Value.AsInt64);
+  Assert.AreEqual('9007199254740992', ToJsonText(Value, Int64Type));
+end;
+
+procedure TMarshalTests.String_RoundTrip;
+begin
+  const StringType = RttiTypeOf(TypeInfo(string));
+  const Value = FromJson('"hello"', StringType);
+  Assert.AreEqual('hello', Value.AsString);
+  Assert.AreEqual('"hello"', ToJsonText(Value, StringType));
+end;
+
+procedure TMarshalTests.Float_RoundTrip;
+begin
+  const FloatType = RttiTypeOf(TypeInfo(Double));
+  const Value = FromJson('1.5', FloatType);
+  Assert.AreEqual(1.5, Value.AsExtended, 0.0001);
+  Assert.AreEqual('1.5', ToJsonText(Value, FloatType));
+end;
+
+procedure TMarshalTests.Boolean_RoundTrip;
+begin
+  const BooleanType = RttiTypeOf(TypeInfo(Boolean));
+  Assert.IsTrue(FromJson('true', BooleanType).AsBoolean);
+  Assert.IsFalse(FromJson('false', BooleanType).AsBoolean);
+  Assert.AreEqual('true', ToJsonText(TValue.From<Boolean>(True), BooleanType));
+  Assert.AreEqual('false', ToJsonText(TValue.From<Boolean>(False), BooleanType));
+end;
+
+procedure TMarshalTests.Enum_ByName_RoundTrip;
+begin
+  const ColourType = RttiTypeOf(TypeInfo(TMarshalColour));
+  const Value = FromJson('"mcGreen"', ColourType);
+  Assert.AreEqual(Ord(mcGreen), Integer(Value.AsOrdinal));
+  Assert.AreEqual('"mcGreen"', ToJsonText(Value, ColourType));
+end;
+
+procedure TMarshalTests.Enum_UnknownName_Raises;
+begin
+  ExpectArgumentError('"mcPurple"', RttiTypeOf(TypeInfo(TMarshalColour)),
+    'Valid values: mcRed, mcGreen, mcBlue');
+end;
+
+procedure TMarshalTests.DateTime_Iso8601_RoundTrip;
+begin
+  const DateTimeType = RttiTypeOf(TypeInfo(TDateTime));
+  const When = EncodeDateTime(2026, 9, 7, 10, 30, 0, 0);
+  const Text = ToJsonText(TValue.From<TDateTime>(When), DateTimeType);
+  Assert.IsTrue(Text.StartsWith('"2026-09-07T10:30:00'), Text);
+  Assert.IsFalse(Text.Contains('Z'), 'the wire format is local time, not UTC: ' + Text);
+
+  const Back = FromJson(Text, DateTimeType);
+  Assert.AreEqual(Double(When), Double(Back.AsType<TDateTime>), 1.0 / SecsPerDay);
+end;
+
+procedure TMarshalTests.WrongType_MessagesKeepTheirShape;
+begin
+  ExpectArgumentError('"two"', RttiTypeOf(TypeInfo(Integer)), 'expected an integer');
+  ExpectArgumentError('1.5', RttiTypeOf(TypeInfo(Integer)), 'expected an integer');
+  ExpectArgumentError('"nope"', RttiTypeOf(TypeInfo(Double)), 'expected a number');
+  ExpectArgumentError('5', RttiTypeOf(TypeInfo(string)), 'expected a string');
+  ExpectArgumentError('5', RttiTypeOf(TypeInfo(Boolean)), 'expected a boolean');
+  ExpectArgumentError('"not-a-date"', RttiTypeOf(TypeInfo(TDateTime)), 'expected an ISO 8601 date-time');
+  ExpectArgumentError('5', FContext.GetType(TMarshalPoint), 'expected an object');
+  ExpectArgumentError('5', RttiTypeOf(TypeInfo(TMarshalIntegerArray)), 'expected an array');
+end;
+
+procedure TMarshalTests.NestedClass_JsonToValue;
+begin
+  const Value = FromJson('{"name":"edge","origin":{"x":1,"y":2}}', FContext.GetType(TMarshalLine));
+  const Line = Value.AsObject as TMarshalLine;
+  Assert.AreEqual('edge', Line.Name);
+  Assert.IsNotNull(Line.Origin);
+  Assert.AreEqual(1, Line.Origin.X);
+  Assert.AreEqual(2, Line.Origin.Y);
+end;
+
+procedure TMarshalTests.NestedClass_ValueToJson;
+begin
+  const LineType = FContext.GetType(TMarshalLine);
+  const Line = TMarshalLine.Create;
+  FOwned.Add(Line);
+  Line.Name := 'edge';
+  Line.Origin := TMarshalPoint.Create;
+  Line.Origin.X := 1;
+  Line.Origin.Y := 2;
+
+  Assert.AreEqual('{"name":"edge","origin":{"x":1,"y":2}}', ToJsonText(Line, LineType));
+end;
+
+procedure TMarshalTests.NestedClass_ErrorNamesTheParameter;
+begin
+  ExpectArgumentError('{"name":"edge","origin":{"x":"nope","y":2}}', FContext.GetType(TMarshalLine),
+    'Parameter "x": expected an integer');
+end;
+
+procedure TMarshalTests.StringArray_RoundTrip;
+begin
+  const ArrayType = RttiTypeOf(TypeInfo(TMarshalStringArray));
+  const Value = FromJson('["a","b"]', ArrayType);
+  Assert.AreEqual(2, Integer(Value.GetArrayLength));
+  Assert.AreEqual('b', Value.GetArrayElement(1).AsString);
+  Assert.AreEqual('["a","b"]', ToJsonText(Value, ArrayType));
+end;
+
+procedure TMarshalTests.IntegerArray_ValueToJson;
+begin
+  const ArrayType = RttiTypeOf(TypeInfo(TMarshalIntegerArray));
+  const Numbers: TMarshalIntegerArray = [1, 2, 3];
+  Assert.AreEqual('[1,2,3]', ToJsonText(TValue.From<TMarshalIntegerArray>(Numbers), ArrayType));
+end;
+
+procedure TMarshalTests.ObjectArray_OwnedHoldsEveryElement;
+begin
+  const ArrayType = RttiTypeOf(TypeInfo(TMarshalPointArray));
+  const Value = FromJson('[{"x":1,"y":2},{"x":3,"y":4}]', ArrayType);
+
+  Assert.AreEqual(2, Integer(Value.GetArrayLength));
+  Assert.AreEqual(2, Integer(FOwned.Count));
+  Assert.AreSame(Value.GetArrayElement(0).AsObject, FOwned[0]);
+  Assert.AreSame(Value.GetArrayElement(1).AsObject, FOwned[1]);
+  Assert.AreEqual(3, (FOwned[1] as TMarshalPoint).X);
+  Assert.AreEqual('[{"x":1,"y":2},{"x":3,"y":4}]', ToJsonText(Value, ArrayType));
+end;
+
+procedure TMarshalTests.PrimitiveArray_OwnedStaysEmpty;
+begin
+  const Value = FromJson('[1,2,3]', RttiTypeOf(TypeInfo(TMarshalIntegerArray)));
+  Assert.AreEqual(3, Integer(Value.GetArrayLength));
+  Assert.AreEqual(0, Integer(FOwned.Count));
+end;
+
+procedure TMarshalTests.Owned_HoldsOnlyTheRootOfANestedClass;
+begin
+  const Value = FromJson('{"name":"edge","origin":{"x":1,"y":2}}', FContext.GetType(TMarshalLine));
+
+  Assert.AreEqual(1, Integer(FOwned.Count), 'the nested object belongs to the object that holds it');
+  Assert.AreSame(Value.AsObject, FOwned[0]);
+end;
+
+procedure TMarshalTests.Owned_Nil_LeavesTheObjectToTheCaller;
+begin
+  const Value = FromJsonUnowned('{"x":1,"y":2}', FContext.GetType(TMarshalPoint));
+
+  Assert.AreEqual(0, Integer(FOwned.Count));
+  const Point = Value.AsObject as TMarshalPoint;
+  try
+    Assert.AreEqual(1, Point.X);
+  finally
+    Point.Free;
+  end;
+end;
+
+procedure TMarshalTests.List_ValueToJson;
+begin
+  const ListType = FContext.GetType(TMarshalIntegerList);
+  const List = TMarshalIntegerList.Create;
+  FOwned.Add(List);
+  List.Add(7);
+  List.Add(8);
+
+  Assert.AreEqual('[7,8]', ToJsonText(List, ListType));
+end;
+
+procedure TMarshalTests.ObjectList_ValueToJson;
+begin
+  const ListType = FContext.GetType(TMarshalPointList);
+  const List = TMarshalPointList.Create;
+  FOwned.Add(List);
+  const Point = TMarshalPoint.Create;
+  Point.X := 1;
+  Point.Y := 2;
+  List.Add(Point);
+
+  Assert.AreEqual('[{"x":1,"y":2}]', ToJsonText(List, ListType));
+end;
+
+procedure TMarshalTests.EmptyValue_IsNullForAClassAndEmptyForAnArray;
+begin
+  Assert.AreEqual('null', ToJsonText(TValue.Empty, FContext.GetType(TMarshalPoint)));
+  Assert.AreEqual('[]', ToJsonText(TValue.Empty, RttiTypeOf(TypeInfo(TMarshalIntegerArray))));
+end;
+
+procedure TMarshalTests.NoType_IsSafe;
+begin
+  const Parsed = TJSONObject.ParseJSONValue('42');
+  try
+    Assert.IsTrue(TMCPSerializer.JsonToValue(Parsed, nil, FOwned).IsEmpty);
+  finally
+    Parsed.Free;
+  end;
+
+  Assert.IsNull(TMCPSerializer.ValueToJson(TValue.From<Integer>(42), nil));
+  Assert.IsTrue(TMCPSerializer.JsonToValue(nil, RttiTypeOf(TypeInfo(Integer)), FOwned).IsEmpty);
+end;
+
+end.

--- a/tests/MCPServer.Tests.MethodTool.pas
+++ b/tests/MCPServer.Tests.MethodTool.pas
@@ -1,0 +1,780 @@
+unit MCPServer.Tests.MethodTool;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Rtti,
+  System.JSON,
+  System.Generics.Collections,
+  MCPServer.Types,
+  MCPServer.Tool.Base,
+  MCPServer.Tool.Method;
+
+type
+  TCountedFilter = class
+  private
+    FCustomer: string;
+    FLimit: Integer;
+  public
+    class var DestroyCount: Integer;
+    destructor Destroy; override;
+    property Customer: string read FCustomer write FCustomer;
+    [Optional]
+    property Limit: Integer read FLimit write FLimit;
+  end;
+
+  TCountedLine = class
+  private
+    FSku: string;
+    FQuantity: Integer;
+  public
+    class var DestroyCount: Integer;
+    destructor Destroy; override;
+    property Sku: string read FSku write FSku;
+    property Quantity: Integer read FQuantity write FQuantity;
+  end;
+
+  TSampleTarget = class
+  private
+    FSeen: string;
+    FKept: TCountedFilter;
+  public
+    destructor Destroy; override;
+    procedure Ping;
+    procedure Remember(const Note: string);
+    function Add(const Left, Right: Integer): Integer;
+    function Greet(const Person: string): string;
+    function Describe(const Filter: TCountedFilter): string;
+    function JoinSkus(const Skus: TArray<string>): string;
+    function CountLines(const Lines: TArray<TCountedLine>): Integer;
+    function MakeLine: TCountedLine;
+    function MakeLines: TArray<TCountedLine>;
+    function Tagged([SchemaName('colour_tag')] const Tag: string): string;
+    function WithOptional(const Base: string; [Optional] const Suffix: string): string;
+    function Keep(const Filter: TCountedFilter): string;
+    property Seen: string read FSeen;
+    property Kept: TCountedFilter read FKept;
+  end;
+
+  TEnvelopeTool = class(TMCPMethodTool)
+  protected
+    function ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue; override;
+  public
+    function GetOutputSchema: TJSONObject; override;
+  end;
+
+  TMismatchedTool = class(TMCPMethodTool)
+  protected
+    function ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue; override;
+  end;
+
+  TKeepingTool = class(TMCPMethodTool)
+  protected
+    procedure ReleaseResult(const Value: TValue; const ResultType: TRttiType); override;
+  public
+    Kept: TObject;
+  end;
+
+  TAdoptingTool = class(TMCPMethodTool)
+  protected
+    procedure ReleaseArguments(const Owned: TList<TObject>); override;
+  end;
+
+  [TestFixture]
+  TMethodToolTests = class
+  private
+    FContext: TRttiContext;
+    FTarget: TSampleTarget;
+    function MethodOf(const MethodName: string): TRttiMethod;
+    function ToolFor(const MethodName: string): IMCPTool;
+    function Run(const Tool: IMCPTool; const ArgumentsJson: string): TJSONObject;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Procedure_ReturnsOk;
+
+    [Test]
+    procedure Procedure_PassesItsArgument;
+
+    [Test]
+    procedure Function_ReturnsTheResultMember;
+
+    [Test]
+    procedure StringFunction_ReturnsAStringResult;
+
+    [Test]
+    procedure DtoParameter_IsMarshalledAndFreed;
+
+    [Test]
+    procedure ArrayParameter_IsMarshalled;
+
+    [Test]
+    procedure ObjectArrayParameter_IsMarshalledAndEveryElementFreed;
+
+    [Test]
+    procedure MissingRequiredArgument_RaisesArgumentException;
+
+    [Test]
+    procedure WrongArgumentType_RaisesArgumentException;
+
+    [Test]
+    procedure UnknownArgument_RaisesArgumentException;
+
+    [Test]
+    procedure OptionalArgument_MayBeOmitted;
+
+    [Test]
+    procedure SchemaName_IsAlsoTheArgumentName;
+
+    [Test]
+    procedure OverriddenResultToJson_ReplacesTheWholeObject;
+
+    [Test]
+    procedure ReturnedObject_IsFreedExactlyOnce;
+
+    [Test]
+    procedure ReturnedObjectArray_IsFreedElementByElement;
+
+    [Test]
+    procedure OverriddenReleaseResult_KeepsTheReturnedObject;
+
+    [Test]
+    procedure OverriddenReleaseArguments_LeavesTheArgumentToTheMethod;
+
+    [Test]
+    procedure GetInputSchema_ReturnsAFreshInstanceEveryCall;
+
+    [Test]
+    procedure FreeingAnInputSchema_LeavesTheToolUsable;
+
+    [Test]
+    procedure GetOutputSchema_ReturnsAFreshInstanceEveryCall;
+
+    [Test]
+    procedure Procedure_HasNoOutputSchema;
+
+    [Test]
+    procedure OutputSchema_ValidatesTheDefaultFunctionResult;
+
+    [Test]
+    procedure OutputSchema_ValidatesADtoArrayResult;
+
+    [Test]
+    procedure Title_FallsBackToTheName;
+
+    [Test]
+    procedure MarkReadOnly_PublishesTheHints;
+
+    [Test]
+    procedure ThroughTheManager_LogsNoOutputSchemaMismatch;
+
+    [Test]
+    procedure ThroughTheManager_ReportsAnEnvelopeWithoutItsOutputSchema;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.Classes,
+  MCPServer.Logger,
+  MCPServer.Schema.Validator,
+  MCPServer.ToolsManager;
+
+const
+  MISMATCH_WARNING = 'structuredContent does not match its outputSchema';
+
+{ TCountedFilter }
+
+destructor TCountedFilter.Destroy;
+begin
+  Inc(DestroyCount);
+  inherited;
+end;
+
+{ TCountedLine }
+
+destructor TCountedLine.Destroy;
+begin
+  Inc(DestroyCount);
+  inherited;
+end;
+
+{ TSampleTarget }
+
+procedure TSampleTarget.Ping;
+begin
+  FSeen := 'ping';
+end;
+
+procedure TSampleTarget.Remember(const Note: string);
+begin
+  FSeen := Note;
+end;
+
+function TSampleTarget.Add(const Left, Right: Integer): Integer;
+begin
+  Result := Left + Right;
+end;
+
+function TSampleTarget.Greet(const Person: string): string;
+begin
+  Result := 'Hello, ' + Person;
+end;
+
+function TSampleTarget.Describe(const Filter: TCountedFilter): string;
+begin
+  Result := Format('%s/%d', [Filter.Customer, Filter.Limit]);
+end;
+
+function TSampleTarget.JoinSkus(const Skus: TArray<string>): string;
+begin
+  Result := string.Join('|', Skus);
+end;
+
+function TSampleTarget.CountLines(const Lines: TArray<TCountedLine>): Integer;
+begin
+  Result := 0;
+  for var Line in Lines do
+    Inc(Result, Line.Quantity);
+end;
+
+function TSampleTarget.MakeLine: TCountedLine;
+begin
+  Result := TCountedLine.Create;
+  Result.Sku := 'SKU-1';
+  Result.Quantity := 3;
+end;
+
+function TSampleTarget.MakeLines: TArray<TCountedLine>;
+const
+  LineCount = 2;
+begin
+  SetLength(Result, LineCount);
+  for var Index: Integer := 0 to LineCount - 1 do
+  begin
+    Result[Index] := TCountedLine.Create;
+    Result[Index].Sku := 'SKU-' + (Index + 1).ToString;
+    Result[Index].Quantity := Index + 1;
+  end;
+end;
+
+function TSampleTarget.Tagged(const Tag: string): string;
+begin
+  Result := '#' + Tag;
+end;
+
+function TSampleTarget.WithOptional(const Base: string; const Suffix: string): string;
+begin
+  Result := Base + Suffix;
+end;
+
+function TSampleTarget.Keep(const Filter: TCountedFilter): string;
+begin
+  FKept.Free;
+  FKept := Filter;
+  Result := Filter.Customer;
+end;
+
+destructor TSampleTarget.Destroy;
+begin
+  FKept.Free;
+  inherited;
+end;
+
+{ TEnvelopeTool }
+
+function TEnvelopeTool.ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue;
+begin
+  const Envelope = TJSONObject.Create;
+  Envelope.AddPair('columns', TJSONArray.Create.Add('total'));
+  Envelope.AddPair('rows', TJSONArray.Create.Add(Value.AsInteger));
+  Result := Envelope;
+end;
+
+function TEnvelopeTool.GetOutputSchema: TJSONObject;
+begin
+  Result := nil;
+end;
+
+{ TMismatchedTool }
+
+function TMismatchedTool.ResultToJson(const Value: TValue; const ResultType: TRttiType): TJSONValue;
+begin
+  const Envelope = TJSONObject.Create;
+  Envelope.AddPair('columns', TJSONArray.Create.Add('total'));
+  Result := Envelope;
+end;
+
+{ TAdoptingTool }
+
+procedure TAdoptingTool.ReleaseArguments(const Owned: TList<TObject>);
+begin
+end;
+
+{ TKeepingTool }
+
+procedure TKeepingTool.ReleaseResult(const Value: TValue; const ResultType: TRttiType);
+begin
+  if Value.IsObject then
+    Kept := Value.AsObject;
+end;
+
+{ TMethodToolTests }
+
+procedure TMethodToolTests.Setup;
+begin
+  FContext := TRttiContext.Create;
+  FTarget := TSampleTarget.Create;
+  TCountedFilter.DestroyCount := 0;
+  TCountedLine.DestroyCount := 0;
+end;
+
+procedure TMethodToolTests.TearDown;
+begin
+  FTarget.Free;
+  FContext.Free;
+end;
+
+function TMethodToolTests.MethodOf(const MethodName: string): TRttiMethod;
+begin
+  Result := FContext.GetType(TSampleTarget).GetMethod(MethodName);
+  Assert.IsNotNull(Result, 'TSampleTarget.' + MethodName + ' has no method RTTI');
+end;
+
+function TMethodToolTests.ToolFor(const MethodName: string): IMCPTool;
+begin
+  Result := TMCPMethodTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf(MethodName),
+    'sample_' + LowerCase(MethodName), 'The ' + MethodName + ' sample');
+end;
+
+function TMethodToolTests.Run(const Tool: IMCPTool; const ArgumentsJson: string): TJSONObject;
+begin
+  const Arguments = TJSONObject.ParseJSONValue(ArgumentsJson) as TJSONObject;
+  try
+    Result := Tool.Execute(Arguments).AsType<TJSONObject>;
+  finally
+    Arguments.Free;
+  end;
+end;
+
+procedure TMethodToolTests.Procedure_ReturnsOk;
+begin
+  const Json = Run(ToolFor('Ping'), '{}');
+  try
+    Assert.IsTrue(Json.GetValue<Boolean>('ok'), 'a procedure reports {"ok": true}');
+    Assert.AreEqual(1, Json.Count, 'nothing else is in the envelope');
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.Procedure_PassesItsArgument;
+begin
+  Run(ToolFor('Remember'), '{"note":"written down"}').Free;
+
+  Assert.AreEqual('written down', FTarget.Seen);
+end;
+
+procedure TMethodToolTests.Function_ReturnsTheResultMember;
+begin
+  const Json = Run(ToolFor('Add'), '{"left":2,"right":40}');
+  try
+    Assert.AreEqual(42, Json.GetValue<Integer>('result'));
+    Assert.AreEqual(1, Json.Count, 'the default envelope carries only the result');
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.StringFunction_ReturnsAStringResult;
+begin
+  const Json = Run(ToolFor('Greet'), '{"person":"Ada"}');
+  try
+    Assert.AreEqual('Hello, Ada', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.DtoParameter_IsMarshalledAndFreed;
+begin
+  const Json = Run(ToolFor('Describe'), '{"filter":{"customer":"ALFKI","limit":5}}');
+  try
+    Assert.AreEqual('ALFKI/5', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+
+  Assert.AreEqual(1, TCountedFilter.DestroyCount, 'the marshalled DTO is freed exactly once');
+end;
+
+procedure TMethodToolTests.ArrayParameter_IsMarshalled;
+begin
+  const Json = Run(ToolFor('JoinSkus'), '{"skus":["a","b","c"]}');
+  try
+    Assert.AreEqual('a|b|c', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.ObjectArrayParameter_IsMarshalledAndEveryElementFreed;
+begin
+  const Json = Run(ToolFor('CountLines'),
+    '{"lines":[{"sku":"a","quantity":2},{"sku":"b","quantity":5}]}');
+  try
+    Assert.AreEqual(7, Json.GetValue<Integer>('result'));
+  finally
+    Json.Free;
+  end;
+
+  Assert.AreEqual(2, TCountedLine.DestroyCount, 'every marshalled element is freed');
+end;
+
+procedure TMethodToolTests.MissingRequiredArgument_RaisesArgumentException;
+begin
+  var Tool := ToolFor('Add');
+  Assert.WillRaise(
+    procedure
+    begin
+      Run(Tool, '{"left":1}').Free;
+    end,
+    EArgumentException);
+end;
+
+procedure TMethodToolTests.WrongArgumentType_RaisesArgumentException;
+begin
+  var Tool := ToolFor('Add');
+  Assert.WillRaise(
+    procedure
+    begin
+      Run(Tool, '{"left":"two","right":40}').Free;
+    end,
+    EArgumentException);
+end;
+
+procedure TMethodToolTests.UnknownArgument_RaisesArgumentException;
+begin
+  var Tool := ToolFor('Add');
+  Assert.WillRaise(
+    procedure
+    begin
+      Run(Tool, '{"left":1,"right":2,"sideways":3}').Free;
+    end,
+    EArgumentException);
+end;
+
+procedure TMethodToolTests.OptionalArgument_MayBeOmitted;
+begin
+  const Tool = ToolFor('WithOptional');
+
+  var Json := Run(Tool, '{"base":"core"}');
+  try
+    Assert.AreEqual('core', Json.GetValue<string>('result'), 'an omitted parameter is its default');
+  finally
+    Json.Free;
+  end;
+
+  Json := Run(Tool, '{"base":"core","suffix":"-plus"}');
+  try
+    Assert.AreEqual('core-plus', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.SchemaName_IsAlsoTheArgumentName;
+begin
+  const Tool = ToolFor('Tagged');
+
+  const Schema = Tool.GetInputSchema;
+  try
+    const Properties = Schema.GetValue('properties') as TJSONObject;
+    Assert.IsNotNull(Properties.GetValue('colour_tag'), 'the schema uses the [SchemaName]');
+    Assert.IsNull(Properties.GetValue('tag'), 'and not the lower-cased parameter name');
+  finally
+    Schema.Free;
+  end;
+
+  const Json = Run(Tool, '{"colour_tag":"amber"}');
+  try
+    Assert.AreEqual('#amber', Json.GetValue<string>('result'), 'the marshal reads the same name');
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.OverriddenResultToJson_ReplacesTheWholeObject;
+begin
+  const Tool: IMCPTool = TEnvelopeTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf('Add'),
+    'sample_envelope', 'An envelope tool');
+
+  const Json = Run(Tool, '{"left":1,"right":2}');
+  try
+    Assert.IsNull(Json.GetValue('result'), 'the override is not nested under "result"');
+    Assert.AreEqual('total', (Json.GetValue('columns') as TJSONArray).Items[0].Value);
+    Assert.AreEqual(3, ((Json.GetValue('rows') as TJSONArray).Items[0] as TJSONNumber).AsInt);
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.ReturnedObject_IsFreedExactlyOnce;
+begin
+  const Json = Run(ToolFor('MakeLine'), '{}');
+  try
+    const Line = Json.GetValue('result') as TJSONObject;
+    Assert.AreEqual('SKU-1', Line.GetValue<string>('sku'));
+    Assert.AreEqual(3, Line.GetValue<Integer>('quantity'));
+  finally
+    Json.Free;
+  end;
+
+  Assert.AreEqual(1, TCountedLine.DestroyCount, 'the returned object is freed exactly once');
+end;
+
+procedure TMethodToolTests.ReturnedObjectArray_IsFreedElementByElement;
+begin
+  const Json = Run(ToolFor('MakeLines'), '{}');
+  try
+    Assert.AreEqual(2, (Json.GetValue('result') as TJSONArray).Count);
+  finally
+    Json.Free;
+  end;
+
+  Assert.AreEqual(2, TCountedLine.DestroyCount, 'every returned element is freed exactly once');
+end;
+
+procedure TMethodToolTests.OverriddenReleaseResult_KeepsTheReturnedObject;
+begin
+  var Keeper := TKeepingTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf('MakeLine'),
+    'sample_keeping', 'A tool that keeps its result');
+  const Tool: IMCPTool = Keeper;
+
+  Run(Tool, '{}').Free;
+
+  Assert.AreEqual(0, TCountedLine.DestroyCount, 'the override frees nothing');
+  Assert.IsNotNull(Keeper.Kept, 'and sees the object the method returned');
+
+  Keeper.Kept.Free;
+  Assert.AreEqual(1, TCountedLine.DestroyCount);
+end;
+
+procedure TMethodToolTests.OverriddenReleaseArguments_LeavesTheArgumentToTheMethod;
+begin
+  const Tool: IMCPTool = TAdoptingTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf('Keep'),
+    'sample_adopting', 'A tool whose method keeps what it is handed');
+
+  const Json = Run(Tool, '{"filter":{"customer":"ALFKI","limit":5}}');
+  try
+    Assert.AreEqual('ALFKI', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+
+  Assert.AreEqual(0, TCountedFilter.DestroyCount, 'the tool freed an argument its method kept');
+  Assert.IsNotNull(FTarget.Kept, 'the method was handed nothing to keep');
+  Assert.AreEqual('ALFKI', FTarget.Kept.Customer, 'the kept argument was freed underneath the method');
+end;
+
+procedure TMethodToolTests.GetInputSchema_ReturnsAFreshInstanceEveryCall;
+begin
+  const Tool = ToolFor('Add');
+
+  const First = Tool.GetInputSchema;
+  const Second = Tool.GetInputSchema;
+  try
+    Assert.IsFalse(First = Second, 'the caller owns each schema, so each call builds one');
+    Assert.AreEqual(First.ToJSON, Second.ToJSON);
+  finally
+    First.Free;
+    Second.Free;
+  end;
+end;
+
+procedure TMethodToolTests.FreeingAnInputSchema_LeavesTheToolUsable;
+begin
+  const Tool = ToolFor('Add');
+
+  Tool.GetInputSchema.Free;
+
+  const Json = Run(Tool, '{"left":1,"right":1}');
+  try
+    Assert.AreEqual(2, Json.GetValue<Integer>('result'), 'validation still has its own schema');
+  finally
+    Json.Free;
+  end;
+
+  Tool.GetInputSchema.Free;
+end;
+
+procedure TMethodToolTests.GetOutputSchema_ReturnsAFreshInstanceEveryCall;
+begin
+  const Tool = ToolFor('Add');
+
+  const First = Tool.GetOutputSchema;
+  const Second = Tool.GetOutputSchema;
+  try
+    Assert.IsFalse(First = Second, 'the tools manager frees what GetOutputSchema hands it');
+    Assert.AreEqual(First.ToJSON, Second.ToJSON);
+  finally
+    First.Free;
+    Second.Free;
+  end;
+end;
+
+procedure TMethodToolTests.Procedure_HasNoOutputSchema;
+begin
+  Assert.IsNull(ToolFor('Ping').GetOutputSchema, 'a procedure describes no structured result');
+end;
+
+procedure TMethodToolTests.OutputSchema_ValidatesTheDefaultFunctionResult;
+begin
+  const Tool = ToolFor('Add');
+
+  const Schema = Tool.GetOutputSchema;
+  try
+    const Json = Run(Tool, '{"left":2,"right":3}');
+    try
+      var Errors: TArray<string>;
+      Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Json, Errors),
+        string.Join('; ', Errors));
+    finally
+      Json.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TMethodToolTests.OutputSchema_ValidatesADtoArrayResult;
+begin
+  const Tool = ToolFor('MakeLines');
+
+  const Schema = Tool.GetOutputSchema;
+  try
+    const Json = Run(Tool, '{}');
+    try
+      var Errors: TArray<string>;
+      Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Json, Errors),
+        string.Join('; ', Errors));
+    finally
+      Json.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TMethodToolTests.Title_FallsBackToTheName;
+begin
+  const Tool = ToolFor('Ping');
+
+  Assert.AreEqual('sample_ping', Tool.GetName);
+  Assert.AreEqual('sample_ping', Tool.GetTitle);
+  Assert.AreEqual('The Ping sample', Tool.GetDescription);
+end;
+
+procedure TMethodToolTests.MarkReadOnly_PublishesTheHints;
+begin
+  const Tool = TMCPMethodTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf('Add'), 'sample_readonly',
+    'A read-only tool');
+  const AsInterface: IMCPTool = Tool;
+
+  var Metadata: IMCPToolMetadata;
+  Assert.IsTrue(Supports(AsInterface, IMCPToolMetadata, Metadata));
+  Assert.IsNull(Metadata.Annotations, 'nothing is published before MarkReadOnly');
+
+  Tool.MarkReadOnly;
+
+  Assert.IsTrue(Metadata.Annotations.GetValue<Boolean>('readOnlyHint'));
+  Assert.IsFalse(Metadata.Annotations.GetValue<Boolean>('openWorldHint'));
+end;
+
+procedure TMethodToolTests.ThroughTheManager_LogsNoOutputSchemaMismatch;
+const
+  CALLS: array [0 .. 2] of string = (
+    '{"name":"sample_add","arguments":{"left":1,"right":2}}',
+    '{"name":"sample_makelines","arguments":{}}',
+    '{"name":"sample_ping","arguments":{}}');
+begin
+  const Warnings = TStringList.Create;
+  const Manager: IMCPCapabilityManager = TMCPToolsManager.Create;
+  const Tools = Manager as TMCPToolsManager;
+  const OriginalLevel = TLogger.MinLogLevel;
+  try
+    Tools.AddTool(ToolFor('Add'));
+    Tools.AddTool(ToolFor('MakeLines'));
+    Tools.AddTool(ToolFor('Ping'));
+
+    TLogger.MinLogLevel := TLogLevel.Debug;
+    TLogger.OnLogMessage :=
+      procedure(const Message: string)
+      begin
+        if Message.Contains(MISMATCH_WARNING) then
+          Warnings.Add(Message);
+      end;
+
+    for var Call in CALLS do
+    begin
+      const Params = TJSONObject.ParseJSONValue(Call) as TJSONObject;
+      try
+        Tools.CallTool(Params, TMCPProtocolEra.Modern).AsType<TJSONObject>.Free;
+      finally
+        Params.Free;
+      end;
+    end;
+
+    Assert.AreEqual(0, Warnings.Count, string.Join('; ', Warnings.ToStringArray));
+  finally
+    TLogger.OnLogMessage := nil;
+    TLogger.MinLogLevel := OriginalLevel;
+    Warnings.Free;
+  end;
+end;
+
+procedure TMethodToolTests.ThroughTheManager_ReportsAnEnvelopeWithoutItsOutputSchema;
+begin
+  const Warnings = TStringList.Create;
+  const Manager: IMCPCapabilityManager = TMCPToolsManager.Create;
+  const Tools = Manager as TMCPToolsManager;
+  const OriginalLevel = TLogger.MinLogLevel;
+  try
+    Tools.AddTool(TMismatchedTool.Create(TValue.From<TSampleTarget>(FTarget), MethodOf('Add'),
+      'sample_mismatch', 'An envelope that forgot its output schema'));
+
+    TLogger.MinLogLevel := TLogLevel.Debug;
+    TLogger.OnLogMessage :=
+      procedure(const Message: string)
+      begin
+        if Message.Contains(MISMATCH_WARNING) then
+          Warnings.Add(Message);
+      end;
+
+    const Params = TJSONObject.ParseJSONValue(
+      '{"name":"sample_mismatch","arguments":{"left":1,"right":2}}') as TJSONObject;
+    try
+      Tools.CallTool(Params, TMCPProtocolEra.Modern).AsType<TJSONObject>.Free;
+    finally
+      Params.Free;
+    end;
+
+    {$IFDEF DEBUG}
+    Assert.AreEqual(1, Warnings.Count, 'a DEBUG build reports the mismatch, so the quiet test above means something');
+    {$ELSE}
+    Assert.AreEqual(0, Warnings.Count, 'only a DEBUG build validates structuredContent');
+    {$ENDIF}
+  finally
+    TLogger.OnLogMessage := nil;
+    TLogger.MinLogLevel := OriginalLevel;
+    Warnings.Free;
+  end;
+end;
+
+end.

--- a/tests/MCPServer.Tests.SchemaFromMethod.pas
+++ b/tests/MCPServer.Tests.SchemaFromMethod.pas
@@ -1,0 +1,637 @@
+unit MCPServer.Tests.SchemaFromMethod;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Rtti,
+  System.JSON,
+  System.Generics.Collections,
+  MCPServer.Types;
+
+type
+  TShipMode = (Standard, Express);
+
+  TMoney = record
+    Amount: Double;
+  end;
+
+  TOrderLine = class
+  private
+    FSku: string;
+    FQuantity: Integer;
+  public
+    property Sku: string read FSku write FSku;
+    property Quantity: Integer read FQuantity write FQuantity;
+  end;
+
+  [SchemaDialect('https://json-schema.org/draft/2020-12/schema')]
+  TDialectFilter = class
+  private
+    FName: string;
+  public
+    property Name: string read FName write FName;
+  end;
+
+  TOrderFilter = class
+  private
+    FCustomer: string;
+    FLimit: Integer;
+  public
+    [SchemaDescription('Customer code')]
+    property Customer: string read FCustomer write FCustomer;
+    [Optional]
+    property Limit: Integer read FLimit write FLimit;
+  end;
+
+  TSampleService = class
+  public
+    procedure NoParameters;
+    procedure Primitives(const Name: string; const Count: Integer; const Ratio: Double;
+      const Flag: Boolean);
+    procedure Scheduled(const When: TDateTime; const Mode: TShipMode);
+    procedure WithFilter(const Filter: TOrderFilter);
+    procedure WithSkus(const Skus: TArray<string>);
+    procedure WithLines(const Lines: TArray<TOrderLine>);
+    procedure WithLineList(const Lines: TList<TOrderLine>);
+    procedure WithOptionalLimit(const Customer: string; [Optional] const Limit: Integer);
+    procedure Annotated(
+      [SchemaDescription('How many')] [SchemaMinimum(1)] [SchemaMaximum(10)] const Count: Integer;
+      [SchemaName('colour_tag')] [SchemaPattern('^[a-z]+$')] const Tag: string);
+    procedure MixedCase(const CustomerCode: string);
+    procedure Untyped(var Anything);
+    procedure OutParameter(out Total: Integer);
+    procedure VarParameter(var Total: Integer);
+    procedure WithDialect(const Filter: TDialectFilter);
+    function CountOrders: Integer;
+    function DescribeOrder: string;
+    function FindLine: TOrderLine;
+    function FindLines: TArray<TOrderLine>;
+    function Total: TMoney;
+    function MakeDialect: TDialectFilter;
+  end;
+
+  [TestFixture]
+  TSchemaFromMethodTests = class
+  private
+    FContext: TRttiContext;
+    function MethodOf(const MethodName: string): TRttiMethod;
+    function SchemaOf(const MethodName: string): TJSONObject;
+    function ResultSchemaOf(const MethodName: string): TJSONObject;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure NoParameters_GivesAnEmptyObjectSchema;
+
+    [Test]
+    procedure Primitives_MapToJsonTypes;
+
+    [Test]
+    procedure DateTime_IsStringWithFormat;
+
+    [Test]
+    procedure Enumeration_IsStringWithItsNames;
+
+    [Test]
+    procedure ClassParameter_DelegatesToGenerateSchema;
+
+    [Test]
+    procedure ArrayParameter_IsArrayWithItems;
+
+    [Test]
+    procedure ClassArrayParameter_ItemsAreTheDtoSchema;
+
+    [Test]
+    procedure ListParameter_IsArrayWithItems;
+
+    [Test]
+    procedure Optional_KeepsAParameterOutOfRequired;
+
+    [Test]
+    procedure EveryOtherParameter_IsRequiredInDeclarationOrder;
+
+    [Test]
+    procedure SchemaName_OverridesTheWireName;
+
+    [Test]
+    procedure WireName_IsTheLowerCasedParameterName;
+
+    [Test]
+    procedure ParameterAttributes_AreApplied;
+
+    [Test]
+    procedure MethodSchema_ForbidsAdditionalProperties;
+
+    [Test]
+    procedure UntypedParameter_IsRejected;
+
+    [Test]
+    procedure OutParameter_IsRejected_NamingTheParameter;
+
+    [Test]
+    procedure VarParameter_IsRejected_NamingTheParameter;
+
+    [Test]
+    procedure Dialect_IsNotCopiedIntoAParameterSchema;
+
+    [Test]
+    procedure Dialect_IsNotCopiedIntoAResultSchema;
+
+    [Test]
+    procedure Dialect_StaysOnTheSchemaOfTheClassItself;
+
+    [Test]
+    procedure Procedure_HasNoResultSchema;
+
+    [Test]
+    procedure IntegerResult_IsWrappedInRequiredResult;
+
+    [Test]
+    procedure StringResult_IsAString;
+
+    [Test]
+    procedure ClassResult_IsTheDtoSchema;
+
+    [Test]
+    procedure ClassArrayResult_IsAnArrayOfTheDtoSchema;
+
+    [Test]
+    procedure RecordResult_HasNoResultSchema;
+
+    [Test]
+    procedure SchemaFromType_DescribesAPrimitiveAnArrayAndAClass;
+
+    [Test]
+    procedure SchemaFromType_GivesNilForNoType;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  MCPServer.Schema.Generator;
+
+{ TSampleService }
+
+procedure TSampleService.NoParameters;
+begin
+end;
+
+procedure TSampleService.Primitives(const Name: string; const Count: Integer; const Ratio: Double;
+  const Flag: Boolean);
+begin
+end;
+
+procedure TSampleService.Scheduled(const When: TDateTime; const Mode: TShipMode);
+begin
+end;
+
+procedure TSampleService.WithFilter(const Filter: TOrderFilter);
+begin
+end;
+
+procedure TSampleService.WithSkus(const Skus: TArray<string>);
+begin
+end;
+
+procedure TSampleService.WithLines(const Lines: TArray<TOrderLine>);
+begin
+end;
+
+procedure TSampleService.WithLineList(const Lines: TList<TOrderLine>);
+begin
+end;
+
+procedure TSampleService.WithOptionalLimit(const Customer: string; const Limit: Integer);
+begin
+end;
+
+procedure TSampleService.Annotated(const Count: Integer; const Tag: string);
+begin
+end;
+
+procedure TSampleService.MixedCase(const CustomerCode: string);
+begin
+end;
+
+procedure TSampleService.Untyped(var Anything);
+begin
+end;
+
+procedure TSampleService.OutParameter(out Total: Integer);
+begin
+  Total := 0;
+end;
+
+procedure TSampleService.VarParameter(var Total: Integer);
+begin
+  Total := 0;
+end;
+
+procedure TSampleService.WithDialect(const Filter: TDialectFilter);
+begin
+end;
+
+function TSampleService.CountOrders: Integer;
+begin
+  Result := 0;
+end;
+
+function TSampleService.DescribeOrder: string;
+begin
+  Result := '';
+end;
+
+function TSampleService.FindLine: TOrderLine;
+begin
+  Result := nil;
+end;
+
+function TSampleService.FindLines: TArray<TOrderLine>;
+begin
+  Result := nil;
+end;
+
+function TSampleService.Total: TMoney;
+begin
+  Result := Default(TMoney);
+end;
+
+function TSampleService.MakeDialect: TDialectFilter;
+begin
+  Result := nil;
+end;
+
+{ TSchemaFromMethodTests }
+
+procedure TSchemaFromMethodTests.Setup;
+begin
+  FContext := TRttiContext.Create;
+end;
+
+procedure TSchemaFromMethodTests.TearDown;
+begin
+  FContext.Free;
+end;
+
+function TSchemaFromMethodTests.MethodOf(const MethodName: string): TRttiMethod;
+begin
+  Result := FContext.GetType(TSampleService).GetMethod(MethodName);
+  Assert.IsNotNull(Result, 'TSampleService.' + MethodName + ' has no method RTTI');
+end;
+
+function TSchemaFromMethodTests.SchemaOf(const MethodName: string): TJSONObject;
+begin
+  Result := TMCPSchemaGenerator.GenerateSchemaFromMethod(MethodOf(MethodName));
+end;
+
+function TSchemaFromMethodTests.ResultSchemaOf(const MethodName: string): TJSONObject;
+begin
+  Result := TMCPSchemaGenerator.GenerateSchemaFromMethodResult(MethodOf(MethodName));
+end;
+
+procedure TSchemaFromMethodTests.NoParameters_GivesAnEmptyObjectSchema;
+begin
+  var Schema := SchemaOf('NoParameters');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('type'));
+    Assert.AreEqual(0, (Schema.GetValue('properties') as TJSONObject).Count);
+    Assert.IsNull(Schema.GetValue('required'));
+    Assert.IsFalse(Schema.GetValue<Boolean>('additionalProperties'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Primitives_MapToJsonTypes;
+begin
+  var Schema := SchemaOf('Primitives');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.name.type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.count.type'));
+    Assert.AreEqual('number', Schema.GetValue<string>('properties.ratio.type'));
+    Assert.AreEqual('boolean', Schema.GetValue<string>('properties.flag.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.DateTime_IsStringWithFormat;
+begin
+  var Schema := SchemaOf('Scheduled');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.when.type'));
+    Assert.AreEqual('date-time', Schema.GetValue<string>('properties.when.format'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Enumeration_IsStringWithItsNames;
+begin
+  var Schema := SchemaOf('Scheduled');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.mode.type'));
+    Assert.AreEqual('Standard', Schema.GetValue<string>('properties.mode.enum[0]'));
+    Assert.AreEqual('Express', Schema.GetValue<string>('properties.mode.enum[1]'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ClassParameter_DelegatesToGenerateSchema;
+begin
+  var Schema := SchemaOf('WithFilter');
+  try
+    var Expected := TMCPSchemaGenerator.GenerateSchema(TOrderFilter);
+    try
+      Assert.AreEqual(Expected.ToJSON, (Schema.FindValue('properties.filter') as TJSONObject).ToJSON);
+    finally
+      Expected.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ArrayParameter_IsArrayWithItems;
+begin
+  var Schema := SchemaOf('WithSkus');
+  try
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.skus.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.skus.items.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ClassArrayParameter_ItemsAreTheDtoSchema;
+begin
+  var Schema := SchemaOf('WithLines');
+  try
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.lines.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.lines.items.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.lines.items.properties.sku.type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.lines.items.properties.quantity.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ListParameter_IsArrayWithItems;
+begin
+  var Schema := SchemaOf('WithLineList');
+  try
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.lines.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.lines.items.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.lines.items.properties.sku.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Optional_KeepsAParameterOutOfRequired;
+begin
+  var Schema := SchemaOf('WithOptionalLimit');
+  try
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.limit.type'));
+
+    var Required := Schema.GetValue('required') as TJSONArray;
+    Assert.AreEqual(1, Required.Count);
+    Assert.AreEqual('customer', Required.Items[0].Value);
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.EveryOtherParameter_IsRequiredInDeclarationOrder;
+begin
+  var Schema := SchemaOf('Primitives');
+  try
+    var Required := Schema.GetValue('required') as TJSONArray;
+    Assert.AreEqual(4, Required.Count);
+    Assert.AreEqual('name', Required.Items[0].Value);
+    Assert.AreEqual('count', Required.Items[1].Value);
+    Assert.AreEqual('ratio', Required.Items[2].Value);
+    Assert.AreEqual('flag', Required.Items[3].Value);
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.SchemaName_OverridesTheWireName;
+begin
+  var Schema := SchemaOf('Annotated');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.colour_tag.type'));
+    Assert.IsNull(Schema.GetValue('properties.tag'));
+
+    var Required := Schema.GetValue('required') as TJSONArray;
+    Assert.AreEqual('colour_tag', Required.Items[1].Value);
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.WireName_IsTheLowerCasedParameterName;
+begin
+  var Schema := SchemaOf('MixedCase');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.customercode.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ParameterAttributes_AreApplied;
+begin
+  var Schema := SchemaOf('Annotated');
+  try
+    Assert.AreEqual('How many', Schema.GetValue<string>('properties.count.description'));
+    Assert.AreEqual(1, Schema.GetValue<Integer>('properties.count.minimum'));
+    Assert.AreEqual(10, Schema.GetValue<Integer>('properties.count.maximum'));
+    Assert.AreEqual('^[a-z]+$', Schema.GetValue<string>('properties.colour_tag.pattern'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.MethodSchema_ForbidsAdditionalProperties;
+begin
+  var Schema := SchemaOf('Primitives');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('type'));
+    Assert.IsFalse(Schema.GetValue<Boolean>('additionalProperties'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.UntypedParameter_IsRejected;
+begin
+  const Method = MethodOf('Untyped');
+  Assert.WillRaise(
+    procedure
+    begin
+      TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    end,
+    EArgumentException);
+end;
+
+procedure TSchemaFromMethodTests.Procedure_HasNoResultSchema;
+begin
+  Assert.IsNull(ResultSchemaOf('NoParameters'));
+end;
+
+procedure TSchemaFromMethodTests.IntegerResult_IsWrappedInRequiredResult;
+begin
+  var Schema := ResultSchemaOf('CountOrders');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.result.type'));
+
+    var Required := Schema.GetValue('required') as TJSONArray;
+    Assert.AreEqual(1, Required.Count);
+    Assert.AreEqual('result', Required.Items[0].Value);
+    Assert.IsFalse(Schema.GetValue<Boolean>('additionalProperties'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.StringResult_IsAString;
+begin
+  var Schema := ResultSchemaOf('DescribeOrder');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.result.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ClassResult_IsTheDtoSchema;
+begin
+  var Schema := ResultSchemaOf('FindLine');
+  try
+    var Expected := TMCPSchemaGenerator.GenerateSchema(TOrderLine);
+    try
+      Assert.AreEqual(Expected.ToJSON, (Schema.FindValue('properties.result') as TJSONObject).ToJSON);
+    finally
+      Expected.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ClassArrayResult_IsAnArrayOfTheDtoSchema;
+begin
+  var Schema := ResultSchemaOf('FindLines');
+  try
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.result.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.result.items.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.result.items.properties.sku.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordResult_HasNoResultSchema;
+begin
+  Assert.IsNull(ResultSchemaOf('Total'));
+end;
+
+procedure TSchemaFromMethodTests.SchemaFromType_DescribesAPrimitiveAnArrayAndAClass;
+begin
+  const Method = MethodOf('WithLines');
+  const Parameters = Method.GetParameters;
+
+  var ArraySchema := TMCPSchemaGenerator.GenerateSchemaFromType(Parameters[0].ParamType);
+  try
+    Assert.AreEqual('array', ArraySchema.GetValue<string>('type'));
+  finally
+    ArraySchema.Free;
+  end;
+
+  var IntegerSchema := TMCPSchemaGenerator.GenerateSchemaFromType(MethodOf('CountOrders').ReturnType);
+  try
+    Assert.AreEqual('integer', IntegerSchema.GetValue<string>('type'));
+  finally
+    IntegerSchema.Free;
+  end;
+
+  var DtoSchema := TMCPSchemaGenerator.GenerateSchemaFromType(MethodOf('FindLine').ReturnType);
+  try
+    Assert.AreEqual('object', DtoSchema.GetValue<string>('type'));
+    Assert.AreEqual('integer', DtoSchema.GetValue<string>('properties.quantity.type'));
+  finally
+    DtoSchema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.SchemaFromType_GivesNilForNoType;
+begin
+  Assert.IsNull(TMCPSchemaGenerator.GenerateSchemaFromType(nil));
+end;
+
+procedure TSchemaFromMethodTests.OutParameter_IsRejected_NamingTheParameter;
+begin
+  const Method = MethodOf('OutParameter');
+  try
+    TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    Assert.Fail('an out parameter is published as an input and its value is dropped, so it must be refused');
+  except
+    on E: EArgumentException do
+      Assert.IsTrue(E.Message.Contains('Total'), 'the refusal does not name the parameter: ' + E.Message);
+  end;
+end;
+
+procedure TSchemaFromMethodTests.VarParameter_IsRejected_NamingTheParameter;
+begin
+  const Method = MethodOf('VarParameter');
+  try
+    TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    Assert.Fail('a var parameter is published as an input and its value is dropped, so it must be refused');
+  except
+    on E: EArgumentException do
+      Assert.IsTrue(E.Message.Contains('Total'), 'the refusal does not name the parameter: ' + E.Message);
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Dialect_IsNotCopiedIntoAParameterSchema;
+begin
+  var Schema := SchemaOf('WithDialect');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.filter.type'));
+    Assert.IsNull(Schema.FindValue('properties.filter.$schema'), '$schema is a root-only keyword');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Dialect_IsNotCopiedIntoAResultSchema;
+begin
+  var Schema := ResultSchemaOf('MakeDialect');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.result.type'));
+    Assert.IsNull(Schema.FindValue('properties.result.$schema'), '$schema is a root-only keyword');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.Dialect_StaysOnTheSchemaOfTheClassItself;
+begin
+  var Schema := TMCPSchemaGenerator.GenerateSchema(TDialectFilter);
+  try
+    Assert.AreEqual('https://json-schema.org/draft/2020-12/schema', Schema.GetValue<string>('$schema'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+end.

--- a/tests/MCPServer.Tests.Settings.pas
+++ b/tests/MCPServer.Tests.Settings.pas
@@ -1,0 +1,338 @@
+unit MCPServer.Tests.Settings;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TMCPSettingsTest = class
+  private
+    FDirectory: string;
+    function TempSettingsPath: string;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Create_WithoutFile_LoadsExpectedDefaults;
+
+    [Test]
+    procedure Create_WithoutFile_LoadsExpectedLimitDefaults;
+
+    [Test]
+    procedure Create_EmptyPathAndNoCreate_CreatesNoFile;
+
+    [Test]
+    procedure Create_MissingPathAndNoCreate_CreatesNoFile;
+
+    [Test]
+    procedure Create_MissingPathAndCreate_WritesDefaultsToFile;
+
+    [Test]
+    procedure Protocol_SslDisabled_ReturnsHttp;
+
+    [Test]
+    procedure Protocol_SslEnabled_ReturnsHttps;
+
+    [Test]
+    procedure SetProperties_ReadBack_ReturnsAssignedValues;
+
+    [Test]
+    procedure LoadFromFile_ExistingFile_OverridesDefaults;
+
+    [Test]
+    procedure SaveToFile_ReloadedByNewInstance_RoundTripsValues;
+
+    [Test]
+    procedure AllowedOrigins_SecurityOriginsEmpty_FallsBackToCorsOrigins;
+
+    [Test]
+    procedure AllowedOrigins_SecurityOriginsSet_WinsOverCorsOrigins;
+
+    [Test]
+    procedure AllowedHostList_MixedSpacingAndBlanks_ReturnsTrimmedEntries;
+
+    [Test]
+    procedure BearerTokenList_EmptyValue_ReturnsEmptyArray;
+
+    [Test]
+    procedure ScopesSupportedList_TwoScopes_ReturnsBothScopes;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IniFiles,
+  System.IOUtils,
+  MCPServer.Settings;
+
+{ TMCPSettingsTest }
+
+procedure TMCPSettingsTest.Setup;
+begin
+  FDirectory := TPath.Combine(TPath.GetTempPath, 'mcp-settings-' + TGuid.NewGuid.ToString);
+  TDirectory.CreateDirectory(FDirectory);
+end;
+
+procedure TMCPSettingsTest.TearDown;
+begin
+  if TDirectory.Exists(FDirectory) then
+    TDirectory.Delete(FDirectory, True);
+end;
+
+function TMCPSettingsTest.TempSettingsPath: string;
+begin
+  Result := TPath.Combine(FDirectory, 'settings.ini');
+end;
+
+procedure TMCPSettingsTest.Create_WithoutFile_LoadsExpectedDefaults;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Assert.AreEqual<Integer>(3000, Settings.Port);
+    Assert.AreEqual('localhost', Settings.Host);
+    Assert.AreEqual('delphi-mcp-server', Settings.ServerName);
+    Assert.AreEqual('1.0.0', Settings.ServerVersion);
+    Assert.AreEqual('/mcp', Settings.Endpoint);
+    Assert.IsTrue(Settings.CorsEnabled);
+    Assert.IsFalse(Settings.SSLEnabled);
+    Assert.IsTrue(Settings.ExposeDiagnosticsResources);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Create_WithoutFile_LoadsExpectedLimitDefaults;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Assert.AreEqual<Integer>(TMCPSettings.DEFAULT_MAX_REQUEST_BODY_BYTES, Settings.MaxRequestBodyBytes);
+    Assert.AreEqual<Integer>(TMCPSettings.DEFAULT_MAX_JSON_DEPTH, Settings.MaxJsonDepth);
+    Assert.AreEqual<Integer>(TMCPSettings.DEFAULT_MAX_CONCURRENT_REQUESTS, Settings.MaxConcurrentRequests);
+    Assert.AreEqual<Integer>(TMCPSettings.DEFAULT_REQUEST_STATE_TTL_SECONDS, Settings.RequestStateTtlSeconds);
+    Assert.AreEqual<Integer>(0, Settings.MaxConnections);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Create_EmptyPathAndNoCreate_CreatesNoFile;
+begin
+  const ExpectedFile = TPath.Combine(ExtractFilePath(ParamStr(0)), 'settings.ini');
+  const ExistedBefore = TFile.Exists(ExpectedFile);
+
+  const Settings = TMCPSettings.Create('', False);
+  try
+    Assert.AreEqual(ExpectedFile, Settings.SettingsFile);
+    Assert.AreEqual(ExistedBefore, TFile.Exists(ExpectedFile),
+      'Create with an empty path and ACreateFile False must never write a settings file');
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Create_MissingPathAndNoCreate_CreatesNoFile;
+begin
+  const SettingsFile = TempSettingsPath;
+
+  const Settings = TMCPSettings.Create(SettingsFile, False);
+  try
+    Assert.AreEqual(SettingsFile, Settings.SettingsFile);
+    Assert.IsFalse(TFile.Exists(SettingsFile));
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Create_MissingPathAndCreate_WritesDefaultsToFile;
+begin
+  const SettingsFile = TempSettingsPath;
+
+  const Settings = TMCPSettings.Create(SettingsFile, True);
+  try
+    Assert.IsTrue(TFile.Exists(SettingsFile));
+  finally
+    Settings.Free;
+  end;
+
+  const IniFile = TIniFile.Create(SettingsFile);
+  try
+    Assert.AreEqual<Integer>(3000, IniFile.ReadInteger('Server', 'Port', 0));
+    Assert.AreEqual('localhost', IniFile.ReadString('Server', 'Host', ''));
+    Assert.IsFalse(IniFile.ReadBool('SSL', 'Enabled', True));
+  finally
+    IniFile.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Protocol_SslDisabled_ReturnsHttp;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Assert.IsFalse(Settings.SSLEnabled);
+
+    Assert.AreEqual('http', Settings.Protocol);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.Protocol_SslEnabled_ReturnsHttps;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.SSLEnabled := True;
+
+    Assert.AreEqual('https', Settings.Protocol);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.SetProperties_ReadBack_ReturnsAssignedValues;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.Port := 8080;
+    Settings.Host := '127.0.0.1';
+    Settings.ServerName := 'custom-server';
+    Settings.Endpoint := '/agent';
+
+    Assert.AreEqual<Integer>(8080, Settings.Port);
+    Assert.AreEqual('127.0.0.1', Settings.Host);
+    Assert.AreEqual('custom-server', Settings.ServerName);
+    Assert.AreEqual('/agent', Settings.Endpoint);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.LoadFromFile_ExistingFile_OverridesDefaults;
+begin
+  const SettingsFile = TempSettingsPath;
+
+  const IniFile = TIniFile.Create(SettingsFile);
+  try
+    IniFile.WriteInteger('Server', 'Port', 9123);
+    IniFile.WriteString('Server', 'Name', 'from-file');
+    IniFile.WriteBool('SSL', 'Enabled', True);
+    IniFile.WriteString('Security', 'AllowedHosts', 'localhost:9123');
+  finally
+    IniFile.Free;
+  end;
+
+  const Settings = TMCPSettings.Create(SettingsFile, False);
+  try
+    Assert.AreEqual<Integer>(9123, Settings.Port);
+    Assert.AreEqual('from-file', Settings.ServerName);
+    Assert.AreEqual('https', Settings.Protocol);
+    Assert.AreEqual('localhost:9123', Settings.AllowedHosts);
+    Assert.AreEqual('localhost', Settings.Host, 'A key absent from the file keeps its default');
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.SaveToFile_ReloadedByNewInstance_RoundTripsValues;
+begin
+  const SettingsFile = TempSettingsPath;
+
+  const Written = TMCPSettings.Create(SettingsFile, False);
+  try
+    Written.Port := 8123;
+    Written.ServerName := 'round-trip';
+    Written.BearerTokens := 'alpha,beta';
+    Written.MaxJsonDepth := 12;
+    Written.SaveToFile;
+  finally
+    Written.Free;
+  end;
+
+  const Reloaded = TMCPSettings.Create(SettingsFile, False);
+  try
+    Assert.AreEqual<Integer>(8123, Reloaded.Port);
+    Assert.AreEqual('round-trip', Reloaded.ServerName);
+    Assert.AreEqual('alpha,beta', Reloaded.BearerTokens);
+    Assert.AreEqual<Integer>(12, Reloaded.MaxJsonDepth);
+    Assert.AreEqual<NativeInt>(2, Length(Reloaded.BearerTokenList));
+  finally
+    Reloaded.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.AllowedOrigins_SecurityOriginsEmpty_FallsBackToCorsOrigins;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.CorsAllowedOrigins := 'http://localhost';
+    Settings.SecurityAllowedOrigins := '';
+
+    Assert.AreEqual('http://localhost', Settings.AllowedOrigins);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.AllowedOrigins_SecurityOriginsSet_WinsOverCorsOrigins;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.CorsAllowedOrigins := 'http://localhost';
+    Settings.SecurityAllowedOrigins := 'https://example.test';
+
+    Assert.AreEqual('https://example.test', Settings.AllowedOrigins);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.AllowedHostList_MixedSpacingAndBlanks_ReturnsTrimmedEntries;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.AllowedHosts := ' localhost:3000 , ,127.0.0.1:3000';
+
+    const Hosts = Settings.AllowedHostList;
+
+    Assert.AreEqual<NativeInt>(2, Length(Hosts));
+    Assert.AreEqual('localhost:3000', Hosts[0]);
+    Assert.AreEqual('127.0.0.1:3000', Hosts[1]);
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.BearerTokenList_EmptyValue_ReturnsEmptyArray;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Assert.AreEqual('', Settings.BearerTokens);
+
+    Assert.AreEqual<NativeInt>(0, Length(Settings.BearerTokenList));
+  finally
+    Settings.Free;
+  end;
+end;
+
+procedure TMCPSettingsTest.ScopesSupportedList_TwoScopes_ReturnsBothScopes;
+begin
+  const Settings = TMCPSettings.Create(TempSettingsPath, False);
+  try
+    Settings.ScopesSupported := 'mcp:read, mcp:write';
+
+    const Scopes = Settings.ScopesSupportedList;
+
+    Assert.AreEqual<NativeInt>(2, Length(Scopes));
+    Assert.AreEqual('mcp:read', Scopes[0]);
+    Assert.AreEqual('mcp:write', Scopes[1]);
+  finally
+    Settings.Free;
+  end;
+end;
+
+end.

--- a/tests/MCPServer.Tests.ToolsManager.pas
+++ b/tests/MCPServer.Tests.ToolsManager.pas
@@ -45,6 +45,14 @@ type
     constructor Create; override;
   end;
 
+  TProbeTool = class(TMCPToolBase)
+  protected
+    function BuildSchema: TJSONObject; override;
+    function DoExecute(const Arguments: TJSONObject): TValue; override;
+  public
+    constructor CreateNamed(const AName: string);
+  end;
+
   [TestFixture]
   TToolsManagerTests = class
   private
@@ -106,12 +114,49 @@ type
     procedure HandWrittenTool_WrongType_IsErrorResult;
   end;
 
+  [TestFixture]
+  TToolsManagerIsolationTests = class
+  private
+    function ToolNames(const Manager: TMCPToolsManager): TArray<string>;
+    function NewManagerWith(const SeedFromRegistry: Boolean; const ToolName: string): TMCPToolsManager;
+    function FirstRegisteredToolName: string;
+  public
+    [Test]
+    procedure Registry_HasAtLeastOneTool;
+
+    [Test]
+    procedure NoSeed_PublishesNoRegistryTool;
+
+    [Test]
+    procedure NoSeed_ListsOnlyItsOwnTool;
+
+    [Test]
+    procedure NoSeed_TwoManagersDoNotShareTools;
+
+    [Test]
+    procedure NoSeed_CallingARegistryTool_IsInvalidParams;
+
+    [Test]
+    procedure NoSeed_RunsItsOwnTool;
+
+    [Test]
+    procedure Parameterless_SeedsFromRegistry;
+
+    [Test]
+    procedure SeedTrue_MatchesTheParameterlessConstructor;
+  end;
+
 implementation
 
 uses
   System.SysUtils,
   MCPServer.Errors,
+  MCPServer.Registration,
   System.Generics.Collections;
+
+const
+  PROBE_FIRST = 'probe_first';
+  PROBE_SECOND = 'probe_second';
 
 { TDoublingTool }
 
@@ -396,6 +441,173 @@ begin
     Assert.IsTrue(Json.GetValue<string>('content[0].text').Contains('expected integer'));
   finally
     Json.Free;
+  end;
+end;
+
+{ TProbeTool }
+
+constructor TProbeTool.CreateNamed(const AName: string);
+begin
+  inherited Create;
+  FName := AName;
+  FDescription := 'A probe tool handed to a single manager';
+end;
+
+function TProbeTool.BuildSchema: TJSONObject;
+begin
+  Result := TJSONObject.ParseJSONValue(
+    '{"type":"object","properties":{},"additionalProperties":false}') as TJSONObject;
+end;
+
+function TProbeTool.DoExecute(const Arguments: TJSONObject): TValue;
+begin
+  Result := TValue.From<string>(FName + ' ran');
+end;
+
+{ TToolsManagerIsolationTests }
+
+function TToolsManagerIsolationTests.ToolNames(const Manager: TMCPToolsManager): TArray<string>;
+begin
+  Result := nil;
+  var Json := Manager.ListTools(nil, TMCPProtocolEra.Modern).AsType<TJSONObject>;
+  try
+    for var Tool in Json.GetValue('tools') as TJSONArray do
+      Result := Result + [Tool.GetValue<string>('name')];
+  finally
+    Json.Free;
+  end;
+end;
+
+function TToolsManagerIsolationTests.NewManagerWith(const SeedFromRegistry: Boolean;
+  const ToolName: string): TMCPToolsManager;
+begin
+  Result := TMCPToolsManager.Create(SeedFromRegistry);
+  Result.AddTool(TProbeTool.CreateNamed(ToolName));
+end;
+
+function TToolsManagerIsolationTests.FirstRegisteredToolName: string;
+begin
+  var Names := TMCPRegistry.GetToolNames;
+  Assert.IsTrue(Length(Names) > 0, 'no tool is registered globally');
+  Result := Names[0];
+end;
+
+procedure TToolsManagerIsolationTests.Registry_HasAtLeastOneTool;
+begin
+  Assert.IsTrue(Length(TMCPRegistry.GetToolNames) > 0,
+    'the seeding tests only mean something while the registry holds a tool');
+end;
+
+procedure TToolsManagerIsolationTests.NoSeed_PublishesNoRegistryTool;
+begin
+  var Manager := TMCPToolsManager.Create(False);
+  try
+    for var ToolName in TMCPRegistry.GetToolNames do
+      Assert.IsFalse(Manager.HasTool(ToolName), 'an unseeded manager must not publish ' + ToolName);
+    Assert.AreEqual<NativeInt>(0, Length(ToolNames(Manager)), 'an unseeded manager starts empty');
+  finally
+    Manager.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.NoSeed_ListsOnlyItsOwnTool;
+begin
+  var Manager := NewManagerWith(False, PROBE_FIRST);
+  try
+    var Names := ToolNames(Manager);
+    Assert.AreEqual<NativeInt>(1, Length(Names), 'only the added tool is listed');
+    Assert.AreEqual(PROBE_FIRST, Names[0]);
+  finally
+    Manager.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.NoSeed_TwoManagersDoNotShareTools;
+begin
+  var First := NewManagerWith(False, PROBE_FIRST);
+  try
+    var Second := NewManagerWith(False, PROBE_SECOND);
+    try
+      Assert.IsTrue(First.HasTool(PROBE_FIRST));
+      Assert.IsFalse(First.HasTool(PROBE_SECOND), 'the first manager sees only what it was given');
+      Assert.IsTrue(Second.HasTool(PROBE_SECOND));
+      Assert.IsFalse(Second.HasTool(PROBE_FIRST), 'the second manager sees only what it was given');
+    finally
+      Second.Free;
+    end;
+  finally
+    First.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.NoSeed_CallingARegistryTool_IsInvalidParams;
+begin
+  var Manager := NewManagerWith(False, PROBE_FIRST);
+  try
+    var Params := TJSONObject.ParseJSONValue(
+      '{"name":"' + FirstRegisteredToolName + '","arguments":{}}') as TJSONObject;
+    try
+      try
+        Manager.CallTool(Params, TMCPProtocolEra.Modern).AsType<TJSONObject>.Free;
+        Assert.Fail('a globally registered tool must not be callable on an unseeded manager');
+      except
+        on E: EMCPError do
+          Assert.AreEqual(JSONRPC_INVALID_PARAMS, E.Code, E.Message);
+      end;
+    finally
+      Params.Free;
+    end;
+  finally
+    Manager.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.NoSeed_RunsItsOwnTool;
+begin
+  var Manager := NewManagerWith(False, PROBE_FIRST);
+  try
+    var Params := TJSONObject.ParseJSONValue(
+      '{"name":"' + PROBE_FIRST + '","arguments":{}}') as TJSONObject;
+    try
+      var Json := Manager.CallTool(Params, TMCPProtocolEra.Modern).AsType<TJSONObject>;
+      try
+        Assert.IsNull(Json.GetValue('isError'));
+        Assert.AreEqual(PROBE_FIRST + ' ran', Json.GetValue<string>('content[0].text'));
+      finally
+        Json.Free;
+      end;
+    finally
+      Params.Free;
+    end;
+  finally
+    Manager.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.Parameterless_SeedsFromRegistry;
+begin
+  var Manager := TMCPToolsManager.Create;
+  try
+    for var ToolName in TMCPRegistry.GetToolNames do
+      Assert.IsTrue(Manager.HasTool(ToolName), 'the parameterless constructor still seeds ' + ToolName);
+  finally
+    Manager.Free;
+  end;
+end;
+
+procedure TToolsManagerIsolationTests.SeedTrue_MatchesTheParameterlessConstructor;
+begin
+  var Seeded := TMCPToolsManager.Create(True);
+  try
+    var Parameterless := TMCPToolsManager.Create;
+    try
+      Assert.AreEqual(string.Join(',', ToolNames(Parameterless)), string.Join(',', ToolNames(Seeded)),
+        'Create(True) and Create publish the same tools in the same order');
+    finally
+      Parameterless.Free;
+    end;
+  finally
+    Seeded.Free;
   end;
 end;
 

--- a/tests/MCPServerTests.dpr
+++ b/tests/MCPServerTests.dpr
@@ -26,6 +26,7 @@ uses
   MCPServer.Registration in '..\src\Core\MCPServer.Registration.pas',
   MCPServer.ManagerRegistry in '..\src\Core\MCPServer.ManagerRegistry.pas',
   MCPServer.Tool.Base in '..\src\Tools\MCPServer.Tool.Base.pas',
+  MCPServer.Tool.Method in '..\src\Tools\MCPServer.Tool.Method.pas',
   MCPServer.Resource.Base in '..\src\Resources\MCPServer.Resource.Base.pas',
   MCPServer.Prompt.Base in '..\src\Prompts\MCPServer.Prompt.Base.pas',
   MCPServer.JsonRpcProcessor in '..\src\Protocol\MCPServer.JsonRpcProcessor.pas',
@@ -37,6 +38,7 @@ uses
   MCPServer.SubscriptionsManager in '..\src\Managers\MCPServer.SubscriptionsManager.pas',
   MCPServer.StdioTransport in '..\src\Server\MCPServer.StdioTransport.pas',
   MCPServer.StdioChannel in '..\src\Server\MCPServer.StdioChannel.pas',
+  MCPServer.Host in '..\src\Server\MCPServer.Host.pas',
   // The built-in tools and resources register themselves in their
   // initialization sections. Keep the order identical to MCPServer.dpr so the
   // registry (and therefore tools/list and resources/list) matches the server.
@@ -60,6 +62,7 @@ uses
   MCPServer.Tests.Golden.Legacy in 'MCPServer.Tests.Golden.Legacy.pas',
   MCPServer.Tests.Constants in 'MCPServer.Tests.Constants.pas',
   MCPServer.Tests.ServerStatus in 'MCPServer.Tests.ServerStatus.pas',
+  MCPServer.Tests.Settings in 'MCPServer.Tests.Settings.pas',
   MCPServer.Tests.Registration in 'MCPServer.Tests.Registration.pas',
   MCPServer.Tests.Logger in 'MCPServer.Tests.Logger.pas',
   MCPServer.Tests.PathBoundary in 'MCPServer.Tests.PathBoundary.pas',
@@ -68,10 +71,14 @@ uses
   MCPServer.Tests.Capabilities in 'MCPServer.Tests.Capabilities.pas',
   MCPServer.Tests.Golden.Modern in 'MCPServer.Tests.Golden.Modern.pas',
   MCPServer.Tests.HttpHeaders in 'MCPServer.Tests.HttpHeaders.pas',
+  MCPServer.Tests.HeaderEncoding in 'MCPServer.Tests.HeaderEncoding.pas',
   MCPServer.Tests.Http in 'MCPServer.Tests.Http.pas',
   MCPServer.Tests.ToolResult in 'MCPServer.Tests.ToolResult.pas',
   MCPServer.Tests.Serializer in 'MCPServer.Tests.Serializer.pas',
+  MCPServer.Tests.Marshal in 'MCPServer.Tests.Marshal.pas',
   MCPServer.Tests.Schema in 'MCPServer.Tests.Schema.pas',
+  MCPServer.Tests.SchemaFromMethod in 'MCPServer.Tests.SchemaFromMethod.pas',
+  MCPServer.Tests.MethodTool in 'MCPServer.Tests.MethodTool.pas',
   MCPServer.Tests.ToolsManager in 'MCPServer.Tests.ToolsManager.pas',
   MCPServer.Tests.ResourcesManager in 'MCPServer.Tests.ResourcesManager.pas',
   MCPServer.Tests.StdioChannel in 'MCPServer.Tests.StdioChannel.pas',
@@ -83,7 +90,9 @@ uses
   MCPServer.Tests.Subscriptions in 'MCPServer.Tests.Subscriptions.pas',
   MCPServer.Tests.Authorization in 'MCPServer.Tests.Authorization.pas',
   MCPServer.Tests.PromptsManager in 'MCPServer.Tests.PromptsManager.pas',
-  MCPServer.Tests.CompletionManager in 'MCPServer.Tests.CompletionManager.pas';
+  MCPServer.Tests.CompletionManager in 'MCPServer.Tests.CompletionManager.pas',
+  MCPServer.Tests.Host in 'MCPServer.Tests.Host.pas',
+  MCPServer.Tests.HttpCancellation in 'MCPServer.Tests.HttpCancellation.pas';
 
 procedure RunTests;
 begin

--- a/tests/MCPServerTests.dproj
+++ b/tests/MCPServerTests.dproj
@@ -90,6 +90,7 @@
         <DCCReference Include="..\src\Core\MCPServer.Registration.pas"/>
         <DCCReference Include="..\src\Core\MCPServer.ManagerRegistry.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.Base.pas"/>
+        <DCCReference Include="..\src\Tools\MCPServer.Tool.Method.pas"/>
         <DCCReference Include="..\src\Resources\MCPServer.Resource.Base.pas"/>
         <DCCReference Include="..\src\Prompts\MCPServer.Prompt.Base.pas"/>
         <DCCReference Include="..\src\Protocol\MCPServer.JsonRpcProcessor.pas"/>
@@ -101,6 +102,7 @@
         <DCCReference Include="..\src\Managers\MCPServer.SubscriptionsManager.pas"/>
         <DCCReference Include="..\src\Server\MCPServer.StdioTransport.pas"/>
         <DCCReference Include="..\src\Server\MCPServer.StdioChannel.pas"/>
+        <DCCReference Include="..\src\Server\MCPServer.Host.pas"/>
         <DCCReference Include="MCPServer.Tests.StdioChannel.pas"/>
         <DCCReference Include="MCPServer.Tests.Cancellation.pas"/>
         <DCCReference Include="MCPServer.Tests.Stdio.pas"/>
@@ -111,6 +113,7 @@
         <DCCReference Include="MCPServer.Tests.Authorization.pas"/>
         <DCCReference Include="MCPServer.Tests.PromptsManager.pas"/>
         <DCCReference Include="MCPServer.Tests.CompletionManager.pas"/>
+        <DCCReference Include="MCPServer.Tests.Marshal.pas"/>
         <DCCReference Include="..\src\Resources\MCPServer.Resource.Server.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.Echo.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.GetTime.pas"/>
@@ -124,6 +127,7 @@
         <DCCReference Include="MCPServer.Tests.Golden.Legacy.pas"/>
         <DCCReference Include="MCPServer.Tests.Constants.pas"/>
         <DCCReference Include="MCPServer.Tests.ServerStatus.pas"/>
+        <DCCReference Include="MCPServer.Tests.Settings.pas"/>
         <DCCReference Include="MCPServer.Tests.Registration.pas"/>
         <DCCReference Include="MCPServer.Tests.Logger.pas"/>
         <DCCReference Include="MCPServer.Tests.PathBoundary.pas"/>
@@ -132,12 +136,17 @@
         <DCCReference Include="MCPServer.Tests.Capabilities.pas"/>
         <DCCReference Include="MCPServer.Tests.Golden.Modern.pas"/>
         <DCCReference Include="MCPServer.Tests.HttpHeaders.pas"/>
+        <DCCReference Include="MCPServer.Tests.HeaderEncoding.pas"/>
         <DCCReference Include="MCPServer.Tests.Http.pas"/>
         <DCCReference Include="MCPServer.Tests.ToolResult.pas"/>
         <DCCReference Include="MCPServer.Tests.Serializer.pas"/>
         <DCCReference Include="MCPServer.Tests.Schema.pas"/>
+        <DCCReference Include="MCPServer.Tests.SchemaFromMethod.pas"/>
+        <DCCReference Include="MCPServer.Tests.MethodTool.pas"/>
         <DCCReference Include="MCPServer.Tests.ToolsManager.pas"/>
         <DCCReference Include="MCPServer.Tests.ResourcesManager.pas"/>
+        <DCCReference Include="MCPServer.Tests.Host.pas"/>
+        <DCCReference Include="MCPServer.Tests.HttpCancellation.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.Result.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.ContentSamples.pas"/>
         <DCCReference Include="..\src\Tools\MCPServer.Tool.InputRequiredSamples.pas"/>


### PR DESCRIPTION
`TMCPServerApplication` blocks in `RunHttp`, has no `Stop`, and always seeds its managers from the global registry. An application that wants its own MCP endpoint has to repeat the composition, and two endpoints in one process publish each other's tools.

## What this adds

`TMCPServerHost` in `MCPServer.Host`. `StartHttp` returns once the listener is up, `StartHttp` and `Stop` are idempotent, and `BoundPort` reports the port after `Port = 0`. `RunStdio` is the console entry point. `TMCPServerApplication` is now built on the host, so the composition exists in one place.

The three managers gained a `Create(SeedFromRegistry)` overload. The parameterless one still seeds from the registry, so existing code behaves as before. A host with `SeedFromGlobalRegistry = False` publishes only what it was handed, tools, resources, templates and prompts alike.

`TMCPMethodTool` in `MCPServer.Tool.Method` publishes a method as a tool: schema from the parameter list, arguments marshalled in, result back as JSON. `ReleaseArguments` and `ReleaseResult` are virtual, so a method that keeps the object it was handed says so.

`GenerateSchemaFromMethod`, `GenerateSchemaFromType` and `GenerateSchemaFromMethodResult` on the schema generator. `JsonToValue` and `ValueToJson` on the serializer, where `JsonToValue` collects the objects it creates.

The four MCP header names move to `MCPServer.Types`, and `TMCPHeaderValue.Encode` is the counterpart of `TryDecode`.

## Fixed along the way

- `Port = 0` gave the IPv4 and the IPv6 binding two different ephemeral ports while `BoundPort` reported the first, so a client that resolved `::1` reached nothing. Both bindings now take one claimed port.
- A `var` or `out` parameter is refused, naming the parameter.
- `$schema` from `[SchemaDialect]` stays on the root instead of appearing inside `properties.<param>`.

## Compatibility

The shipped executable answers identically to `21d3887` on initialize, tools/list, resources/list, prompts/list and a tool call, byte for byte. `tests/golden` and `tests/fixtures` are unchanged.

One correction is documentation only: closing the stream cancels an HTTP request, a `notifications/cancelled` on a second connection is answered `202` and dropped, and only stdio stops a request that way. Two tests hold both facts.

512 tests, 0 failed, 0 leaked, on Win32 and Win64.
