### PR TITLE
feat(schema): describe and marshal records the way classes are described

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,28 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `MCP_HEADER_METHOD` and `MCP_HEADER_NAME` in `MCPServer.Types` are the one
   place the four MCP header names are spelled; the HTTP server and the JSON-RPC
   processor read them from there.
+- Records are first-class in a schema and on the wire.
+  `MCPServer.Schema.Generator` describes a record as the `type: object` a class
+  produces, with one property per public field, `required` for the fields
+  without `[Optional]`, and the same depth guard, so records nest, hold arrays,
+  hold classes, sit inside classes and cannot recurse forever. Every schema
+  attribute that works on a class property works on a record field.
+  `MCPServer.Serializer` builds a record from a JSON object and writes one back
+  out; a record is a value and is never put up for freeing, while an object it
+  holds is. `TMCPMethodTool` therefore takes a record parameter and returns a
+  record result with no special case of its own. A `TGUID` is described as a
+  `string` with `format: uuid` and travels as
+  `f81d4fae-7dec-11d0-a765-00a0c91e6bf6`, read with or without braces, because
+  its `D4` member is an anonymous array `System` publishes no type for. A
+  record whose unit publishes no field RTTI has no fields to describe and keeps
+  the `string` every record was published as; a method tool refuses such a
+  record as a parameter, naming the record and the
+  `{$RTTI EXPLICIT FIELDS([vcPublic])}` that fixes it, and publishes no output
+  schema for it as a result.
+- `TMCPSchemaGenerator` refuses a field, property or array element whose type
+  carries no RTTI at all, with an `EArgumentException` naming the member.
+  Reading the type kind off a member that has none was an access violation, and
+  a `TGUID` was the way into it.
 
 ### Changed
 
@@ -278,6 +300,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   helpers are class functions on `TMCPContentBlock`, `TMCPProtocolVersion` and
   `TLogger`; `MCPServer.Schema.Generator` keeps its RTTI context in a class
   variable instead of an `initialization` section.
+- A type the schema generator cannot describe is refused instead of published
+  as a string. A parameter, property or field whose type is a pointer,
+  procedure or method reference, class reference, interface or variant raises
+  `EArgumentException` naming the member and its type, and so does a record
+  whose unit publishes no field RTTI, which would otherwise be published as an
+  object with no members.
 - `IMCPAuthorizer.Authorize` returns a `TMCPAuthResult`, a custom authorizer
   overrides `TryValidateToken`, `TMCPLineReader.TryReadLine` returns a
   `TMCPLine`, `TMCPSchemaValidator.TryValidate` replaces `Validate`, and
@@ -388,9 +416,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `logs://recent` no longer writes an access-log entry on every read;
   `project://info` reports `MCP 2026-07-28 (initialize-based: 2025-11-25,
   2025-06-18)` and is cacheable for an hour (`cacheScope: public`).
+- A record-typed property of a tool's parameter class is published as the
+  `type: object` its public fields describe and filled from that object. It
+  used to be published as a `string` and dropped when the arguments were
+  unmarshalled. Every other property the generator cannot describe, a variant,
+  an interface, a method pointer or a class reference, keeps that `string`, so
+  a tool that listed before lists now. MIGRATION.md carries the detail.
 
 ### Fixed
 
+- A record that failed to convert halfway leaked the objects it already held:
+  `TMCPSerializer.JsonToValue` adds them to the caller's list only once the
+  whole record is built, so `{"line": {"sku": "a"}, "count": "x"}` created an
+  object and destroyed none. The half-built record is emptied on the way out,
+  the way a nested class already was.
 - Enumeration sets with more than 64 elements were truncated when serialised,
   and a JSON number outside the range of its target integer type was silently
   wrapped instead of rejected.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -89,6 +89,19 @@ and sets list their names, and a tool without parameters declares
 `additionalProperties: false`. Clients that validate arguments against the
 schema now reject `1.5` for an integer.
 
+**A record property is described and filled.** A property whose type is a
+record used to be published as `{"type": "string"}` and dropped when the
+arguments were unmarshalled. It is now published as the `type: object` its
+public fields describe, and filled from that object, so a client that sent a
+string for it must send an object, and a tool that always read such a property
+as empty now receives what the caller sent. A `TGUID` property stays a string
+and gains `format: uuid`. A record whose unit publishes no field RTTI has no
+fields to describe and stays the string it was; "Records in a schema" in the
+README carries the directive that makes those fields visible. Properties of
+every other kind are unchanged: a variant, an interface, a method pointer or a
+class reference is still published as `string`, so a tool that listed before
+lists now.
+
 **Result and resource JSON changed.** Enumerations are written by name (they
 were booleans), sets and dynamic arrays as arrays, `nil` objects as `null`
 and `TDateTime` as an ISO 8601 string. The `logs://recent` timestamps and the

--- a/README.md
+++ b/README.md
@@ -431,6 +431,86 @@ parameter. Integer properties are published as `integer`, `TDateTime` as a
 `[SchemaTitle]`, `[SchemaFormat]`, `[SchemaMinimum]` and `[SchemaMaximum]`
 add the corresponding keywords.
 
+#### Records in a schema
+
+A record is described exactly the way a class is: `type: object` with one
+`properties` member per **public field**, and a `required` array holding the
+fields that carry no `[Optional]`. Records nest, hold arrays, hold classes and
+sit inside classes; the walk stops at the same depth guard the class walk uses,
+so a record that reaches itself through a `TArray<T>` cannot recurse forever.
+Every attribute that works on a class property works on a record field:
+`[SchemaDescription]`, `[SchemaTitle]`, `[SchemaFormat]`, `[SchemaMinimum]`,
+`[SchemaMaximum]`, `[SchemaMinLength]`, `[SchemaMaxLength]`, `[SchemaPattern]`,
+`[SchemaDefault]`, `[SchemaName]` and `[Optional]`.
+
+```pascal
+type
+  TMoney = record
+    [SchemaDescription('Amount in the smallest unit')]
+    [SchemaMinimum(0)]
+    Amount: Double;
+
+    [SchemaName('currency_code')]
+    [SchemaPattern('^[A-Z]{3}$')]
+    Currency: string;
+
+    [Optional]
+    Note: string;
+  end;
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "amount": { "type": "number", "description": "Amount in the smallest unit", "minimum": 0 },
+    "currency_code": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "note": { "type": "string" }
+  },
+  "required": ["amount", "currency_code"]
+}
+```
+
+The same shape crosses the wire in both directions: `MCPServer.Serializer`
+builds the record from a JSON object and writes it back out, with enumerations
+by name, `TDateTime` as ISO 8601, and an absent `[Optional]` field left at the
+default of its type. A record is a value, so nothing about it is freed after a
+call; an object a record holds is owned by the call and freed with it.
+
+**What a record needs from RTTI.** The generator reads a record's fields and
+their attributes through extended RTTI, so the unit that declares the record
+must publish field RTTI for the visibility the fields have. Delphi's default
+(`FIELDS([vcPrivate, vcProtected, vcPublic])`) already does, so a record in an
+ordinary unit needs nothing. A unit that narrows the setting must keep public
+fields in it:
+
+```pascal
+{$RTTI EXPLICIT FIELDS([vcPublic])}
+```
+
+A record whose fields are invisible has nothing to describe. As a property of a
+parameter class it keeps the `{"type": "string"}` every record was published as
+before, so a tool that has always listed goes on listing. As a parameter of a
+method tool it is refused instead, naming the record and this directive,
+because a tool written against this version should not ship a schema that does
+not match what the method takes.
+
+The same split applies to a type with no JSON shape at all: a pointer, a
+procedure or method reference, a class reference, an interface or a variant is
+published as `string` on the class walk, the way it always was, and refused as
+a method parameter, naming the parameter and its type. One property the
+generator cannot describe therefore never costs a `tools/list` its other tools.
+A field, property or array element whose type carries no RTTI at all is refused
+wherever it appears, naming the member, because there is nothing left to fall
+back on. Private fields are skipped silently, because a private field is not
+part of the wire.
+
+**`TGUID`.** A `TGUID` is a record, but its `D4` member is an anonymous array
+that `System` publishes no type for, so a `TGUID` has no members to walk. It is
+published as `{"type": "string", "format": "uuid"}` and travels as
+`f81d4fae-7dec-11d0-a765-00a0c91e6bf6`, written in lower case without braces
+and read with or without them.
+
 A tool that returns more than text overrides `ExecuteWithContext` and builds
 a `TMCPToolResult` (`MCPServer.Tool.Result`):
 

--- a/src/Protocol/MCPServer.Schema.Generator.pas
+++ b/src/Protocol/MCPServer.Schema.Generator.pas
@@ -15,16 +15,30 @@ type
     class var FContext: TRttiContext;
     class function GetJsonName(const Member: TRttiNamedObject): string;
     class function IsRequired(const Member: TRttiNamedObject): Boolean;
+    class function IsGuid(const RttiType: TRttiType): Boolean;
+    class function IsSchemaField(const RttiField: TRttiField): Boolean;
+    class function HasSchemaFields(const RttiType: TRttiType): Boolean;
+    class function IsOpaqueRecord(const RttiType: TRttiType): Boolean;
     class function CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
     class function ListItemType(RttiType: TRttiType): TRttiType;
     class function TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+    class function SimpleSchema(const JsonType: string): TJSONObject;
+    class function GuidSchema: TJSONObject;
+    class function ItemsSchema(const Site: string; const ElementType: TRttiType; Depth: Integer): TJSONObject;
     class procedure DescribeFloat(RttiType: TRttiType; const Schema: TJSONObject);
     class procedure DescribeSet(RttiType: TRttiType; const Schema: TJSONObject);
-    class function ClassSchema(RttiType: TRttiType; Depth: Integer; const Schema: TJSONObject): TJSONObject;
+    class function ClassSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+    class function RecordSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
     class function ObjectSchema(RttiType: TRttiType; Depth: Integer; const IsRoot: Boolean): TJSONObject;
+    class procedure DescribeProperties(RttiType: TRttiType; Depth: Integer;
+                                       const Properties: TJSONObject; const RequiredArray: TJSONArray);
+    class procedure DescribeFields(RttiType: TRttiType; Depth: Integer;
+                                   const Properties: TJSONObject; const RequiredArray: TJSONArray);
     class function NumberValue(const Value: Double): TJSONNumber;
     class procedure ApplyAttributes(const Member: TRttiNamedObject; const MemberSchema: TJSONObject);
+    class procedure GuardMemberHasType(const Site: string; const RttiType: TRttiType);
     class procedure GuardParameterHasSchema(const Method: TRttiMethod; const Param: TRttiParameter);
+    class procedure GuardParameterRecordHasFields(const Method: TRttiMethod; const Param: TRttiParameter);
   public
     class constructor Create;
     class destructor Destroy;
@@ -55,11 +69,14 @@ const
   SCHEMA_KEY_PROPERTIES = 'properties';
   SCHEMA_KEY_REQUIRED = 'required';
   SCHEMA_KEY_RESULT = 'result';
+  SCHEMA_FORMAT_UUID = 'uuid';
 
   DEPTH_ABOVE_ROOT = -1;
 
-  UNDESCRIBABLE_RESULT_KINDS = [tkUnknown, tkPointer, tkProcedure, tkMethod, tkClassRef,
-    tkInterface, tkRecord, tkMRecord];
+  UNDESCRIBABLE_KINDS = [tkUnknown, tkPointer, tkProcedure, tkMethod, tkClassRef,
+    tkInterface, tkVariant];
+
+  RECORD_KINDS = [tkRecord, tkMRecord];
 
 
 { TMCPSchemaGenerator }
@@ -89,8 +106,9 @@ begin
   if not Assigned(RttiType) then
     Exit(nil);
 
-  if RttiType.TypeKind = tkClass then
-    Exit(ClassSchema(RttiType, DEPTH_ABOVE_ROOT, TJSONObject.Create));
+  const DescribesItsOwnMembers = (RttiType.TypeKind = tkClass) or (RttiType.TypeKind in RECORD_KINDS);
+  if DescribesItsOwnMembers then
+    Exit(TypeSchema(RttiType, DEPTH_ABOVE_ROOT));
 
   Result := TypeSchema(RttiType, 0);
 end;
@@ -139,7 +157,10 @@ end;
 class function TMCPSchemaGenerator.GenerateSchemaFromMethodResult(const Method: TRttiMethod): TJSONObject;
 begin
   const ReturnType = Method.ReturnType;
-  if not Assigned(ReturnType) or (ReturnType.TypeKind in UNDESCRIBABLE_RESULT_KINDS) then
+  if not Assigned(ReturnType) or (ReturnType.TypeKind in UNDESCRIBABLE_KINDS) then
+    Exit(nil);
+
+  if IsOpaqueRecord(ReturnType) then
     Exit(nil);
 
   Result := TJSONObject.Create;
@@ -173,6 +194,33 @@ begin
     raise EArgumentException.CreateFmt(
       'Parameter "%s" of %s is a var or out parameter, so it has no schema: a tool answers with its result',
       [Param.Name, Method.Name]);
+
+  const HasNoJsonShape = (Param.ParamType.TypeKind in UNDESCRIBABLE_KINDS);
+  if HasNoJsonShape then
+    raise EArgumentException.CreateFmt(
+      'Parameter "%s" of %s is of type %s, which has no JSON schema',
+      [Param.Name, Method.Name, Param.ParamType.Name]);
+
+  GuardParameterRecordHasFields(Method, Param);
+end;
+
+class procedure TMCPSchemaGenerator.GuardParameterRecordHasFields(const Method: TRttiMethod;
+  const Param: TRttiParameter);
+begin
+  if not IsOpaqueRecord(Param.ParamType) then
+    Exit;
+
+  raise EArgumentException.CreateFmt(
+    'Parameter "%s" of %s is record %s, which publishes no field RTTI, so it has no schema. ' +
+    'Declare it in a unit whose field RTTI covers its public fields, for example ' +
+    '{$RTTI EXPLICIT FIELDS([vcPublic])}.',
+    [Param.Name, Method.Name, Param.ParamType.Name]);
+end;
+
+class procedure TMCPSchemaGenerator.GuardMemberHasType(const Site: string; const RttiType: TRttiType);
+begin
+  if not Assigned(RttiType) then
+    raise EArgumentException.CreateFmt('%s has no type RTTI, so it has no schema', [Site]);
 end;
 
 class function TMCPSchemaGenerator.GetJsonName(const Member: TRttiNamedObject): string;
@@ -192,6 +240,30 @@ begin
     if Attr is OptionalAttribute then
       Exit(False);
   Result := True;
+end;
+
+class function TMCPSchemaGenerator.IsGuid(const RttiType: TRttiType): Boolean;
+begin
+  Result := (RttiType.Handle = TypeInfo(TGUID));
+end;
+
+class function TMCPSchemaGenerator.IsSchemaField(const RttiField: TRttiField): Boolean;
+begin
+  Result := (RttiField.Visibility in SCHEMA_FIELD_VISIBILITIES);
+end;
+
+class function TMCPSchemaGenerator.HasSchemaFields(const RttiType: TRttiType): Boolean;
+begin
+  for var RttiField in RttiType.GetFields do
+    if IsSchemaField(RttiField) then
+      Exit(True);
+  Result := False;
+end;
+
+class function TMCPSchemaGenerator.IsOpaqueRecord(const RttiType: TRttiType): Boolean;
+begin
+  Result := ((RttiType.TypeKind in RECORD_KINDS) and not IsGuid(RttiType) and
+             not HasSchemaFields(RttiType));
 end;
 
 class function TMCPSchemaGenerator.CreateEnumValuesArray(RttiType: TRttiType): TJSONArray;
@@ -256,43 +328,77 @@ begin
     Items.AddPair(SCHEMA_KEY_ENUM, Names);
 end;
 
-class function TMCPSchemaGenerator.ClassSchema(RttiType: TRttiType; Depth: Integer;
-  const Schema: TJSONObject): TJSONObject;
+class function TMCPSchemaGenerator.SimpleSchema(const JsonType: string): TJSONObject;
 begin
-  Result := Schema;
+  Result := TJSONObject.Create;
+  Result.AddPair(MCP_KEY_TYPE, JsonType);
+end;
+
+class function TMCPSchemaGenerator.GuidSchema: TJSONObject;
+begin
+  Result := SimpleSchema(SCHEMA_TYPE_STRING);
+  Result.AddPair(SCHEMA_KEY_FORMAT, SCHEMA_FORMAT_UUID);
+end;
+
+class function TMCPSchemaGenerator.ItemsSchema(const Site: string; const ElementType: TRttiType;
+  Depth: Integer): TJSONObject;
+begin
+  GuardMemberHasType(Site, ElementType);
+
+  Result := TypeSchema(ElementType, Depth + 1);
+end;
+
+class function TMCPSchemaGenerator.ClassSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+begin
   const Metaclass = TRttiInstanceType(RttiType).MetaclassType;
   if Metaclass.InheritsFrom(TJSONArray) then
-  begin
-    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-    Exit;
-  end;
+    Exit(SimpleSchema(SCHEMA_TYPE_ARRAY));
   if Metaclass.InheritsFrom(TJSONValue) then
-  begin
-    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
-    Exit;
-  end;
+    Exit(SimpleSchema(SCHEMA_TYPE_OBJECT));
 
   const ItemType = ListItemType(RttiType);
   if Assigned(ItemType) then
   begin
-    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
-    Schema.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ItemType, Depth + 1));
+    Result := SimpleSchema(SCHEMA_TYPE_ARRAY);
+    try
+      Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ItemType, Depth + 1));
+    except
+      Result.Free;
+      raise;
+    end;
     Exit;
   end;
 
   const FitsAnotherLevel = (Depth < MAX_NESTING_DEPTH);
   if not FitsAnotherLevel then
-  begin
-    Schema.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
-    Exit;
-  end;
+    Exit(SimpleSchema(SCHEMA_TYPE_OBJECT));
 
-  Schema.Free;
+  Result := ObjectSchema(RttiType, Depth + 1, False);
+end;
+
+class function TMCPSchemaGenerator.RecordSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
+begin
+  if IsGuid(RttiType) then
+    Exit(GuidSchema);
+
+  if not HasSchemaFields(RttiType) then
+    Exit(SimpleSchema(SCHEMA_TYPE_STRING));
+
+  const FitsAnotherLevel = (Depth < MAX_NESTING_DEPTH);
+  if not FitsAnotherLevel then
+    Exit(SimpleSchema(SCHEMA_TYPE_OBJECT));
+
   Result := ObjectSchema(RttiType, Depth + 1, False);
 end;
 
 class function TMCPSchemaGenerator.TypeSchema(RttiType: TRttiType; Depth: Integer): TJSONObject;
 begin
+  if RttiType.TypeKind = tkClass then
+    Exit(ClassSchema(RttiType, Depth));
+
+  if RttiType.TypeKind in RECORD_KINDS then
+    Exit(RecordSchema(RttiType, Depth));
+
   Result := TJSONObject.Create;
   try
     case RttiType.TypeKind of
@@ -321,18 +427,17 @@ begin
         begin
           Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
           const ElementType = TRttiDynamicArrayType(RttiType).ElementType;
-          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ElementType, Depth + 1));
+          const ElementSite = Format('Element of %s', [RttiType.Name]);
+          Result.AddPair(SCHEMA_KEY_ITEMS, ItemsSchema(ElementSite, ElementType, Depth));
         end;
 
       tkArray:
         begin
           Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_ARRAY);
           const ElementType = TRttiArrayType(RttiType).ElementType;
-          Result.AddPair(SCHEMA_KEY_ITEMS, TypeSchema(ElementType, Depth + 1));
+          const ElementSite = Format('Element of %s', [RttiType.Name]);
+          Result.AddPair(SCHEMA_KEY_ITEMS, ItemsSchema(ElementSite, ElementType, Depth));
         end;
-
-      tkClass:
-        Result := ClassSchema(RttiType, Depth, Result);
     else
       Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_STRING);
     end;
@@ -406,22 +511,18 @@ begin
           Result.AddPair('$schema', SchemaDialectAttribute(Attr).Uri);
 
     Result.AddPair(MCP_KEY_TYPE, SCHEMA_TYPE_OBJECT);
-    var Properties := TJSONObject.Create;
+    const Properties = TJSONObject.Create;
     Result.AddPair(SCHEMA_KEY_PROPERTIES, Properties);
-    var RequiredArray := TJSONArray.Create;
-
-    for var RttiProp in RttiType.GetProperties do
-    begin
-      if not (RttiProp.IsReadable and RttiProp.IsWritable) then
-        Continue;
-
-      var JsonName := GetJsonName(RttiProp);
-      var PropSchema := TypeSchema(RttiProp.PropertyType, Depth);
-      Properties.AddPair(JsonName, PropSchema);
-      ApplyAttributes(RttiProp, PropSchema);
-
-      if IsRequired(RttiProp) then
-        RequiredArray.Add(JsonName);
+    const RequiredArray = TJSONArray.Create;
+    try
+      const DescribesItsFields = (RttiType.TypeKind in RECORD_KINDS);
+      if DescribesItsFields then
+        DescribeFields(RttiType, Depth, Properties, RequiredArray)
+      else
+        DescribeProperties(RttiType, Depth, Properties, RequiredArray);
+    except
+      RequiredArray.Free;
+      raise;
     end;
 
     const HasRequiredArray = (RequiredArray.Count > 0);
@@ -443,6 +544,48 @@ begin
   except
     Result.Free;
     raise;
+  end;
+end;
+
+class procedure TMCPSchemaGenerator.DescribeProperties(RttiType: TRttiType; Depth: Integer;
+  const Properties: TJSONObject; const RequiredArray: TJSONArray);
+begin
+  for var RttiProp in RttiType.GetProperties do
+  begin
+    if not (RttiProp.IsReadable and RttiProp.IsWritable) then
+      Continue;
+
+    GuardMemberHasType(Format('Property %s.%s', [RttiType.Name, RttiProp.Name]),
+      RttiProp.PropertyType);
+
+    const JsonName = GetJsonName(RttiProp);
+    const PropSchema = TypeSchema(RttiProp.PropertyType, Depth);
+    Properties.AddPair(JsonName, PropSchema);
+    ApplyAttributes(RttiProp, PropSchema);
+
+    if IsRequired(RttiProp) then
+      RequiredArray.Add(JsonName);
+  end;
+end;
+
+class procedure TMCPSchemaGenerator.DescribeFields(RttiType: TRttiType; Depth: Integer;
+  const Properties: TJSONObject; const RequiredArray: TJSONArray);
+begin
+  for var RttiField in RttiType.GetFields do
+  begin
+    if not IsSchemaField(RttiField) then
+      Continue;
+
+    GuardMemberHasType(Format('Field %s.%s', [RttiType.Name, RttiField.Name]),
+      RttiField.FieldType);
+
+    const JsonName = GetJsonName(RttiField);
+    const FieldSchema = TypeSchema(RttiField.FieldType, Depth);
+    Properties.AddPair(JsonName, FieldSchema);
+    ApplyAttributes(RttiField, FieldSchema);
+
+    if IsRequired(RttiField) then
+      RequiredArray.Add(JsonName);
   end;
 end;
 

--- a/src/Protocol/MCPServer.Serializer.pas
+++ b/src/Protocol/MCPServer.Serializer.pas
@@ -22,11 +22,24 @@ type
     class function ConvertJsonToInteger(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function ConvertJsonToFloat(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function ConvertJsonToClass(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToRecord(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
+    class function ConvertJsonToGuid(const JsonValue: TJSONValue): TValue;
+    class procedure FillRecordFields(const Json: TJSONObject; const RttiType: TRttiType;
+      const Data: Pointer);
+    class procedure FreeRecordObjects(const Value: TValue; const RttiType: TRttiType);
     class function ConvertJsonToEnum(const JsonValue: TJSONValue; const RttiType: TRttiType): TValue;
     class function GetEnumValueNames(const EnumType: TRttiEnumerationType): string;
     class function ConvertValueToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
+    class function ConvertRecordToJson(const Value: TValue; const RttiType: TRttiType): TJSONValue;
+    class function ConvertGuidToJson(const Value: TValue): TJSONValue;
     class function TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;
     class function CreateInstanceFromType(const RttiType: TRttiType): TObject;
+    class function IsGuid(const RttiType: TRttiType): Boolean;
+    class function IsWireField(const RttiField: TRttiField): Boolean;
+    class function HasWireFields(const RttiType: TRttiType): Boolean;
+    class procedure GuardKnownKeys(const Json: TJSONObject; const KnownNorms: TStringList);
+    class procedure GuardRecordKeys(const Json: TJSONObject; const RttiType: TRttiType);
+    class procedure GuardFieldHasType(const RttiType: TRttiType; const RttiField: TRttiField);
 
     class function DeserializeDynamicArray(const DynArrayType: TRttiDynamicArrayType; const JsonArray: TJSONArray): TValue;
     class function DeserializeGenericList(const ListType: TRttiInstanceType; const JsonArray: TJSONArray): TValue;
@@ -35,15 +48,19 @@ type
     class function GetJsonValueCaseInsensitive(const Json: TJSONObject; const PropName: string): TJSONValue;
 
     class function NormalizeKey(const Name: string): string; inline;
-    class function IsRequiredProperty(const Prop: TRttiProperty): Boolean;
+    class function IsRequiredMember(const Member: TRttiNamedObject): Boolean;
 
     class procedure CollectCreatedObjects(const Value: TValue; const RttiType: TRttiType;
+      const Owned: TList<TObject>);
+    class procedure CollectFromArray(const Value: TValue; const ElementType: TRttiType;
+      const Owned: TList<TObject>);
+    class procedure CollectFromRecord(const Value: TValue; const RttiType: TRttiType;
       const Owned: TList<TObject>);
   public
     class constructor Create;
     class destructor Destroy;
 
-    class function GetWireName(const Prop: TRttiProperty): string;
+    class function GetWireName(const Member: TRttiNamedObject): string;
 
     class function Deserialize<T: class, constructor>(const Json: TJSONObject): T;
     class procedure Serialize(Obj: TObject; Json: TJSONObject);
@@ -64,6 +81,10 @@ uses
 
 const
   MESSAGE_EXPECTED_INTEGER = 'expected an integer';
+  MESSAGE_EXPECTED_OBJECT = 'expected an object';
+  MESSAGE_EXPECTED_UUID = 'expected a UUID string';
+
+  OWNERSHIP_BEARING_KINDS = [tkClass, tkDynArray, tkRecord, tkMRecord];
 
 
 { TMCPSerializer }
@@ -112,9 +133,7 @@ end;
 class procedure TMCPSerializer.DeserializeObject(Instance: TObject; const Json: TJSONObject);
 var
   JsonValue: TJSONValue;
-  KeyName: string;
   KnownNorms: TStringList;
-  Pair: TJSONPair;
   PropValue: TValue;
   RttiProp: TRttiProperty;
   RttiType: TRttiType;
@@ -127,14 +146,7 @@ begin
       if RttiProp.IsWritable then
         KnownNorms.Add(NormalizeKey(GetWireName(RttiProp)));
 
-    for Pair in Json do
-    begin
-      KeyName := Pair.JsonString.Value;
-      if KnownNorms.IndexOf(NormalizeKey(KeyName)) < 0 then
-        raise EArgumentException.CreateFmt(
-          'Unknown parameter "%s". Valid parameters: %s.',
-          [KeyName, String.Join(', ', KnownNorms.ToStringArray)]);
-    end;
+    GuardKnownKeys(Json, KnownNorms);
   finally
     KnownNorms.Free;
   end;
@@ -148,7 +160,7 @@ begin
 
     if not Assigned(JsonValue) or (JsonValue is TJSONNull) then
     begin
-      if IsRequiredProperty(RttiProp) then
+      if IsRequiredMember(RttiProp) then
         raise EArgumentException.CreateFmt('Missing required parameter "%s"', [GetWireName(RttiProp)]);
       Continue;
     end;
@@ -169,23 +181,75 @@ begin
   end;
 end;
 
-class function TMCPSerializer.IsRequiredProperty(const Prop: TRttiProperty): Boolean;
+class function TMCPSerializer.IsRequiredMember(const Member: TRttiNamedObject): Boolean;
 begin
-  for var Attr in Prop.GetAttributes do
+  for var Attr in Member.GetAttributes do
     if Attr is OptionalAttribute then
       Exit(False);
   Result := True;
 end;
 
-class function TMCPSerializer.GetWireName(const Prop: TRttiProperty): string;
+class function TMCPSerializer.GetWireName(const Member: TRttiNamedObject): string;
 begin
-  for var Attr in Prop.GetAttributes do
+  for var Attr in Member.GetAttributes do
     if Attr is SchemaNameAttribute then
       begin
         Result := SchemaNameAttribute(Attr).Name;
         Exit;
       end;
-  Result := LowerCase(Prop.Name);
+  Result := LowerCase(Member.Name);
+end;
+
+class function TMCPSerializer.IsGuid(const RttiType: TRttiType): Boolean;
+begin
+  Result := (RttiType.Handle = TypeInfo(TGUID));
+end;
+
+class function TMCPSerializer.IsWireField(const RttiField: TRttiField): Boolean;
+begin
+  Result := (RttiField.Visibility in SCHEMA_FIELD_VISIBILITIES);
+end;
+
+class function TMCPSerializer.HasWireFields(const RttiType: TRttiType): Boolean;
+begin
+  for var RttiField in RttiType.GetFields do
+    if IsWireField(RttiField) then
+      Exit(True);
+  Result := False;
+end;
+
+class procedure TMCPSerializer.GuardKnownKeys(const Json: TJSONObject; const KnownNorms: TStringList);
+begin
+  for var Pair in Json do
+  begin
+    const KeyName = Pair.JsonString.Value;
+    if KnownNorms.IndexOf(NormalizeKey(KeyName)) < 0 then
+      raise EArgumentException.CreateFmt(
+        'Unknown parameter "%s". Valid parameters: %s.',
+        [KeyName, String.Join(', ', KnownNorms.ToStringArray)]);
+  end;
+end;
+
+class procedure TMCPSerializer.GuardRecordKeys(const Json: TJSONObject; const RttiType: TRttiType);
+begin
+  const KnownNorms = TStringList.Create;
+  try
+    for var RttiField in RttiType.GetFields do
+      if IsWireField(RttiField) then
+        KnownNorms.Add(NormalizeKey(GetWireName(RttiField)));
+
+    GuardKnownKeys(Json, KnownNorms);
+  finally
+    KnownNorms.Free;
+  end;
+end;
+
+class procedure TMCPSerializer.GuardFieldHasType(const RttiType: TRttiType;
+  const RttiField: TRttiField);
+begin
+  if not Assigned(RttiField.FieldType) then
+    raise EArgumentException.CreateFmt('Field %s.%s has no type RTTI, so it has no JSON value',
+      [RttiType.Name, RttiField.Name]);
 end;
 
 class procedure TMCPSerializer.Serialize(Obj: TObject; Json: TJSONObject);
@@ -218,7 +282,7 @@ end;
 class procedure TMCPSerializer.CollectCreatedObjects(const Value: TValue; const RttiType: TRttiType;
   const Owned: TList<TObject>);
 begin
-  if not Assigned(Owned) or Value.IsEmpty then
+  if not Assigned(Owned) or not Assigned(RttiType) or Value.IsEmpty then
     Exit;
 
   case RttiType.TypeKind of
@@ -227,18 +291,38 @@ begin
         Owned.Add(Value.AsObject);
 
     tkDynArray:
-      begin
-        const ElementType = TRttiDynamicArrayType(RttiType).ElementType;
-        if not Assigned(ElementType) or (ElementType.TypeKind <> tkClass) then
-          Exit;
+      CollectFromArray(Value, TRttiDynamicArrayType(RttiType).ElementType, Owned);
 
-        for var I := 0 to Value.GetArrayLength - 1 do
-        begin
-          const Element = Value.GetArrayElement(I);
-          if Element.IsObject and (Element.AsObject <> nil) then
-            Owned.Add(Element.AsObject);
-        end;
-      end;
+    tkRecord, tkMRecord:
+      CollectFromRecord(Value, RttiType, Owned);
+  end;
+end;
+
+class procedure TMCPSerializer.CollectFromArray(const Value: TValue; const ElementType: TRttiType;
+  const Owned: TList<TObject>);
+begin
+  const CarriesOwnership = Assigned(ElementType) and (ElementType.TypeKind in OWNERSHIP_BEARING_KINDS);
+  if not CarriesOwnership then
+    Exit;
+
+  for var Index := 0 to Value.GetArrayLength - 1 do
+  begin
+    CollectCreatedObjects(Value.GetArrayElement(Index), ElementType, Owned);
+  end;
+end;
+
+class procedure TMCPSerializer.CollectFromRecord(const Value: TValue; const RttiType: TRttiType;
+  const Owned: TList<TObject>);
+begin
+  if IsGuid(RttiType) then
+    Exit;
+
+  const Data = Value.GetReferenceToRawData;
+  for var RttiField in RttiType.GetFields do
+  begin
+    const HoldsAValue = (IsWireField(RttiField) and Assigned(RttiField.FieldType));
+    if HoldsAValue then
+      CollectCreatedObjects(RttiField.GetValue(Data), RttiField.FieldType, Owned);
   end;
 end;
 
@@ -329,7 +413,7 @@ begin
       Exit;
     end;
   if not (JsonValue is TJSONObject) then
-    raise EArgumentException.Create('expected an object');
+    raise EArgumentException.Create(MESSAGE_EXPECTED_OBJECT);
 
   const NestedInstance = CreateInstanceFromType(RttiType);
   if not Assigned(NestedInstance) then
@@ -377,6 +461,9 @@ begin
     tkClass:
       Result := ConvertJsonToClass(JsonValue, RttiType);
 
+    tkRecord, tkMRecord:
+      Result := ConvertJsonToRecord(JsonValue, RttiType);
+
     tkDynArray:
       begin
         if not (JsonValue is TJSONArray) then
@@ -385,6 +472,93 @@ begin
       end;
   else
     Result := TValue.Empty;
+  end;
+end;
+
+class function TMCPSerializer.ConvertJsonToRecord(const JsonValue: TJSONValue;
+  const RttiType: TRttiType): TValue;
+begin
+  if IsGuid(RttiType) then
+    Exit(ConvertJsonToGuid(JsonValue));
+
+  if not HasWireFields(RttiType) then
+    Exit(TValue.Empty);
+
+  if not (JsonValue is TJSONObject) then
+    raise EArgumentException.Create(MESSAGE_EXPECTED_OBJECT);
+
+  const Json = TJSONObject(JsonValue);
+  GuardRecordKeys(Json, RttiType);
+
+  TValue.Make(nil, RttiType.Handle, Result);
+  try
+    FillRecordFields(Json, RttiType, Result.GetReferenceToRawData);
+  except
+    FreeRecordObjects(Result, RttiType);
+    raise;
+  end;
+end;
+
+class function TMCPSerializer.ConvertJsonToGuid(const JsonValue: TJSONValue): TValue;
+begin
+  if not IsJsonString(JsonValue) then
+    raise EArgumentException.Create(MESSAGE_EXPECTED_UUID);
+
+  const Text = JsonValue.Value.Trim;
+  const IsBraced = Text.StartsWith('{');
+  var Braced := Text;
+  if not IsBraced then
+    Braced := Format('{%s}', [Text]);
+
+  try
+    Result := TValue.From<TGUID>(StringToGUID(Braced));
+  except
+    on E: EConvertError do
+      raise EArgumentException.Create(MESSAGE_EXPECTED_UUID);
+  end;
+end;
+
+class procedure TMCPSerializer.FillRecordFields(const Json: TJSONObject; const RttiType: TRttiType;
+  const Data: Pointer);
+begin
+  for var RttiField in RttiType.GetFields do
+  begin
+    if not IsWireField(RttiField) then
+      Continue;
+
+    GuardFieldHasType(RttiType, RttiField);
+
+    const WireName = GetWireName(RttiField);
+    const Member = GetJsonValueCaseInsensitive(Json, WireName);
+
+    const IsAbsent = (not Assigned(Member) or (Member is TJSONNull));
+    if IsAbsent then
+    begin
+      if IsRequiredMember(RttiField) then
+        raise EArgumentException.CreateFmt('Missing required parameter "%s"', [WireName]);
+      Continue;
+    end;
+
+    var FieldValue: TValue;
+    try
+      FieldValue := ConvertJsonToValue(Member, RttiField.FieldType);
+    except
+      on E: EArgumentException do
+        raise EArgumentException.CreateFmt('Parameter "%s": %s', [WireName, E.Message]);
+    end;
+
+    if not FieldValue.IsEmpty then
+      RttiField.SetValue(Data, FieldValue);
+  end;
+end;
+
+class procedure TMCPSerializer.FreeRecordObjects(const Value: TValue; const RttiType: TRttiType);
+begin
+  const Held = TObjectList<TObject>.Create(True);
+  try
+    CollectFromRecord(Value, RttiType, Held);
+  finally
+    Held.Free;
   end;
 end;
 
@@ -542,7 +716,48 @@ begin
       end
       else
         Result := TJSONNull.Create;
+
+    tkRecord, tkMRecord:
+      Result := ConvertRecordToJson(Value, RttiType);
   end;
+end;
+
+class function TMCPSerializer.ConvertRecordToJson(const Value: TValue;
+  const RttiType: TRttiType): TJSONValue;
+begin
+  if IsGuid(RttiType) then
+    Exit(ConvertGuidToJson(Value));
+
+  if not HasWireFields(RttiType) then
+    Exit(nil);
+
+  const Json = TJSONObject.Create;
+  try
+    const Data = Value.GetReferenceToRawData;
+    for var RttiField in RttiType.GetFields do
+    begin
+      if not IsWireField(RttiField) then
+        Continue;
+
+      GuardFieldHasType(RttiType, RttiField);
+
+      const Member = ConvertValueToJson(RttiField.GetValue(Data), RttiField.FieldType);
+      if Assigned(Member) then
+        Json.AddPair(GetWireName(RttiField), Member);
+    end;
+  except
+    Json.Free;
+    raise;
+  end;
+
+  Result := Json;
+end;
+
+class function TMCPSerializer.ConvertGuidToJson(const Value: TValue): TJSONValue;
+begin
+  const Braced = GUIDToString(Value.AsType<TGUID>);
+  const Bare = Braced.Trim(['{', '}']);
+  Result := TJSONString.Create(LowerCase(Bare));
 end;
 
 class function TMCPSerializer.TrySerializeList(Obj: TObject; out Json: TJSONValue): Boolean;

--- a/src/Protocol/MCPServer.Types.pas
+++ b/src/Protocol/MCPServer.Types.pas
@@ -6,6 +6,7 @@ uses
   System.SysUtils,
   System.JSON,
   System.Rtti,
+  System.TypInfo,
   System.Generics.Collections;
 
 const
@@ -129,6 +130,8 @@ const
   );
   MCP_LOG_LEVELS: array[0..7] of string = (
     'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency');
+
+  SCHEMA_FIELD_VISIBILITIES = [mvPublic, mvPublished];
 
 type
   TMCPProtocolVersion = record

--- a/tests/MCPServer.Tests.Marshal.pas
+++ b/tests/MCPServer.Tests.Marshal.pas
@@ -32,6 +32,67 @@ type
     property Origin: TMarshalPoint read FOrigin write FOrigin;
   end;
 
+  TMarshalStamp = record
+    When: TDateTime;
+    Colour: TMarshalColour;
+  end;
+
+  TMarshalCoordinate = record
+    X: Integer;
+    Y: Integer;
+  end;
+
+  TMarshalRegion = record
+  private
+    FInternal: Integer;
+  public
+    Name: string;
+    Corner: TMarshalCoordinate;
+    Tags: TArray<string>;
+    [Optional]
+    Note: string;
+    [SchemaName('anchor_point')]
+    Anchor: TMarshalCoordinate;
+
+    function Internal: Integer;
+  end;
+
+  TMarshalPlacement = record
+    Label_: string;
+    [Optional]
+    Pin: TMarshalPoint;
+  end;
+
+  TMarshalCountedPin = class
+  private
+    FX: Integer;
+    FY: Integer;
+  public
+    class var DestroyCount: Integer;
+    destructor Destroy; override;
+    property X: Integer read FX write FX;
+    property Y: Integer read FY write FY;
+  end;
+
+  TMarshalPinned = record
+    Pin: TMarshalCountedPin;
+    Count: Integer;
+  end;
+
+  TMarshalTagged = record
+    Id: TGUID;
+    Name: string;
+  end;
+
+  TMarshalBoxed = class
+  private
+    FCorner: TMarshalCoordinate;
+  public
+    property Corner: TMarshalCoordinate read FCorner write FCorner;
+  end;
+
+  TMarshalCoordinateArray = TArray<TMarshalCoordinate>;
+  TMarshalPlacementArray = TArray<TMarshalPlacement>;
   TMarshalIntegerArray = TArray<Integer>;
   TMarshalStringArray = TArray<string>;
   TMarshalPointArray = TArray<TMarshalPoint>;
@@ -121,6 +182,60 @@ type
 
     [Test]
     procedure NoType_IsSafe;
+
+    [Test]
+    procedure Record_RoundTripIsExact;
+
+    [Test]
+    procedure Record_NotAnObject_Raises;
+
+    [Test]
+    procedure NestedRecord_RoundTrip;
+
+    [Test]
+    procedure RecordWithEnumAndDateTime_RoundTrip;
+
+    [Test]
+    procedure RecordArray_RoundTrip;
+
+    [Test]
+    procedure ClassHoldingARecord_RoundTrip;
+
+    [Test]
+    procedure OptionalRecordField_AbsentKeepsItsDefault;
+
+    [Test]
+    procedure MissingRequiredRecordField_Raises;
+
+    [Test]
+    procedure UnknownRecordMember_Raises;
+
+    [Test]
+    procedure WrongRecordMemberType_NamesTheField;
+
+    [Test]
+    procedure SchemaNameOnARecordField_IsTheWireName;
+
+    [Test]
+    procedure PrivateRecordField_IsNeitherReadNorWritten;
+
+    [Test]
+    procedure RecordHoldingAnObject_OwnedHoldsThatObject;
+
+    [Test]
+    procedure RecordArrayHoldingObjects_OwnedHoldsEveryOne;
+
+    [Test]
+    procedure Record_OwnedGainsNothingForAValueOnlyRecord;
+
+    [Test]
+    procedure RecordMemberFails_FreesTheObjectTheRecordAlreadyHolds;
+
+    [Test]
+    procedure Guid_RoundTripIsExact;
+
+    [Test]
+    procedure Guid_AcceptsBracesAndRejectsAnythingElse;
   end;
 
 implementation
@@ -137,6 +252,21 @@ destructor TMarshalLine.Destroy;
 begin
   FOrigin.Free;
   inherited;
+end;
+
+{ TMarshalCountedPin }
+
+destructor TMarshalCountedPin.Destroy;
+begin
+  Inc(DestroyCount);
+  inherited;
+end;
+
+{ TMarshalRegion }
+
+function TMarshalRegion.Internal: Integer;
+begin
+  Result := FInternal;
 end;
 
 { TMarshalTests }
@@ -408,6 +538,213 @@ begin
 
   Assert.IsNull(TMCPSerializer.ValueToJson(TValue.From<Integer>(42), nil));
   Assert.IsTrue(TMCPSerializer.JsonToValue(nil, RttiTypeOf(TypeInfo(Integer)), FOwned).IsEmpty);
+end;
+
+procedure TMarshalTests.Record_RoundTripIsExact;
+begin
+  const CoordinateType = RttiTypeOf(TypeInfo(TMarshalCoordinate));
+  const Text = '{"x":3,"y":4}';
+
+  const Value = FromJson(Text, CoordinateType);
+  const Coordinate = Value.AsType<TMarshalCoordinate>;
+  Assert.AreEqual(3, Coordinate.X);
+  Assert.AreEqual(4, Coordinate.Y);
+
+  Assert.AreEqual(Text, ToJsonText(Value, CoordinateType));
+end;
+
+procedure TMarshalTests.Record_NotAnObject_Raises;
+begin
+  ExpectArgumentError('5', RttiTypeOf(TypeInfo(TMarshalCoordinate)), 'expected an object');
+end;
+
+procedure TMarshalTests.NestedRecord_RoundTrip;
+begin
+  const RegionType = RttiTypeOf(TypeInfo(TMarshalRegion));
+  const Text = '{"name":"north","corner":{"x":1,"y":2},"tags":["a","b"],"note":"seen",' +
+               '"anchor_point":{"x":5,"y":6}}';
+
+  const Value = FromJson(Text, RegionType);
+  const Region = Value.AsType<TMarshalRegion>;
+  Assert.AreEqual('north', Region.Name);
+  Assert.AreEqual(1, Region.Corner.X);
+  Assert.AreEqual(2, Region.Corner.Y);
+  Assert.AreEqual(2, Integer(Length(Region.Tags)));
+  Assert.AreEqual('b', Region.Tags[1]);
+  Assert.AreEqual('seen', Region.Note);
+  Assert.AreEqual(5, Region.Anchor.X);
+
+  Assert.AreEqual(Text, ToJsonText(Value, RegionType));
+end;
+
+procedure TMarshalTests.RecordWithEnumAndDateTime_RoundTrip;
+begin
+  const StampType = RttiTypeOf(TypeInfo(TMarshalStamp));
+  const When = EncodeDateTime(2026, 9, 7, 10, 30, 0, 0);
+
+  var Stamp: TMarshalStamp;
+  Stamp.When := When;
+  Stamp.Colour := mcBlue;
+
+  const Text = ToJsonText(TValue.From<TMarshalStamp>(Stamp), StampType);
+  Assert.IsTrue(Text.Contains('"2026-09-07T10:30:00'), Text);
+  Assert.IsTrue(Text.Contains('"mcBlue"'), Text);
+
+  const Back = FromJson(Text, StampType).AsType<TMarshalStamp>;
+  Assert.AreEqual(Double(When), Double(Back.When), 1.0 / SecsPerDay);
+  Assert.AreEqual(Ord(mcBlue), Ord(Back.Colour));
+end;
+
+procedure TMarshalTests.RecordArray_RoundTrip;
+begin
+  const ArrayType = RttiTypeOf(TypeInfo(TMarshalCoordinateArray));
+  const Text = '[{"x":1,"y":2},{"x":3,"y":4}]';
+
+  const Value = FromJson(Text, ArrayType);
+  Assert.AreEqual(2, Integer(Value.GetArrayLength));
+  Assert.AreEqual(3, Value.GetArrayElement(1).AsType<TMarshalCoordinate>.X);
+
+  Assert.AreEqual(Text, ToJsonText(Value, ArrayType));
+  Assert.AreEqual(0, Integer(FOwned.Count), 'a record is a value, so it owns nothing');
+end;
+
+procedure TMarshalTests.ClassHoldingARecord_RoundTrip;
+begin
+  const BoxedType = FContext.GetType(TMarshalBoxed);
+  const Text = '{"corner":{"x":7,"y":8}}';
+
+  const Value = FromJson(Text, BoxedType);
+  const Boxed = Value.AsObject as TMarshalBoxed;
+  Assert.AreEqual(7, Boxed.Corner.X);
+  Assert.AreEqual(8, Boxed.Corner.Y);
+
+  Assert.AreEqual(Text, ToJsonText(Value, BoxedType));
+end;
+
+procedure TMarshalTests.OptionalRecordField_AbsentKeepsItsDefault;
+begin
+  const RegionType = RttiTypeOf(TypeInfo(TMarshalRegion));
+  const Value = FromJson('{"name":"north","corner":{"x":1,"y":2},"tags":[],"anchor_point":{"x":0,"y":0}}',
+    RegionType);
+
+  const Region = Value.AsType<TMarshalRegion>;
+  Assert.AreEqual('north', Region.Name);
+  Assert.AreEqual('', Region.Note, 'an absent optional field keeps the default of its type');
+end;
+
+procedure TMarshalTests.MissingRequiredRecordField_Raises;
+begin
+  ExpectArgumentError('{"x":1}', RttiTypeOf(TypeInfo(TMarshalCoordinate)),
+    'Missing required parameter "y"');
+end;
+
+procedure TMarshalTests.UnknownRecordMember_Raises;
+begin
+  ExpectArgumentError('{"x":1,"y":2,"z":3}', RttiTypeOf(TypeInfo(TMarshalCoordinate)),
+    'Unknown parameter "z"');
+end;
+
+procedure TMarshalTests.WrongRecordMemberType_NamesTheField;
+begin
+  ExpectArgumentError('{"x":"nope","y":2}', RttiTypeOf(TypeInfo(TMarshalCoordinate)),
+    'Parameter "x": expected an integer');
+end;
+
+procedure TMarshalTests.SchemaNameOnARecordField_IsTheWireName;
+begin
+  const RegionType = RttiTypeOf(TypeInfo(TMarshalRegion));
+  ExpectArgumentError('{"name":"north","corner":{"x":1,"y":2},"tags":[],"anchor":{"x":0,"y":0}}',
+    RegionType, 'Unknown parameter "anchor"');
+end;
+
+procedure TMarshalTests.PrivateRecordField_IsNeitherReadNorWritten;
+begin
+  const RegionType = RttiTypeOf(TypeInfo(TMarshalRegion));
+  const Text = ToJsonText(TValue.From<TMarshalRegion>(Default(TMarshalRegion)), RegionType);
+
+  Assert.IsFalse(Text.Contains('finternal'), Text);
+  ExpectArgumentError('{"name":"north","corner":{"x":1,"y":2},"tags":[],"anchor_point":{"x":0,"y":0},' +
+    '"finternal":9}', RegionType, 'Unknown parameter "finternal"');
+end;
+
+procedure TMarshalTests.RecordHoldingAnObject_OwnedHoldsThatObject;
+begin
+  const PlacementType = RttiTypeOf(TypeInfo(TMarshalPlacement));
+  const Text = '{"label_":"pin","pin":{"x":1,"y":2}}';
+
+  const Value = FromJson(Text, PlacementType);
+  const Placement = Value.AsType<TMarshalPlacement>;
+  Assert.IsNotNull(Placement.Pin);
+  Assert.AreEqual(1, Placement.Pin.X);
+
+  Assert.AreEqual(1, Integer(FOwned.Count), 'a record owns nothing, so the object it holds needs an owner');
+  Assert.AreSame(TObject(Placement.Pin), FOwned[0]);
+
+  Assert.AreEqual(Text, ToJsonText(Value, PlacementType));
+end;
+
+procedure TMarshalTests.RecordArrayHoldingObjects_OwnedHoldsEveryOne;
+begin
+  const ArrayType = RttiTypeOf(TypeInfo(TMarshalPlacementArray));
+  const Text = '[{"label_":"a","pin":{"x":1,"y":2}},{"label_":"b","pin":{"x":3,"y":4}}]';
+
+  const Value = FromJson(Text, ArrayType);
+  Assert.AreEqual(2, Integer(Value.GetArrayLength));
+  Assert.AreEqual(2, Integer(FOwned.Count));
+  Assert.AreSame(TObject(Value.GetArrayElement(1).AsType<TMarshalPlacement>.Pin), FOwned[1]);
+
+  Assert.AreEqual(Text, ToJsonText(Value, ArrayType));
+end;
+
+procedure TMarshalTests.Record_OwnedGainsNothingForAValueOnlyRecord;
+begin
+  FromJson('{"name":"north","corner":{"x":1,"y":2},"tags":["a"],"anchor_point":{"x":0,"y":0}}',
+    RttiTypeOf(TypeInfo(TMarshalRegion)));
+  Assert.AreEqual(0, Integer(FOwned.Count), 'a record made of values owns nothing');
+
+  const Value = FromJson('{"label_":"pin"}', RttiTypeOf(TypeInfo(TMarshalPlacement)));
+  Assert.IsNull(Value.AsType<TMarshalPlacement>.Pin, 'an absent optional object field stays nil');
+  Assert.AreEqual(0, Integer(FOwned.Count), 'and nothing nil is put up for freeing');
+end;
+
+procedure TMarshalTests.RecordMemberFails_FreesTheObjectTheRecordAlreadyHolds;
+begin
+  TMarshalCountedPin.DestroyCount := 0;
+
+  ExpectArgumentError('{"pin":{"x":1,"y":2},"count":"x"}', RttiTypeOf(TypeInfo(TMarshalPinned)),
+    'Parameter "count": expected an integer');
+
+  Assert.AreEqual(0, Integer(FOwned.Count),
+    'a record that never finished converting hands nothing to the caller to free');
+  Assert.AreEqual(1, TMarshalCountedPin.DestroyCount,
+    'the object the half-built record already held is freed on the way out');
+end;
+
+procedure TMarshalTests.Guid_RoundTripIsExact;
+begin
+  const TaggedType = RttiTypeOf(TypeInfo(TMarshalTagged));
+  const Text = '{"id":"f81d4fae-7dec-11d0-a765-00a0c91e6bf6","name":"crate"}';
+
+  const Value = FromJson(Text, TaggedType);
+  const Tagged = Value.AsType<TMarshalTagged>;
+  Assert.AreEqual('{F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6}', GUIDToString(Tagged.Id));
+  Assert.AreEqual('crate', Tagged.Name);
+  Assert.AreEqual(0, Integer(FOwned.Count), 'a GUID is a value and owns nothing');
+
+  Assert.AreEqual(Text, ToJsonText(Value, TaggedType));
+end;
+
+procedure TMarshalTests.Guid_AcceptsBracesAndRejectsAnythingElse;
+begin
+  const TaggedType = RttiTypeOf(TypeInfo(TMarshalTagged));
+
+  const Value = FromJson('{"id":"{F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6}","name":"crate"}', TaggedType);
+  Assert.AreEqual('{F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6}', GUIDToString(Value.AsType<TMarshalTagged>.Id));
+
+  ExpectArgumentError('{"id":"not-a-uuid","name":"crate"}', TaggedType,
+    'Parameter "id": expected a UUID string');
+  ExpectArgumentError('{"id":7,"name":"crate"}', TaggedType,
+    'Parameter "id": expected a UUID string');
 end;
 
 end.

--- a/tests/MCPServer.Tests.MethodTool.pas
+++ b/tests/MCPServer.Tests.MethodTool.pas
@@ -35,6 +35,18 @@ type
     property Quantity: Integer read FQuantity write FQuantity;
   end;
 
+  TSampleBox = record
+    Width: Integer;
+    Height: Integer;
+  end;
+
+  TSampleLabelled = record
+    Caption: string;
+    Box: TSampleBox;
+    [Optional]
+    Note: string;
+  end;
+
   TSampleTarget = class
   private
     FSeen: string;
@@ -53,6 +65,9 @@ type
     function Tagged([SchemaName('colour_tag')] const Tag: string): string;
     function WithOptional(const Base: string; [Optional] const Suffix: string): string;
     function Keep(const Filter: TCountedFilter): string;
+    function Area(const Box: TSampleBox): Integer;
+    function Grow(const Box: TSampleBox): TSampleBox;
+    function Caption(const Labelled: TSampleLabelled): string;
     property Seen: string read FSeen;
     property Kept: TCountedFilter read FKept;
   end;
@@ -175,6 +190,30 @@ type
 
     [Test]
     procedure ThroughTheManager_ReportsAnEnvelopeWithoutItsOutputSchema;
+
+    [Test]
+    procedure RecordParameter_IsMarshalled;
+
+    [Test]
+    procedure RecordResult_IsTheResultMember;
+
+    [Test]
+    procedure RecordResult_ValidatesAgainstItsOutputSchema;
+
+    [Test]
+    procedure RecordParameter_IsPublishedAsAnObjectInTheInputSchema;
+
+    [Test]
+    procedure NestedRecordParameter_IsMarshalled;
+
+    [Test]
+    procedure RecordParameter_OptionalFieldMayBeOmitted;
+
+    [Test]
+    procedure RecordParameter_MissingFieldRaisesArgumentException;
+
+    [Test]
+    procedure RecordParameter_WrongFieldTypeRaisesArgumentException;
   end;
 
 implementation
@@ -279,6 +318,23 @@ begin
   FKept.Free;
   FKept := Filter;
   Result := Filter.Customer;
+end;
+
+function TSampleTarget.Area(const Box: TSampleBox): Integer;
+begin
+  Result := Box.Width * Box.Height;
+end;
+
+function TSampleTarget.Grow(const Box: TSampleBox): TSampleBox;
+begin
+  Result.Width := Box.Width * 2;
+  Result.Height := Box.Height * 2;
+end;
+
+function TSampleTarget.Caption(const Labelled: TSampleLabelled): string;
+begin
+  Result := Format('%s %dx%d%s',
+    [Labelled.Caption, Labelled.Box.Width, Labelled.Box.Height, Labelled.Note]);
 end;
 
 destructor TSampleTarget.Destroy;
@@ -775,6 +831,102 @@ begin
     TLogger.MinLogLevel := OriginalLevel;
     Warnings.Free;
   end;
+end;
+
+procedure TMethodToolTests.RecordParameter_IsMarshalled;
+begin
+  const Json = Run(ToolFor('Area'), '{"box":{"width":3,"height":4}}');
+  try
+    Assert.AreEqual(12, Json.GetValue<Integer>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.RecordResult_IsTheResultMember;
+begin
+  const Json = Run(ToolFor('Grow'), '{"box":{"width":3,"height":4}}');
+  try
+    Assert.AreEqual('{"result":{"width":6,"height":8}}', Json.ToJSON);
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.RecordResult_ValidatesAgainstItsOutputSchema;
+begin
+  const Tool = ToolFor('Grow');
+
+  const Schema = Tool.GetOutputSchema;
+  try
+    Assert.IsNotNull(Schema, 'a record result describes itself');
+
+    const Json = Run(Tool, '{"box":{"width":1,"height":2}}');
+    try
+      var Errors: TArray<string>;
+      Assert.IsTrue(TMCPSchemaValidator.TryValidate(Schema, Json, Errors),
+        string.Join('; ', Errors));
+    finally
+      Json.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TMethodToolTests.RecordParameter_IsPublishedAsAnObjectInTheInputSchema;
+begin
+  const Schema = ToolFor('Area').GetInputSchema;
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.box.type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.box.properties.width.type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.box.properties.height.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TMethodToolTests.NestedRecordParameter_IsMarshalled;
+begin
+  const Json = Run(ToolFor('Caption'),
+    '{"labelled":{"caption":"tile","box":{"width":2,"height":5},"note":"!"}}');
+  try
+    Assert.AreEqual('tile 2x5!', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.RecordParameter_OptionalFieldMayBeOmitted;
+begin
+  const Json = Run(ToolFor('Caption'), '{"labelled":{"caption":"tile","box":{"width":2,"height":5}}}');
+  try
+    Assert.AreEqual('tile 2x5', Json.GetValue<string>('result'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TMethodToolTests.RecordParameter_MissingFieldRaisesArgumentException;
+begin
+  const Tool = ToolFor('Area');
+  Assert.WillRaise(
+    procedure
+    begin
+      Run(Tool, '{"box":{"width":3}}').Free;
+    end,
+    EArgumentException);
+end;
+
+procedure TMethodToolTests.RecordParameter_WrongFieldTypeRaisesArgumentException;
+begin
+  const Tool = ToolFor('Area');
+  Assert.WillRaise(
+    procedure
+    begin
+      Run(Tool, '{"box":{"width":"three","height":4}}').Free;
+    end,
+    EArgumentException);
 end;
 
 end.

--- a/tests/MCPServer.Tests.SchemaFromMethod.pas
+++ b/tests/MCPServer.Tests.SchemaFromMethod.pas
@@ -14,6 +14,53 @@ type
 
   TMoney = record
     Amount: Double;
+    Currency: string;
+  end;
+
+  TAddress = record
+    Street: string;
+    City: string;
+  end;
+
+  TContact = record
+    Name: string;
+    Home: TAddress;
+  end;
+
+  TBasket = record
+    Owner: string;
+    Skus: TArray<string>;
+  end;
+
+  TSelfNode = record
+    Name: string;
+    Children: TArray<TSelfNode>;
+  end;
+
+  TAnnotatedFields = record
+  private
+    FChecksum: Integer;
+  public
+    [SchemaName('placed_at')]
+    [SchemaTitle('Placed at')]
+    [SchemaDescription('When the order was placed')]
+    [SchemaFormat('date')]
+    PlacedAt: TDateTime;
+
+    [SchemaMinimum(1)]
+    [SchemaMaximum(10)]
+    Count: Integer;
+
+    [SchemaMinLength(2)]
+    [SchemaMaxLength(8)]
+    [SchemaPattern('^[a-z]+$')]
+    [SchemaDefault('"abc"')]
+    Code: string;
+
+    [Optional]
+    Note: string;
+
+    function Checksum: Integer;
   end;
 
   TOrderLine = class
@@ -44,6 +91,81 @@ type
     property Limit: Integer read FLimit write FLimit;
   end;
 
+  TPricedLine = class
+  private
+    FSku: string;
+    FPrice: TMoney;
+  public
+    property Sku: string read FSku write FSku;
+    property Price: TMoney read FPrice write FPrice;
+  end;
+
+  TCarrier = class
+  private
+    FName: string;
+  public
+    property Name: string read FName write FName;
+  end;
+
+  TShipment = record
+    Reference: string;
+    Carrier: TCarrier;
+  end;
+
+{$RTTI EXPLICIT FIELDS([vcPublic])}
+
+  TDocumentedMoney = record
+  private
+    FInternal: Integer;
+  public
+    [SchemaDescription('Amount in the smallest unit')]
+    [SchemaMinimum(0)]
+    Amount: Double;
+
+    function Internal: Integer;
+  end;
+
+{$RTTI EXPLICIT FIELDS([])}
+
+  TOpaqueMoney = record
+    Amount: Double;
+  end;
+
+{$RTTI EXPLICIT FIELDS([vcPrivate, vcProtected, vcPublic])}
+
+  TRawFrame = record
+    Tag: Byte;
+    Payload: array[0..3] of Byte;
+  end;
+
+  TTaggedFilter = class
+  private
+    FId: TGUID;
+    FName: string;
+  public
+    property Id: TGUID read FId write FId;
+    property Name: string read FName write FName;
+  end;
+
+  TLegacyDoneEvent = procedure of object;
+
+  TLegacyFilter = class
+  private
+    FAnything: Variant;
+    FThing: IInterface;
+    FOnDone: TLegacyDoneEvent;
+    FKind: TClass;
+    FMoney: TOpaqueMoney;
+    FCount: Integer;
+  public
+    property Anything: Variant read FAnything write FAnything;
+    property Thing: IInterface read FThing write FThing;
+    property OnDone: TLegacyDoneEvent read FOnDone write FOnDone;
+    property Kind: TClass read FKind write FKind;
+    property Money: TOpaqueMoney read FMoney write FMoney;
+    property Count: Integer read FCount write FCount;
+  end;
+
   TSampleService = class
   public
     procedure NoParameters;
@@ -63,12 +185,28 @@ type
     procedure OutParameter(out Total: Integer);
     procedure VarParameter(var Total: Integer);
     procedure WithDialect(const Filter: TDialectFilter);
+    procedure WithInterface(const Thing: IInterface);
+    procedure WithMoney(const Money: TMoney);
+    procedure WithContact(const Contact: TContact);
+    procedure WithBasket(const Basket: TBasket);
+    procedure WithMoneys(const Moneys: TArray<TMoney>);
+    procedure WithPricedLine(const Line: TPricedLine);
+    procedure WithShipment(const Shipment: TShipment);
+    procedure WithAnnotatedFields(const Stamped: TAnnotatedFields);
+    procedure WithSelfNode(const Node: TSelfNode);
+    procedure WithDocumentedMoney(const Money: TDocumentedMoney);
+    procedure WithOpaqueMoney(const Money: TOpaqueMoney);
+    procedure WithGuid(const Id: TGUID);
+    procedure WithRawFrame(const Frame: TRawFrame);
     function CountOrders: Integer;
     function DescribeOrder: string;
     function FindLine: TOrderLine;
     function FindLines: TArray<TOrderLine>;
     function Total: TMoney;
     function MakeDialect: TDialectFilter;
+    function OpaqueTotal: TOpaqueMoney;
+    function FindThing: IInterface;
+    function MakeGuid: TGUID;
   end;
 
   [TestFixture]
@@ -160,7 +298,73 @@ type
     procedure ClassArrayResult_IsAnArrayOfTheDtoSchema;
 
     [Test]
-    procedure RecordResult_HasNoResultSchema;
+    procedure RecordResult_IsTheRecordSchema;
+
+    [Test]
+    procedure RecordParameter_IsAnObjectWithItsFields;
+
+    [Test]
+    procedure RecordParameter_MatchesWhatSchemaFromTypeProduces;
+
+    [Test]
+    procedure NestedRecord_IsDescribedInPlace;
+
+    [Test]
+    procedure RecordInsideAClass_IsDescribed;
+
+    [Test]
+    procedure ClassInsideARecord_IsDescribed;
+
+    [Test]
+    procedure RecordArrayParameter_ItemsAreTheRecordSchema;
+
+    [Test]
+    procedure RecordHoldingAnArray_IsDescribed;
+
+    [Test]
+    procedure RecordFieldAttributes_AreApplied;
+
+    [Test]
+    procedure OptionalRecordField_StaysOutOfRequired;
+
+    [Test]
+    procedure PrivateRecordField_IsNotDescribed;
+
+    [Test]
+    procedure SelfReferencingRecord_StopsAtTheDepthGuard;
+
+    [Test]
+    procedure RecordWithDocumentedFieldRtti_KeepsItsFieldsAndAttributes;
+
+    [Test]
+    procedure RecordWithoutFieldRtti_IsRejected;
+
+    [Test]
+    procedure RecordResultWithoutFieldRtti_HasNoResultSchema;
+
+    [Test]
+    procedure InterfaceParameter_IsRejected;
+
+    [Test]
+    procedure InterfaceResult_HasNoResultSchema;
+
+    [Test]
+    procedure GuidParameter_IsAStringWithUuidFormat;
+
+    [Test]
+    procedure GuidProperty_IsAStringWithUuidFormat;
+
+    [Test]
+    procedure GuidResult_IsAStringWithUuidFormat;
+
+    [Test]
+    procedure FieldWithoutTypeRtti_IsRejectedNamingTheField;
+
+    [Test]
+    procedure UndescribablePropertyKinds_StayStringsOnTheClassWalk;
+
+    [Test]
+    procedure OpaqueRecordProperty_StaysAStringOnTheClassWalk;
 
     [Test]
     procedure SchemaFromType_DescribesAPrimitiveAnArrayAndAClass;
@@ -174,6 +378,20 @@ implementation
 uses
   System.SysUtils,
   MCPServer.Schema.Generator;
+
+{ TAnnotatedFields }
+
+function TAnnotatedFields.Checksum: Integer;
+begin
+  Result := FChecksum;
+end;
+
+{ TDocumentedMoney }
+
+function TDocumentedMoney.Internal: Integer;
+begin
+  Result := FInternal;
+end;
 
 { TSampleService }
 
@@ -236,6 +454,58 @@ procedure TSampleService.WithDialect(const Filter: TDialectFilter);
 begin
 end;
 
+procedure TSampleService.WithInterface(const Thing: IInterface);
+begin
+end;
+
+procedure TSampleService.WithMoney(const Money: TMoney);
+begin
+end;
+
+procedure TSampleService.WithContact(const Contact: TContact);
+begin
+end;
+
+procedure TSampleService.WithBasket(const Basket: TBasket);
+begin
+end;
+
+procedure TSampleService.WithMoneys(const Moneys: TArray<TMoney>);
+begin
+end;
+
+procedure TSampleService.WithPricedLine(const Line: TPricedLine);
+begin
+end;
+
+procedure TSampleService.WithShipment(const Shipment: TShipment);
+begin
+end;
+
+procedure TSampleService.WithAnnotatedFields(const Stamped: TAnnotatedFields);
+begin
+end;
+
+procedure TSampleService.WithSelfNode(const Node: TSelfNode);
+begin
+end;
+
+procedure TSampleService.WithDocumentedMoney(const Money: TDocumentedMoney);
+begin
+end;
+
+procedure TSampleService.WithOpaqueMoney(const Money: TOpaqueMoney);
+begin
+end;
+
+procedure TSampleService.WithGuid(const Id: TGUID);
+begin
+end;
+
+procedure TSampleService.WithRawFrame(const Frame: TRawFrame);
+begin
+end;
+
 function TSampleService.CountOrders: Integer;
 begin
   Result := 0;
@@ -264,6 +534,21 @@ end;
 function TSampleService.MakeDialect: TDialectFilter;
 begin
   Result := nil;
+end;
+
+function TSampleService.OpaqueTotal: TOpaqueMoney;
+begin
+  Result := Default(TOpaqueMoney);
+end;
+
+function TSampleService.FindThing: IInterface;
+begin
+  Result := nil;
+end;
+
+function TSampleService.MakeGuid: TGUID;
+begin
+  Result := TGUID.Empty;
 end;
 
 { TSchemaFromMethodTests }
@@ -540,9 +825,253 @@ begin
   end;
 end;
 
-procedure TSchemaFromMethodTests.RecordResult_HasNoResultSchema;
+procedure TSchemaFromMethodTests.RecordResult_IsTheRecordSchema;
 begin
-  Assert.IsNull(ResultSchemaOf('Total'));
+  var Schema := ResultSchemaOf('Total');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.result.type'));
+    Assert.AreEqual('number', Schema.GetValue<string>('properties.result.properties.amount.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.result.properties.currency.type'));
+
+    const Required = Schema.FindValue('properties.result.required') as TJSONArray;
+    Assert.AreEqual(2, Required.Count);
+    Assert.AreEqual('amount', Required.Items[0].Value);
+    Assert.AreEqual('currency', Required.Items[1].Value);
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordParameter_IsAnObjectWithItsFields;
+begin
+  var Schema := SchemaOf('WithMoney');
+  try
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.money.type'));
+    Assert.AreEqual('number', Schema.GetValue<string>('properties.money.properties.amount.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.money.properties.currency.type'));
+
+    const Required = Schema.FindValue('properties.money.required') as TJSONArray;
+    Assert.AreEqual(2, Required.Count);
+    Assert.AreEqual('amount', Required.Items[0].Value);
+    Assert.AreEqual('currency', Required.Items[1].Value);
+    Assert.IsNull(Schema.FindValue('properties.money.additionalProperties'),
+      'a record with fields says as little about additional properties as a class with properties');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordParameter_MatchesWhatSchemaFromTypeProduces;
+begin
+  var Schema := SchemaOf('WithMoney');
+  try
+    const Parameters = MethodOf('WithMoney').GetParameters;
+    var Expected := TMCPSchemaGenerator.GenerateSchemaFromType(Parameters[0].ParamType);
+    try
+      Assert.AreEqual(Expected.ToJSON, (Schema.FindValue('properties.money') as TJSONObject).ToJSON);
+    finally
+      Expected.Free;
+    end;
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.NestedRecord_IsDescribedInPlace;
+begin
+  var Schema := SchemaOf('WithContact');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.contact.properties.name.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.contact.properties.home.type'));
+    Assert.AreEqual('string',
+      Schema.GetValue<string>('properties.contact.properties.home.properties.street.type'));
+    Assert.AreEqual('string',
+      Schema.GetValue<string>('properties.contact.properties.home.properties.city.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordInsideAClass_IsDescribed;
+begin
+  var Schema := SchemaOf('WithPricedLine');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.line.properties.sku.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.line.properties.price.type'));
+    Assert.AreEqual('number',
+      Schema.GetValue<string>('properties.line.properties.price.properties.amount.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.ClassInsideARecord_IsDescribed;
+begin
+  var Schema := SchemaOf('WithShipment');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.shipment.properties.reference.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.shipment.properties.carrier.type'));
+    Assert.AreEqual('string',
+      Schema.GetValue<string>('properties.shipment.properties.carrier.properties.name.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordArrayParameter_ItemsAreTheRecordSchema;
+begin
+  var Schema := SchemaOf('WithMoneys');
+  try
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.moneys.type'));
+    Assert.AreEqual('object', Schema.GetValue<string>('properties.moneys.items.type'));
+    Assert.AreEqual('number', Schema.GetValue<string>('properties.moneys.items.properties.amount.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.moneys.items.properties.currency.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordHoldingAnArray_IsDescribed;
+begin
+  var Schema := SchemaOf('WithBasket');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.basket.properties.owner.type'));
+    Assert.AreEqual('array', Schema.GetValue<string>('properties.basket.properties.skus.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.basket.properties.skus.items.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordFieldAttributes_AreApplied;
+begin
+  var Schema := SchemaOf('WithAnnotatedFields');
+  try
+    const Fields = Schema.FindValue('properties.stamped.properties') as TJSONObject;
+
+    Assert.IsNotNull(Fields.GetValue('placed_at'), '[SchemaName] renames the field');
+    Assert.IsNull(Fields.GetValue('placedat'), 'and the field name itself is gone');
+    Assert.AreEqual('Placed at', Fields.GetValue<string>('placed_at.title'));
+    Assert.AreEqual('When the order was placed', Fields.GetValue<string>('placed_at.description'));
+    Assert.AreEqual('date', Fields.GetValue<string>('placed_at.format'),
+      'SchemaFormat replaces the date-time a TDateTime carries by default');
+
+    Assert.AreEqual(1, Fields.GetValue<Integer>('count.minimum'));
+    Assert.AreEqual(10, Fields.GetValue<Integer>('count.maximum'));
+
+    Assert.AreEqual(2, Fields.GetValue<Integer>('code.minLength'));
+    Assert.AreEqual(8, Fields.GetValue<Integer>('code.maxLength'));
+    Assert.AreEqual('^[a-z]+$', Fields.GetValue<string>('code.pattern'));
+    Assert.AreEqual('abc', Fields.GetValue<string>('code.default'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.OptionalRecordField_StaysOutOfRequired;
+begin
+  var Schema := SchemaOf('WithAnnotatedFields');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.stamped.properties.note.type'),
+      'an optional field is still described');
+
+    const Required = Schema.FindValue('properties.stamped.required') as TJSONArray;
+    Assert.AreEqual(3, Required.Count);
+    Assert.AreEqual('placed_at', Required.Items[0].Value);
+    Assert.AreEqual('count', Required.Items[1].Value);
+    Assert.AreEqual('code', Required.Items[2].Value);
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.PrivateRecordField_IsNotDescribed;
+begin
+  var Schema := SchemaOf('WithAnnotatedFields');
+  try
+    const Fields = Schema.FindValue('properties.stamped.properties') as TJSONObject;
+    Assert.AreEqual(4, Fields.Count, 'only the public fields are on the wire');
+    Assert.IsNull(Fields.GetValue('fchecksum'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.SelfReferencingRecord_StopsAtTheDepthGuard;
+begin
+  var Schema := SchemaOf('WithSelfNode');
+  try
+    var Level := Schema.FindValue('properties.node') as TJSONObject;
+    var Depth := 0;
+    while Assigned(Level.FindValue('properties.children.items.properties')) do
+    begin
+      Level := Level.FindValue('properties.children.items') as TJSONObject;
+      Inc(Depth);
+      Assert.IsTrue(Depth < 32, 'the walk must stop, not recurse forever');
+    end;
+
+    Assert.IsTrue(Depth > 0, 'the record describes itself at least once');
+    Assert.AreEqual('object',
+      (Level.FindValue('properties.children.items') as TJSONObject).GetValue<string>('type'),
+      'the deepest level is an opaque object, not another walk');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordWithDocumentedFieldRtti_KeepsItsFieldsAndAttributes;
+begin
+  var Schema := SchemaOf('WithDocumentedMoney');
+  try
+    Assert.AreEqual('number', Schema.GetValue<string>('properties.money.properties.amount.type'));
+    Assert.AreEqual('Amount in the smallest unit',
+      Schema.GetValue<string>('properties.money.properties.amount.description'));
+    Assert.AreEqual(0, Schema.GetValue<Integer>('properties.money.properties.amount.minimum'));
+
+    const Fields = Schema.FindValue('properties.money.properties') as TJSONObject;
+    Assert.AreEqual(1, Fields.Count,
+      'FIELDS([vcPublic]) publishes the public fields and leaves the private one off the wire');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.RecordWithoutFieldRtti_IsRejected;
+begin
+  const Method = MethodOf('WithOpaqueMoney');
+  Assert.WillRaiseWithMessage(
+    procedure
+    begin
+      TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    end,
+    EArgumentException,
+    'Parameter "Money" of WithOpaqueMoney is record TOpaqueMoney, which publishes no field RTTI, ' +
+    'so it has no schema. Declare it in a unit whose field RTTI covers its public fields, for ' +
+    'example {$RTTI EXPLICIT FIELDS([vcPublic])}.');
+end;
+
+procedure TSchemaFromMethodTests.RecordResultWithoutFieldRtti_HasNoResultSchema;
+begin
+  Assert.IsNull(ResultSchemaOf('OpaqueTotal'),
+    'a result whose members cannot be seen is published as no output schema at all');
+end;
+
+procedure TSchemaFromMethodTests.InterfaceParameter_IsRejected;
+begin
+  const Method = MethodOf('WithInterface');
+  Assert.WillRaiseWithMessage(
+    procedure
+    begin
+      TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    end,
+    EArgumentException,
+    'Parameter "Thing" of WithInterface is of type IInterface, which has no JSON schema');
+end;
+
+procedure TSchemaFromMethodTests.InterfaceResult_HasNoResultSchema;
+begin
+  Assert.IsNull(ResultSchemaOf('FindThing'),
+    'a result that cannot cross a wire is published as no output schema at all');
 end;
 
 procedure TSchemaFromMethodTests.SchemaFromType_DescribesAPrimitiveAnArrayAndAClass;
@@ -629,6 +1158,80 @@ begin
   var Schema := TMCPSchemaGenerator.GenerateSchema(TDialectFilter);
   try
     Assert.AreEqual('https://json-schema.org/draft/2020-12/schema', Schema.GetValue<string>('$schema'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.GuidParameter_IsAStringWithUuidFormat;
+begin
+  var Schema := SchemaOf('WithGuid');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.id.type'));
+    Assert.AreEqual('uuid', Schema.GetValue<string>('properties.id.format'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.GuidProperty_IsAStringWithUuidFormat;
+begin
+  var Schema := TMCPSchemaGenerator.GenerateSchema(TTaggedFilter);
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.id.type'),
+      'TGUID.D4 has no type RTTI, so a TGUID is described as the string it travels as');
+    Assert.AreEqual('uuid', Schema.GetValue<string>('properties.id.format'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.name.type'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.GuidResult_IsAStringWithUuidFormat;
+begin
+  var Schema := ResultSchemaOf('MakeGuid');
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.result.type'));
+    Assert.AreEqual('uuid', Schema.GetValue<string>('properties.result.format'));
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.FieldWithoutTypeRtti_IsRejectedNamingTheField;
+begin
+  const Method = MethodOf('WithRawFrame');
+  Assert.WillRaiseWithMessage(
+    procedure
+    begin
+      TMCPSchemaGenerator.GenerateSchemaFromMethod(Method).Free;
+    end,
+    EArgumentException,
+    'Field TRawFrame.Payload has no type RTTI, so it has no schema');
+end;
+
+procedure TSchemaFromMethodTests.UndescribablePropertyKinds_StayStringsOnTheClassWalk;
+begin
+  var Schema := TMCPSchemaGenerator.GenerateSchema(TLegacyFilter);
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.anything.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.thing.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.ondone.type'));
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.kind.type'));
+    Assert.AreEqual('integer', Schema.GetValue<string>('properties.count.type'),
+      'one property the generator cannot describe leaves the rest of the class described');
+  finally
+    Schema.Free;
+  end;
+end;
+
+procedure TSchemaFromMethodTests.OpaqueRecordProperty_StaysAStringOnTheClassWalk;
+begin
+  var Schema := TMCPSchemaGenerator.GenerateSchema(TLegacyFilter);
+  try
+    Assert.AreEqual('string', Schema.GetValue<string>('properties.money.type'),
+      'a record whose fields are invisible keeps the string every record was described as');
+    Assert.IsNull(Schema.FindValue('properties.money.properties'));
   finally
     Schema.Free;
   end;

--- a/tests/MCPServer.Tests.ToolsManager.pas
+++ b/tests/MCPServer.Tests.ToolsManager.pas
@@ -53,6 +53,30 @@ type
     constructor CreateNamed(const AName: string);
   end;
 
+  TLegacyDoneEvent = procedure of object;
+
+  TLegacyParams = class
+  private
+    FAnything: Variant;
+    FThing: IInterface;
+    FOnDone: TLegacyDoneEvent;
+    FKind: TClass;
+    FCount: Integer;
+  public
+    property Anything: Variant read FAnything write FAnything;
+    property Thing: IInterface read FThing write FThing;
+    property OnDone: TLegacyDoneEvent read FOnDone write FOnDone;
+    property Kind: TClass read FKind write FKind;
+    property Count: Integer read FCount write FCount;
+  end;
+
+  TLegacyTool = class(TMCPToolBase<TLegacyParams>)
+  protected
+    function ExecuteWithParams(const Params: TLegacyParams): string; override;
+  public
+    constructor Create; override;
+  end;
+
   [TestFixture]
   TToolsManagerTests = class
   private
@@ -94,6 +118,9 @@ type
 
     [Test]
     procedure List_IsInRegistrationOrder_WithAnnotations;
+
+    [Test]
+    procedure UndescribableProperties_AreStringsAndHideNoOtherTool;
 
     [Test]
     procedure MarkReadOnly_SetsBothHints_Once;
@@ -190,6 +217,20 @@ begin
   FName := 'read_only';
   MarkReadOnly(True);
   MarkReadOnly(True);
+end;
+
+{ TLegacyTool }
+
+constructor TLegacyTool.Create;
+begin
+  inherited;
+  FName := 'legacy_variant';
+  FDescription := 'A tool whose parameter class predates the schema rules';
+end;
+
+function TLegacyTool.ExecuteWithParams(const Params: TLegacyParams): string;
+begin
+  Result := Params.Count.ToString;
 end;
 
 function THandWrittenTool.BuildSchema: TJSONObject;
@@ -350,6 +391,31 @@ begin
     Assert.IsTrue(ReadOnly);
     Assert.AreEqual('integer',
       Json.GetValue<string>('tools[' + (Tools.Count - 2).ToString + '].inputSchema.properties.value.type'));
+  finally
+    Json.Free;
+  end;
+end;
+
+procedure TToolsManagerTests.UndescribableProperties_AreStringsAndHideNoOtherTool;
+begin
+  FManager.AddTool(TLegacyTool.Create);
+
+  const Json = FManager.ListTools(nil, TMCPProtocolEra.Legacy).AsType<TJSONObject>;
+  try
+    const Tools = Json.GetValue('tools') as TJSONArray;
+    const Last = Tools.Count - 1;
+    Assert.AreEqual('legacy_variant', Tools.Items[Last].GetValue<string>('name'));
+    Assert.AreEqual('hand_written', Tools.Items[Last - 1].GetValue<string>('name'),
+      'a property the generator cannot describe hides no tool that was listed before it');
+    Assert.AreEqual('doubling', Tools.Items[Last - 2].GetValue<string>('name'));
+    Assert.AreEqual('echo', Json.GetValue<string>('tools[0].name'));
+
+    const Prefix = Format('tools[%d].inputSchema.properties.', [Last]);
+    Assert.AreEqual('string', Json.GetValue<string>(Prefix + 'anything.type'));
+    Assert.AreEqual('string', Json.GetValue<string>(Prefix + 'thing.type'));
+    Assert.AreEqual('string', Json.GetValue<string>(Prefix + 'ondone.type'));
+    Assert.AreEqual('string', Json.GetValue<string>(Prefix + 'kind.type'));
+    Assert.AreEqual('integer', Json.GetValue<string>(Prefix + 'count.type'));
   finally
     Json.Free;
   end;


### PR DESCRIPTION
A record property is published as `{"type": "string"}` and dropped when unmarshalling. This describes and marshals records the way classes are described.

## What changes

A record produces an object schema: one member per public field, `required` for the fields without `[Optional]`, `additionalProperties: false`. The class walk and the record walk are now one routine, so the depth guard, the required rule and the attribute pass are the same for both. The attributes that work on a property work on a field.

`TGUID` is a string with `format: uuid`, written lower case without braces and read with or without.

Records reach the marshal facade as well, so a record parameter or result on `TMCPMethodTool` works end to end. `ConvertJsonToRecord` frees what the record already holds when a later member fails to convert.

## What does not change

The class walk keeps its `string` fallback for a type it cannot describe, so no deployed tool loses its listing. Refusals are limited to the entry points this branch adds on top of `feature/mcp-client-and-host`, which nothing has shipped against: an undescribable parameter type, a record parameter whose unit publishes no field RTTI, and a member with no type RTTI, each named in the message. An opaque record result is published without an `outputSchema` rather than with a wrong one.

## Compatibility

`MIGRATION.md` carries the one visible change: a record-typed property used to arrive as a string and be dropped, and now arrives as an object and is filled. Variant, interface, method-pointer and class-reference properties are untouched.

Records need field RTTI. Delphi's default gives it; a unit that narrows the directive keeps its public fields with `{$RTTI EXPLICIT FIELDS([vcPublic])}`. The README says so next to the schema documentation.

561 tests, 0 failed, 0 leaked, on Win32 and Win64. `tests/golden` and `tests/fixtures` are unchanged.

